### PR TITLE
API 가이드 수정

### DIFF
--- a/ko/public-api-gov.md
+++ b/ko/public-api-gov.md
@@ -17,22 +17,6 @@ API 응답에 가이드에 명시되지 않은 필드가 나타날 수 있습니
 
 NHN Kubernetes Service(NKS) API는 클러스터 및 노드 그룹 구성을 위해 여러 가지 리소스를 사용합니다. 리소스별 정보 확인 방법은 다음과 같습니다.
 
-### 인터넷 게이트웨이에 연결된 VPC 네트워크 UUID
-
-인터넷 게이트웨이에 연결된 VPC 네트워크는 VPC 네트워크 목록 조회 API에 **router:external=True** 쿼리 파라미터를 이용해 조회할 수 있습니다.
-
-```
-GET /v2.0/networks?router:external=True
-```
-
-네트워크 목록 조회 API에 대한 좀 더 자세한 내용은 [네트워크 목록 보기](/Network/VPC/ko/public-api-gov/#_2)를 참고하세요.
-
-
-### 인터넷 게이트웨이에 연결된 서브넷 UUID 목록
-
-인터넷 게이트웨이에 연결된 VPC 네트워크와 연결된 서브넷 UUID를 입력합니다. 여러 서브넷이 조회됐다면 콜론(`:`)으로 연결해 입력합니다. 서브넷 목록 조회 API에 대한 좀 더 자세한 내용은 [서브넷 목록 보기](/Network/VPC/ko/public-api-gov/#_6)를 참고하세요.
-
-
 ### VPC 네트워크 UUID
 
 노드와 연결할 내부 VPC 네트워크 UUID를 입력합니다. 네트워크 목록 조회 API에 대한 좀 더 자세한 내용은 [네트워크 목록 보기](/Network/VPC/ko/public-api-gov/#_2)를 참고하세요.

--- a/ko/public-api.md
+++ b/ko/public-api.md
@@ -16,22 +16,6 @@ API 응답에 가이드에 명시되지 않은 필드가 나타날 수 있습니
 
 NHN Kubernetes Service(NKS) API는 클러스터 및 노드 그룹 구성을 위해 여러 가지 리소스를 사용합니다. 리소스별 정보 확인 방법은 다음과 같습니다.
 
-### 인터넷 게이트웨이에 연결된 VPC 네트워크 UUID
-
-인터넷 게이트웨이에 연결된 VPC 네트워크는 VPC 네트워크 목록 조회 API에 **router:external=True** 쿼리 파라미터를 이용해 조회할 수 있습니다.
-
-```
-GET /v2.0/networks?router:external=True
-```
-
-네트워크 목록 조회 API에 대한 좀 더 자세한 내용은 [네트워크 목록 보기](/Network/VPC/ko/public-api/#_2)를 참고하세요.
-
-
-### 인터넷 게이트웨이에 연결된 서브넷 UUID 목록
-
-인터넷 게이트웨이에 연결된 VPC 네트워크와 연결된 서브넷 UUID를 입력합니다. 여러 서브넷이 조회되었다면 콜론(`:`)으로 연결해 입력합니다. 서브넷 목록 조회 API에 대한 좀 더 자세한 내용은 [서브넷 목록 보기](/Network/VPC/ko/public-api/#vpc_7)를 참고하세요.
-
-
 ### VPC 네트워크 UUID
 
 노드와 연결할 내부 VPC 네트워크 UUID를 입력합니다. 네트워크 목록 조회 API에 대한 좀 더 자세한 내용은 [네트워크 목록 보기](/Network/VPC/ko/public-api/#vpc_1)를 참고하세요.


### PR DESCRIPTION
- 클러스터 생성 시 external_network_id/external_subnet_id_list 값은 옵션 값이고 external_subnet_id_list 관련하여 API 가이드에 정보가 잘 못 등록되어 있어서 삭제하는 것이 좋을 것 같습니다. 확인 부탁드립니다.
  - 서브넷 목록에서 public 대역에 연결 된 서브넷만 입력할 수 있는 스펙입니다.

[[NKS] API에 사용되는 리소스 정보 사용자 가이드 문의](https://nhnent.dooray.com/project/tasks/4005364193171211367)