### PR TITLE
nas deploy tool 광주 리전 내용 제거

### DIFF
--- a/ko/user-guide.md
+++ b/ko/user-guide.md
@@ -3018,7 +3018,6 @@ ORAS(OCI Registry As Storage)는 OCI 레지스트리에서 OCI 아티팩트를 p
 | --- | --- |
 | 한국(판교) 리전 | oras pull dfe965c3-kr1-registry.container.nhncloud.com/nks_container/nfs-deploy-tool:v1 |
 | 한국(평촌) 리전 | oras pull 6e7f43c6-kr2-registry.container.cloud.toast.com/nks_container/nfs-deploy-tool:v1 |
-| 한국(광주) 리전 | oras pull d6628457-kr3-registry.container.nhncloud.com/nks_container/nfs-deploy-tool:v1 |
 
 ##### 3. 설치 패키지를 압축 해제한 후 **install-driver.sh {mode}** 명령어를 사용하여 csi-driver-nfs 구성 요소를 설치합니다.
 install-driver.sh 명령 실행 시 인터넷 연결이 가능한 클러스터는 **public**, 그렇지 않은 클러스터는 **private**을 입력해야 합니다.


### PR DESCRIPTION
광주 리전이 아직 일반 사용자에게는 노출되지 않아 가이드에서 제거. 추후 일반 사용자에게 오픈 시 가이드 업데이트

@twkim @iksoon-park 
단순 내용 제거라서 리뷰 없이 머지합니다.