### PR TITLE
chore(pre-align): align heading structure (9 docs) with ko

### DIFF
--- a/en/backup-guide.md
+++ b/en/backup-guide.md
@@ -1,6 +1,10 @@
-## Container > NHN Kubernetes Service (NKS) > Backup Guide
+<!-- pre-align:aligned sig=dd3a912dfca5 -->
 
-## Overview
+<a id="container-nhn-kubernetes-service-nks-backup-guide"></a>
+## Container > NHN Kubernetes Service (NKS) > Backup Guide { #container-nhn-kubernetes-service-nks-backup-guide }
+
+<a id="overview"></a>
+## Overview { #overview }
 
 If you need a backup of your NHN Kubernetes Service (NKS) cluster, you can use the Velero plugin to back it up to Object Storage.
 This document describes how to back up and restore a cluster using Object Storage and Velero.
@@ -11,12 +15,15 @@ This document describes how to back up and restore a cluster using Object Storag
 
 For more information on Velero, refer to [Velero Docs](https://velero.io/docs/v1.9/).
 
-## Cluster Backup and Restoration with Velero
+<a id="cluster-backup-and-restoration-with-velero"></a>
+## Cluster Backup and Restoration with Velero { #cluster-backup-and-restoration-with-velero }
 
-### Prerequisites
+<a id="prerequisites"></a>
+### Prerequisites { #prerequisites }
 
 To use the Object Storage API, you must check the tenant ID and API endpoint, and set the API password and create Temporary URL key.
 
+<a id="prerequisites-check-the-tenant-id-and-api-endpoint"></a>
 #### Check the Tenant ID and API Endpoint
 
 You can check the tenant ID and API endpoint by clicking the **Set API Endpoint** button on the Object Storage service page.
@@ -26,6 +33,7 @@ You can check the tenant ID and API endpoint by clicking the **Set API Endpoint*
 | Identity | https://api-identity-infrastructure.nhncloudservice.com/v2.0 | Issue an authentication token |
 | Tenant ID | 32 character string consisting of numbers and alphabets | Issue an authentication token |
 
+<a id="prerequisites-set-an-api-password"></a>
 #### Set an API password
 
 You can set the API password by clicking the **Set API Endpoint** button on the Object Storage service page.
@@ -36,6 +44,7 @@ You can set the API password by clicking the **Set API Endpoint** button on the 
 
 For more information about the Object Storage API, see the [Object Storage API Guide](/Storage/Object%20Storage/en/api-guide/).
 
+<a id="prerequisites-create-temporary-url-key"></a>
 #### Create Temporary URL Key
 
 To use the `velero log` command in the Velero client, you must create a Temporary URL Key in Object Storage.
@@ -53,24 +62,28 @@ To use the `velero log` command in the Velero client, you must create a Temporar
 $ curl -X POST {Object Store} -H "X-Auth-Token: {tokenId}" -H "X-Account-Meta-Temp-Url-Key: {key}"
 ```
 
-### Install the Velero Client
+<a id="install-the-velero-client"></a>
+### Install the Velero Client { #install-the-velero-client }
 
 The Velero client is a program where you can enter the cluster's backup and restore commands.
 You can download the Velero client from the Velero Github repository and use it for cluster backup and restoration. Before running the downloaded Velero client command, you must download the kubeconfig file of the backup and restore clusters from the web console, and **set the KUBECONFIG environment variable to specify the target clusters for backup and restoration exactly**.
 For more information on kubeconfig settings, see [Installing kubectl](/Container/NKS/en/user-guide/#kubectl).
 
+<a id="install-the-velero-client-download-the-velero-client"></a>
 #### Download the Velero Client
 
 ```
 $ wget https://github.com/vmware-tanzu/velero/releases/download/v1.17.0/velero-v1.17.0-linux-amd64.tar.gz
 ```
 
+<a id="install-the-velero-client-decompress-the-file"></a>
 #### Decompress the File
 
 ```
 $ tar xzf velero-v1.17.0-linux-amd64.tar.gz
 ```
 
+<a id="install-the-velero-client-change-the-location-or-set-the-path"></a>
 #### Change the Location or Set the Path
 
 Move the file to the path specified in the environment variable so that you can run the Velero client from any path, or add the path where Velero is located to the environment variable.
@@ -87,16 +100,19 @@ $ sudo mv velero-v1.17.0-linux-amd64/velero /usr/local/bin
 $ export PATH=$PATH:$(pwd)
 ```
 
-### Install the Velero Server
+<a id="install-the-velero-server"></a>
+### Install the Velero Server { #install-the-velero-server }
 
 Install the Velero server using Helm.
 
+<a id="install-the-velero-server-download-helm"></a>
 #### Download Helm
 
 ```
 $ curl -fsSL -o get_helm.sh https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3
 ```
 
+<a id="install-the-velero-server-change-a-permission"></a>
 #### Change a Permission
 
 The downloaded file does not have execute permission by default. Add an execute permission.
@@ -105,12 +121,14 @@ The downloaded file does not have execute permission by default. Add an execute 
 $ chmod 700 get_helm.sh
 ```
 
+<a id="install-the-velero-server-install-helm"></a>
 #### Install Helm
 
 ```
 $ ./get_helm.sh
 ```
 
+<a id="install-the-velero-server-add-the-helm-repository"></a>
 #### Add the Helm Repository
 
 To install the Velero server, you need to add the Helm repository.
@@ -119,6 +137,7 @@ To install the Velero server, you need to add the Helm repository.
 $ helm repo add vmware-tanzu https://vmware-tanzu.github.io/helm-charts
 ```
 
+<a id="install-the-velero-server-2"></a>
 #### Install the Velero Server
 
 The Velero server must be installed on a `backup cluster` and a `restore cluster` respectively. We recommend that you install using `the same helm command on both clusters` to use the same Object Storage.
@@ -174,10 +193,12 @@ $ helm install velero vmware-tanzu/velero \
 | Region | Korea (Pangyo) Region: `KR1`<br>Korea (Pyeongchon) Region: `KR2`<br>Korea (Gwangju) Region: `KR3` |
 | OBS endpoint | Object Storage API Endpoint |
 
+<a id="install-the-velero-server-delete-the-velero-server"></a>
 #### Delete the Velero Server
 You can uninstall the Velero server with the `velero uninstall` command.
 
-### Back up a Cluster
+<a id="back-up-a-cluster"></a>
+### Back up a Cluster { #back-up-a-cluster }
 
 You can configure a cluster backup with the `velero backup create` command.
 
@@ -203,7 +224,8 @@ my-backup    Completed   0        0          2025-10-13 11:01:53 +0900 KST   29d
 
 * You can view the backed up information on the Object Storage service page.
 
-### Restore a Cluster
+<a id="restore-a-cluster"></a>
+### Restore a Cluster { #restore-a-cluster }
 
 You can configure a cluster backup/restoration with the `velero restore create` command.
 
@@ -220,8 +242,10 @@ $ velero restore create --from-backup {name}
 > [Caution]
 > If the versions of the `backup cluster` and the `restore cluster` are different, problems may occur during restoration.
 
-### Examples
+<a id="examples"></a>
+### Examples { #examples }
 
+<a id="examples-example-of-cluster-backup-and-restoration"></a>
 #### Example of Cluster Backup and Restoration
 
 * Perform backup using the velero backup create command on the backup cluster.
@@ -250,6 +274,7 @@ $ velero restore create --from-backup my-backup
 $ kubectl get pod --all-namespaces
 ```
 
+<a id="examples-example-of-setting-periodic-backups"></a>
 #### Example of Setting Periodic Backups
 
 You can configure periodic backups with the `velero schedule create` command. See [schedule-a-backup](https://velero.io/docs/v1.17/backup-reference/#schedule-a-backup) for details.
@@ -269,6 +294,7 @@ my-schedule-20251013055022   Completed   0        0          2025-10-13 14:50:22
 my-schedule-20251013054022   Completed   0        0          2025-10-13 14:40:22 +0900 KST   29d       default            <none>
 ```
 
+<a id="examples-example-of-clearing-periodic-backups"></a>
 #### Example of Clearing Periodic Backups
 Periodic backups can be cleared with the `velero schedule delete` command.
 

--- a/en/gateway-api-guide.md
+++ b/en/gateway-api-guide.md
@@ -1,6 +1,10 @@
-## Container > NHN Kubernetes Service (NKS) > Application Guide > Gateway API
+<!-- pre-align:aligned sig=091ebaa2b119 -->
 
-### Overview
+<a id="container-nhn-kubernetes-service-nks-application-guide-gateway-api"></a>
+## Container > NHN Kubernetes Service (NKS) > Application Guide > Gateway API { #container-nhn-kubernetes-service-nks-application-guide-gateway-api }
+
+<a id="overview"></a>
+### Overview { #overview }
 
 Gateway API is a next-generation standard API for managing traffic routing in Kubernetes. It overcomes the limitations of the existing Ingress API and enables routing of various traffic types — such as HTTP, HTTPS, and TCP — from outside the cluster to internal services in a more expressive and extensible way. For more information on Gateway API and related resources, see the [Gateway API](https://gateway-api.sigs.k8s.io/) documentation.
 
@@ -14,6 +18,7 @@ Gateway API supports various implementations, and you can choose the one that be
 
 > [Note] The supported Gateway API version may vary by implementation. For more information, refer to the official documentation of each implementation.
 
+<a id="overview-key-gateway-api-resources"></a>
 #### Key Gateway API Resources
 
 Gateway API is designed to separate resources by role, allowing platform operators and application developers to configure settings within their respective scopes of authority.
@@ -31,11 +36,13 @@ Gateway API is designed to separate resources by role, allowing platform operato
 
 > [Note] In NGF, the NginxProxy resource can be used to additionally configure NGINX data plane behavior (service settings, replica count, etc.).
 
-### Install NGINX Gateway Fabric
+<a id="install-nginx-gateway-fabric"></a>
+### Install NGINX Gateway Fabric { #install-nginx-gateway-fabric }
 
 For more information on installing NGINX Gateway Fabric, see the [NGINX Gateway Fabric installation guide](https://docs.nginx.com/nginx-gateway-fabric/install) documentation.
 
-### HTTP Routing Example
+<a id="http-routing-example"></a>
+### HTTP Routing Example { #http-routing-example }
 
 The following is an example of routing traffic to multiple services based on the URI path. The diagram below shows the structure for routing requests to different services based on the `/coffee` and `/tea` paths.
 
@@ -45,6 +52,7 @@ Client → Gateway (LoadBalancer) → HTTPRoute
                                     └── /tea    → tea-svc    → tea Pod
 ```
 
+<a id="http-routing-example-deploy-services-and-pods"></a>
 #### Deploy Services and Pods
 
 Write a manifest to create services and Pods as shown below. Connect the `coffee` Pod to the `coffee-svc` service and the `tea` Pod to the `tea-svc` service.
@@ -124,6 +132,7 @@ Apply the above manifest.
 kubectl apply -f cafe.yaml
 ```
 
+<a id="http-routing-example-verify-gatewayclass"></a>
 #### Verify GatewayClass
 
 When NGINX Gateway Fabric is installed via Helm, a GatewayClass named `nginx` is created. Depending on the installation method, the GatewayClass may not be created automatically, in which case you must create it manually.
@@ -141,6 +150,7 @@ nginx   gateway.nginx.org/nginx-gateway-controller    True       10s
 
 If the `ACCEPTED` field is `True`, the GatewayClass has been created successfully.
 
+<a id="http-routing-example-create-gateway"></a>
 #### Create Gateway
 
 Create a gateway to receive traffic from outside the cluster. The following manifest defines a gateway that receives HTTP traffic on port 80.
@@ -180,6 +190,7 @@ nginx   nginx   123.123.123.44   True         1m
 
 Verify that the `PROGRAMMED` field is `True` and that an IP address has been assigned to `ADDRESS`.
 
+<a id="http-routing-example-create-httproute"></a>
 #### Create HTTPRoute
 
 Create an HTTPRoute that defines path-based routing rules. Write and apply the following manifest.
@@ -216,6 +227,7 @@ Apply the above manifest.
 kubectl apply -f cafe-route.yaml
 ```
 
+<a id="http-routing-example-verify-operation"></a>
 #### Verify Operation
 
 Send an HTTP request from an external host to the gateway IP address to verify that routing has been configured correctly.
@@ -232,7 +244,8 @@ curl http://${GATEWAY_IP}/tea
 
 When a request is sent to the `/coffee` path, it is forwarded to the `coffee-svc` service and the `coffee` Pod responds. The `Server name` field in the response shows that the `coffee` Pods respond alternately in a round-robin manner.
 
-### Host-Based Routing Example
+<a id="host-based-routing-example"></a>
+### Host-Based Routing Example { #host-based-routing-example }
 
 The following is an example of routing traffic to different services based on the hostname (Host header) of the request. The diagram below shows the structure for routing requests to different services based on the `coffee.example.com` and `tea.example.com` hostnames.
 
@@ -243,6 +256,7 @@ Client → Gateway (LoadBalancer) → HTTPRoute (coffee.example.com) → coffee-
 
 The services and Pods use the `cafe.yaml` from the previous example as-is.
 
+<a id="host-based-routing-example-create-httproute"></a>
 #### Create HTTPRoute
 
 Create an HTTPRoute for each hostname. Specify the hostname to route to in the `spec.hostnames` field.
@@ -284,6 +298,7 @@ Apply the above manifest.
 kubectl apply -f cafe-route-host.yaml
 ```
 
+<a id="host-based-routing-example-verify-operation"></a>
 #### Verify Operation
 
 Send a request from an external host by mapping the hostname to the gateway IP using the `--resolve` option.
@@ -304,7 +319,8 @@ When a request is sent to the `coffee.example.com` host, it is forwarded to the 
 
 > [Note] In a production environment, each hostname must be registered in DNS to point to the gateway's external IP. For testing, you can map the hostname directly to the gateway IP using the `--resolve` option as shown above, or by adding a record to the `/etc/hosts` file.
 
-### Cross-Namespace Routing Example
+<a id="cross-namespace-routing-example"></a>
+### Cross-Namespace Routing Example { #cross-namespace-routing-example }
 
 Gateway API supports traffic routing across multiple namespaces. In this example, a Gateway is deployed in the `nginx-gateway` namespace, an HTTPRoute in the `default` namespace, and a Service in the `app` namespace.
 
@@ -313,6 +329,7 @@ Cross-namespace references in Gateway API are controlled by the following two se
 * **`allowedRoutes.namespaces`**: Required when the Gateway and HTTPRoute are in different namespaces. Allows the HTTPRoute to reference a Gateway in another namespace as a `parentRef`.
 * **`ReferenceGrant`**: Required when the HTTPRoute and backend Service are in different namespaces. Allows the HTTPRoute to reference a Service in another namespace as a `backendRef`.
 
+<a id="cross-namespace-routing-example-deploy-services-and-pods"></a>
 #### Deploy Services and Pods
 
 Create the `app` namespace to be used in the example.
@@ -327,6 +344,7 @@ Deploy the `cafe.yaml` from the previous example to the `app` namespace.
 kubectl apply -f cafe.yaml -n app
 ```
 
+<a id="cross-namespace-routing-example-create-gateway"></a>
 #### Create Gateway
 
 Create a Gateway in the `nginx-gateway` namespace. Set `allowedRoutes.namespaces.from: All` to allow the HTTPRoute in the `default` namespace to reference this Gateway. Write and apply the following manifest.
@@ -355,6 +373,7 @@ Apply the above manifest.
 kubectl apply -f gateway-cross-ns.yaml
 ```
 
+<a id="cross-namespace-routing-example-create-referencegrant"></a>
 #### Create ReferenceGrant
 
 Create a `ReferenceGrant` to allow the HTTPRoute in the `default` namespace to reference the Service in the `app` namespace. Write and apply the following manifest.
@@ -384,6 +403,7 @@ kubectl apply -f reference-grant.yaml
 
 > [Note] The ReferenceGrant resource is available as a v1 API starting from Gateway API v1.5. Depending on the Gateway API version or implementation in use, the v1beta1 API may be used.
 
+<a id="cross-namespace-routing-example-create-httproute"></a>
 #### Create HTTPRoute
 
 Create an HTTPRoute in the `default` namespace. Specify the Gateway's namespace (`nginx-gateway`) in `parentRef` and the Service's namespace (`app`) in `backendRef`. Write and apply the following manifest.
@@ -424,6 +444,7 @@ Apply the above manifest.
 kubectl apply -f cafe-route-cross-ns.yaml
 ```
 
+<a id="cross-namespace-routing-example-verify-operation"></a>
 #### Verify Operation
 
 Use the following command to verify that routing has been configured correctly.
@@ -438,7 +459,8 @@ curl http://${GATEWAY_IP}/coffee
 curl http://${GATEWAY_IP}/tea
 ```
 
-### Migrate from Ingress to Gateway API
+<a id="migrate-from-ingress-to-gateway-api"></a>
+### Migrate from Ingress to Gateway API { #migrate-from-ingress-to-gateway-api }
 
 `ingress2gateway` is a tool managed by Kubernetes SIG-Network that can be used to convert existing Ingress resources to Gateway API resources (Gateway, HTTPRoute, etc.). However, not all Ingress settings are fully converted, and some features may require manual adjustments. For more information, see the [ingress2gateway](https://github.com/kubernetes-sigs/ingress2gateway) documentation.
 
@@ -446,10 +468,12 @@ curl http://${GATEWAY_IP}/tea
 
 > [Note] Not all Ingress annotations are converted to Gateway API. If there are unsupported annotations after conversion, a warning message is displayed. For more information, see the [supported providers list](https://github.com/kubernetes-sigs/ingress2gateway?tab=readme-ov-file#supported-providers).
 
+<a id="migrate-from-ingress-to-gateway-api-install-ingress2gateway"></a>
 #### Install ingress2gateway
 
 For more information on installing ingress2gateway, see the [ingress2gateway installation guide](https://github.com/kubernetes-sigs/ingress2gateway?tab=readme-ov-file#installation) documentation.
 
+<a id="migrate-from-ingress-to-gateway-api-convert-ingress-resources"></a>
 #### Convert Ingress Resources
 
 Convert the Ingress resources deployed in the current cluster to Gateway API resources. Specify the Ingress controller in use with the `--providers` option and convert resources from all namespaces with the `-A` option. Use the following command to save the conversion results to a file.
@@ -470,6 +494,7 @@ Convert the saved file as input.
 ingress2gateway print --providers=ingress-nginx --input-file /path/to/ingress.yaml > gateway-resources.yaml
 ```
 
+<a id="migrate-from-ingress-to-gateway-api-conversion-example"></a>
 #### Conversion Example
 
 The following is an example of an Ingress resource before conversion and a Gateway API resource after conversion.
@@ -553,6 +578,7 @@ status:
 
 > [Note] The `gatewayClassName` of the converted resource uses the existing Ingress class name (`nginx`) as-is. Verify that it matches the GatewayClass name specified during installation.
 
+<a id="migrate-from-ingress-to-gateway-api-apply-conversion-results"></a>
 #### Apply Conversion Results
 
 Review the converted resources and apply them to the cluster.

--- a/en/istio-guide.md
+++ b/en/istio-guide.md
@@ -1,14 +1,20 @@
-## Container > NHN Kubernetes Service (NKS) > Application Guide > Istio
+<!-- pre-align:aligned sig=f2738c580f82 -->
 
-### Overview
+<a id="container-nhn-kubernetes-service-nks-application-guide-istio"></a>
+## Container > NHN Kubernetes Service (NKS) > Application Guide > Istio { #container-nhn-kubernetes-service-nks-application-guide-istio }
+
+<a id="overview"></a>
+### Overview { #overview }
 This document is a guide that describes examples of configuring and testing Istio on NHN Kubernetes Service (NKS) clusters. NKS provides guides and Istio images from the NCR registry to help you configure Istio on clusters that are not connected to the internet. You can use this guide to configure Istio using the images provided by NKS, or you can configure Istio yourself by referring to the official Istio document.
 
-### Istio
+<a id="istio"></a>
+### Istio { #istio }
 A service mesh is an infrastructure layer for microservices that specializes in controlling and efficiently managing communication between services in a distributed system. 
 Istio is one of the mostly used open source service meshes. This example shows how the Istio service of demo profile works after being deployed to clusters. For more information about Istio, see [Istio](https://istio.io/latest/about/service-mesh/).
 
 
-### Prerequisites for istio deployment
+<a id="prerequisites-for-istio-deployment"></a>
+### Prerequisites for istio deployment { #prerequisites-for-istio-deployment }
 Check the correct registry information for the Istio version and cluster to deploy and set them in the variables. The variables you set will be used during the deployment process.
 
 ```
@@ -16,6 +22,7 @@ $VERSION="{Version of istio you want to download}"
 $ REGISTRY="{Region-specific registry}"
 ```
 
+<a id="prerequisites-for-istio-deployment-supported-kubernetes-versions-by-istio-version"></a>
 #### Supported Kubernetes versions by Istio version
 
 | Version | Supported Kubernetes versions |
@@ -27,6 +34,7 @@ $ REGISTRY="{Region-specific registry}"
 NKS provides installation only for the Istio versions specified in the table above. If you want to use a version not provided by NKS, you must configure Istio yourself. For information about supported Istio versions, see the [istio support policy](https://istio.io/latest/docs/releases/supported-releases/).
 
 
+<a id="prerequisites-for-istio-deployment-registry-information-by-region-and-internet-environment"></a>
 #### Registry information by region and Internet environment
 | Region | Internet Connection | Registry |
 | --- | --- | --- |
@@ -42,6 +50,7 @@ NKS provides installation only for the Istio versions specified in the table abo
 For clusters to use NCR registries that are not connected to the internet, it is necessary to configure an environment to use a private URI. For information on how to use Private URI, refer to the [](/Container/NCR/ko/user-guide/#private-uri)NHN Cloud Container Registry (NCR) User Guide[](/Container/NCR/ko/user-guide/#private-uri).
 
 
+<a id="prerequisites-for-istio-deployment-install-the-oras-command-line-tool"></a>
 #### Install the ORAS command-line tool
 Download the OCI Registry As Storage (ORAS) command-line tool to pull artifacts. ORAS is a tool that provides a way to push and pull OCI artifacts from the OCI Registry.
 Run the command below to install the ORAS command-line tool. For detailed instructions on how to use the ORAS command line tool, see the [ORAS docs](https://oras.land/docs/).
@@ -57,8 +66,10 @@ $ export PATH="/usr/local/bin:$PATH"
 ```
 
 
-### Install Istio
+<a id="install-istio"></a>
+### Install Istio { #install-istio }
 
+<a id="install-istio-download-and-install-istioctl-using-the-oras-command-line-tool"></a>
 #### 1. Download and install istioctl using the ORAS command line tool.
 istioctl is a configuration command-line utility that allows you to debug and diagnose the service mesh deployment provided by Istio, offering various features, such as setting Istio deployment configuration options. For more information on istioctl, see [istioctl](https://istio.io/latest/docs/reference/commands/istioctl/). 
 
@@ -70,6 +81,7 @@ $ cd istio-${VERSION}
 $ export PATH=$PWD/bin:$PATH
 ```
 
+<a id="install-istio-deploy-istio-components-using-istioctl"></a>
 #### 2. Deploy Istio components using istioctl.
 Profiles provide custom deployment features for sidecars in the Istio control plane and data plane. The profile that is set up determines which components are enabled upon deployment. Depending on the environmental configuration of your cluster, you can use the default profile or customize the configuration to meet your specific needs. For more information on Istio profiles, see [Istio installation configuration profiles](https://istio.io/latest/docs/setup/additional-setup/config-profiles/). In this example, demo profile that is provided by default is used for deployment.
 
@@ -159,9 +171,11 @@ replicaset.apps/istio-ingressgateway-b8844867c 1 1 1 86s
 replicaset.apps/istiod-8c7fbbdc8 1 1 1 90s
 ```
 
-### Deploy application
+<a id="deploy-application"></a>
+### Deploy application { #deploy-application }
 Deploy an application to verify that Istio is installed and works properly. For this example, the Bookinfo sample application that comes with Istio is used. The sample application consists of four microservices: productpage, details, reviews, and ratings. For more information about the Bookinfo sample application, see [Istio Bookinfo Application](https://istio.io/latest/docs/examples/bookinfo/).
 
+<a id="deploy-application-label-namespace"></a>
 #### 1. Label namespace
 To use the Istio sidecar proxy, you need to label the namespace where the pods will be created. The label is used to identify the namespace where you want to deploy Istio components. When a Pod is deployed to a labeled namespace, the Istio sidecar proxy is automatically deployed to the Pod.
 
@@ -171,6 +185,7 @@ $ kubectl label namespace default istio-injection=enabled
 namespace/default labeled
 ```
 
+<a id="deploy-application-components"></a>
 #### 2. Deploy application components
 Deploy the application components and check whether they are deployed successfully.
 
@@ -218,9 +233,11 @@ $ kubectl exec "$(kubectl get pod -l app=ratings -o jsonpath='{.items[0].metadat
 <title>Simple Bookstore App</title>
 ```
 
-### Expose service
+<a id="expose-service"></a>
+### Expose service { #expose-service }
 Up to this point, the service is set up as a `ClusterIP`, which is only accessible to hosts inside the cluster. While Kubernetes provides various types of `Service` objects ( `NodePort`, `LoadBalancer`, etc.) for exposing services, Istio provides gateway objects to handle a wider range of network traffic. The following example shows the process of exposing a service using the sample bookinfo gateway provided by Istio. For more information on Istio gateways, see [Istio Gateways](https://istio.io/latest/docs/concepts/traffic-management/#gateways).
 
+<a id="expose-service-configure-ingress-gateway"></a>
 #### Configure ingress gateway
 Further configure the Istio ingress gateway to expose the service.
 
@@ -237,6 +254,7 @@ $ istioctl analyze
 ✔ No validation issues found when analyzing namespace: default.
 ```
 
+<a id="expose-service-access-service"></a>
 #### Access service
 Check the gateway URL information to access the exposed service. The gateway URL defaults to the configuration `Ingress Host:Ingress IP`. How you find the gateway URL information depends on whether the cluster is configured in the Internet or an isolated network environment. Clusters configured on the Internet have the gateway URL configured based on the `EXTERNAL-IP` information of the load balancer, and clusters configured in an isolated network environment have the gateway URL configured based on the node ports.
 
@@ -272,7 +290,8 @@ $ curl http://114.110.160.79:80/productpage
 ```
 
 
-### Delete Istio
+<a id="delete-istio"></a>
+### Delete Istio { #delete-istio }
 Perform the command below to remove the components related to the bookinfo application that were used in the example.
 ```
 $ kubectl delete -f samples/bookinfo/networking/bookinfo-gateway.yaml

--- a/en/overview.md
+++ b/en/overview.md
@@ -1,7 +1,11 @@
-## Container > NHN Kubernetes Service (NKS) > Overview
+<!-- pre-align:aligned sig=380a0a4ca9e2 -->
+
+<a id="container-nhn-kubernetes-service-nks-overview"></a>
+## Container > NHN Kubernetes Service (NKS) > Overview { #container-nhn-kubernetes-service-nks-overview }
 This document briefly describes what Kubernetes is, and outlines NHN Kubernetes Service (NKS) provided by NHN Cloud. 
 
-## Kubernetes
+<a id="kubernetes"></a>
+## Kubernetes { #kubernetes }
 Kubernetes is an open-source platform which manages containerized workload and services. Kubernetes provides the following features: 
 
 * Service discovery and load balancing 
@@ -15,20 +19,25 @@ For more details, see the following documents on Kubernetes:
 
 * [What is Kubernetes?](https://kubernetes.io/docs/concepts/overview/)
 
-## Kubernetes Cluster 
+<a id="kubernetes-cluster"></a>
+## Kubernetes Cluster { #kubernetes-cluster }
 A Kubernetes cluster is a computer cluster connected to each other and run as one unit. Features provided by Kubernetes operate on a cluster-by-cluster basis and can be configured on a cluster-by-cluster basis.
 
-### Configuration 
+<a id="configuration"></a>
+### Configuration { #configuration }
 A Kubernetes cluster consists of a control plane and nodes.  
 
+<a id="configuration-control-plane"></a>
 #### Control Plane 
 A control plane is in charge of cluster management. A control plane manages all activities of a cluster, such as application scheduling, scaling, or updating. In general, the components of control plane run on separate machines (virtual or physical machines). To ensure high availability, multiple control planes can be configured on a cluster. 
 
+<a id="configuration-node"></a>
 #### Node
 A node is a worker machine where user's application runs. One cluster may contain many nodes. The nodes can run when connected to the control plane. Nodes follow the commands of a control plane and perform the operations, such as running or suspending applications.
 
 
-## NHN Kubernetes Service (NKS)
+<a id="nhn-kubernetes-service-nks"></a>
+## NHN Kubernetes Service (NKS) { #nhn-kubernetes-service-nks }
 NHN Kubernetes Service (NKS) is a service that allows users to create and manage Kubernetes clusters to run Kubernetes in the cloud properly and safely. Users can use the web console to create and manage Kubernetes clusters that are suitable for NHN Cloud. For safe and efficient operations, control planes are managed by NHN Cloud, while nodes, services, and pods are managed by users.
 
 The main features of NKS are as follows: 

--- a/en/public-api.md
+++ b/en/public-api.md
@@ -1,4 +1,5 @@
-## Container > NHN Kubernetes Service (NKS) > API v2 Guide
+<a id="container-nhn-kubernetes-service-nks-api-v2-guide"></a>
+## Container > NHN Kubernetes Service (NKS) > API v2 Guide { #container-nhn-kubernetes-service-nks-api-v2-guide }
 
 This guide describes the API for configuring Kubernetes clusters.
 NKS uses IaaS tokens for authentication and authorization when making API calls. The IaaS token is an authentication token used for NHN Cloud's OpenStack-based infrastructure services (IaaS). For more information on issuing and using IaaS tokens, see the [IaaS token](/nhncloud/ko/public-api/iaas-token).
@@ -11,11 +12,13 @@ All API calls are made using the `kubernetes` type endpoint.
 
 Fields not specified in the guide may appear in API responses. These fields are used for internal use by NHN Cloud and are subject to change without prior notice, so we advise you not to use them.
 
-## Check the Information of Resources Used in API
+<a id="check-the-information-of-resources-used-in-api"></a>
+## Check the Information of Resources Used in API { #check-the-information-of-resources-used-in-api }
 
 The NHN Kubernetes Service (NKS) API uses several resources for configuring clusters and node groups. You can check the information of each resource as follows.
 
-### UUID of the VPC Network Attached to the Internet Gateway
+<a id="uuid-of-the-vpc-network-attached-to-the-internet-gateway"></a>
+### UUID of the VPC Network Attached to the Internet Gateway { #uuid-of-the-vpc-network-attached-to-the-internet-gateway }
 
 You can query the VPC network attached to the internet gateway by using the **router:external=True** query parameter in the VPC network list query API.
 
@@ -26,44 +29,54 @@ GET /v2.0/networks?router:external=True
 For more information about the network list query API, refer to [List Networks](/Network/VPC/en/public-api/#list-networks).
 
 
-### List of UUIDs of Subnets Attached to the Internet Gateway
+<a id="list-of-uuids-of-subnets-attached-to-the-internet-gateway"></a>
+### List of UUIDs of Subnets Attached to the Internet Gateway { #list-of-uuids-of-subnets-attached-to-the-internet-gateway }
 
 Enter the UUID of subnet associated with the VPC network attached to the internet gateway. If multiple subnets are found, enter them by concatenating them with a colon (`:`). For more information about the subnet list query API, refer to [List Subnets](/Network/VPC/en/public-api/#list-vpc-subnets).
 
 
-### VPC Network UUID
+<a id="vpc-network-uuid"></a>
+### VPC Network UUID { #vpc-network-uuid }
 
 Enter the UUID of internal VPC network to associate with the node. For more information about the network list query API, refer to [List Networks](/Network/VPC/en/public-api/#view-vpc-list).
 
-### VPC Subnet UUID
+<a id="vpc-subnet-uuid"></a>
+### VPC Subnet UUID { #vpc-subnet-uuid }
 
 Enter the UUID of subnet associated with the internal VPC network to associate with the node. For more information about the subnet list query API, refer to [List Subnets](/Network/VPC/en/public-api/#list-vpc-subnets).
 
-### Availability Zone UUID
+<a id="availability-zone-uuid"></a>
+### Availability Zone UUID { #availability-zone-uuid }
 
 Enter the UUID of availability zone in which to create the node. For more information about the availability zone list query API, see [List Availability Zones](/Compute/Instance/en/public-api/#list-availability-zones).
 
-### Key Pair UUID
+<a id="key-pair-uuid"></a>
+### Key Pair UUID { #key-pair-uuid }
 
 Enter the key pair to use when connecting to the node. For more information about the key pair list query API, refer to [List Key Pairs](/Compute/Instance/en/public-api/#list-key-pairs).
 
-### Base Image UUID
+<a id="base-image-uuid"></a>
+### Base Image UUID { #base-image-uuid }
 
 Enter the base image UUID to use for node creation. To filter only the base images used to create NKS nodes, enter the value `nhncloud_allow_nks_cpu_flavor=true&visibility=public` in the query string parameter when calling the API. For more information on the retrieve base image list API, see [Retrieve Image list](/Compute/Image/en/public-api/#_2).
 
-### Block Storage Type
+<a id="block-storage-type"></a>
+### Block Storage Type { #block-storage-type }
 
 Enter the block storage UUID to use for the node. For more information about the block storage type list query API, refer to [List Volume Types](/Storage/Block%20Storage/en/public-api/#list-volume-types) .
 
-### Flavor UUID
+<a id="flavor-uuid"></a>
+### Flavor UUID { #flavor-uuid }
 
 Enter the UUID of flavor for the node to be created. For more information about the flavor list query API, refer to [List Flavors](/Compute/Instance/en/public-api/#list-flavors).
 
 
 
-## Cluster
+<a id="cluster"></a>
+## Cluster { #cluster }
 
-### List Clusters
+<a id="list-clusters"></a>
+### List Clusters { #list-clusters }
 
 Retrieves a list of clusters.
 
@@ -75,6 +88,7 @@ OpenStack-API-Version: container-infra latest
 X-Auth-Token: {tokenId}
 ```
 
+<a id="list-clusters-request"></a>
 #### Request
 
 This API does not require a request body. 
@@ -83,6 +97,7 @@ This API does not require a request body.
 |---|---|---|---|---|
 | tokenId | Header | String | O | Token ID |
 
+<a id="list-clusters-response"></a>
 #### Response
 
 | Name | Type | Format | Description |
@@ -186,7 +201,8 @@ This API does not require a request body.
 
 ---
 
-### Get a Cluster
+<a id="get-a-cluster"></a>
+### Get a Cluster { #get-a-cluster }
 
 Retrieves information of an individual cluster.
 
@@ -198,6 +214,7 @@ OpenStack-API-Version: container-infra latest
 X-Auth-Token: {tokenId}
 ```
 
+<a id="get-a-cluster-request"></a>
 #### Request
 
 This API does not require a request body. 
@@ -207,6 +224,7 @@ This API does not require a request body.
 | tokenId | Header | String | O | Token ID |
 | CLUSTER_ID_OR_NAME| URL | UUID or String | O | Cluster UUID or cluster name |
 
+<a id="get-a-cluster-response"></a>
 #### Response
 
 | Name | Type | Format | Description |
@@ -332,7 +350,8 @@ This API does not require a request body.
 
 ---
 
-### View Task History List
+<a id="view-task-history-list"></a>
+### View Task History List { #view-task-history-list }
 
 Views a list of the cluster's job history.
 
@@ -344,6 +363,7 @@ OpenStack-API-Version: container-infra latest
 X-Auth-Token: {tokenId}
 ```
 
+<a id="view-task-history-list-request"></a>
 #### Request
 
 This API does not require a request body.
@@ -354,6 +374,7 @@ This API does not require a request body.
 | CLUSTER_UUID | URL | UUID | O | Cluster UUID |
 
 
+<a id="view-task-history-list-response"></a>
 #### Response
 
 | Name | Type | Format | Description |
@@ -404,7 +425,8 @@ This API does not require a request body.
 
 ---
 
-### List Task History
+<a id="list-task-history"></a>
+### List Task History { #list-task-history }
 
 Lists the job history of a cluster.
 
@@ -416,6 +438,7 @@ OpenStack-API-Version: container-infra latest
 X-Auth-Token: {tokenId}
 ```
 
+<a id="list-task-history-request"></a>
 #### Request
 
 This API does not require a request body.
@@ -427,6 +450,7 @@ This API does not require a request body.
 | EVENT_UUID | URL | UUID | O | Task UUID |
 
 
+<a id="list-task-history-response"></a>
 #### Response
 
 | Name | Type | Format | Description |
@@ -472,7 +496,8 @@ This API does not require a request body.
 
 ---
 
-### Create a Cluster
+<a id="create-a-cluster"></a>
+### Create a Cluster { #create-a-cluster }
 
 Creates a cluster.
 
@@ -484,6 +509,7 @@ OpenStack-API-Version: container-infra latest
 X-Auth-Token: {tokenId}
 ```
 
+<a id="create-a-cluster-request"></a>
 #### Request
 
 | Name | Type | Format | Required | Description |
@@ -619,6 +645,7 @@ X-Auth-Token: {tokenId}
 </p>
 </details>
 
+<a id="create-a-cluster-response"></a>
 #### Response
 
 | Name | Type | Format | Description |
@@ -639,7 +666,8 @@ X-Auth-Token: {tokenId}
 
 ---
 
-### Delete a Cluster
+<a id="delete-a-cluster"></a>
+### Delete a Cluster { #delete-a-cluster }
 
 Deletes a Cluster.
 
@@ -651,6 +679,7 @@ OpenStack-API-Version: container-infra latest
 X-Auth-Token: {tokenId}
 ```
 
+<a id="delete-a-cluster-request"></a>
 #### Request
 
 This API does not require a request body. 
@@ -661,13 +690,15 @@ This API does not require a request body.
 | CLUSTER_ID_OR_NAME | URL | UUID or String | O | Cluster UUID or cluster name | 
 
 
+<a id="delete-a-cluster-response"></a>
 #### Response
 
 This API does not return a response body.
 
 ---
 
-### Resize
+<a id="resize"></a>
+### Resize { #resize }
 
 Adjusts the number of nodes in the cluster.
 
@@ -679,6 +710,7 @@ OpenStack-API-Version: container-infra latest
 X-Auth-Token: {tokenId}
 ```
 
+<a id="resize-request"></a>
 #### Request
 
 | Name | Type | Format | Required | Description |
@@ -725,6 +757,7 @@ X-Auth-Token: {tokenId}
 
 
 
+<a id="resize-response"></a>
 #### Response
 
 | Name | Type | Format | Description |
@@ -746,7 +779,8 @@ X-Auth-Token: {tokenId}
 
 ---
 
-### Get kubeconfig of a Cluster
+<a id="get-kubeconfig-of-a-cluster"></a>
+### Get kubeconfig of a Cluster { #get-kubeconfig-of-a-cluster }
 
 Retrieves the cluster configuration file (kubeconfig).
 
@@ -758,6 +792,7 @@ OpenStack-API-Version: container-infra latest
 X-Auth-Token: {tokenId}
 ```
 
+<a id="get-kubeconfig-of-a-cluster-request"></a>
 #### Request
 
 This API does not require a request body. 
@@ -768,6 +803,7 @@ This API does not require a request body.
 | CLUSTER_ID_OR_NAME | URL | UUID or String | O | Cluster UUID or cluster name | 
 
 
+<a id="get-kubeconfig-of-a-cluster-response"></a>
 #### Response
 
 | Name | Type | Format | Description |
@@ -787,7 +823,8 @@ This API does not require a request body.
 </p>
 </details>
 
-### Enforce IP Access Control to Cluster API Endpoints
+<a id="enforce-ip-access-control-to-cluster-api-endpoints"></a>
+### Enforce IP Access Control to Cluster API Endpoints { #enforce-ip-access-control-to-cluster-api-endpoints }
 You can enforce or disable IP access control to cluster API endpoints.
 For more information about IP access control features, see [IP access control](/Network/Load%20Balancer/en/overview/#ip).
 For more information about IP access control rules for Cluster API endpoints, see the [user guide](/Container/NKS/en/user-guide/#api_endpoint_ipacl).
@@ -800,6 +837,7 @@ OpenStack-API-Version: container-infra latest
 X-Auth-Token: {tokenId}
 ```
 
+<a id="enforce-ip-access-control-to-cluster-api-endpoints-request"></a>
 #### Request
 
 | Name | Type | Format | Required | Description |
@@ -836,6 +874,7 @@ X-Auth-Token: {tokenId}
 </details>
 
 
+<a id="enforce-ip-access-control-to-cluster-api-endpoints-response"></a>
 #### Response
 
 | Name | Type | Format | Description |
@@ -855,7 +894,8 @@ X-Auth-Token: {tokenId}
 </details>
 
 
-### Get Cluster API Endpoint IP Access Control 
+<a id="get-cluster-api-endpoint-ip-access-control"></a>
+### Get Cluster API Endpoint IP Access Control { #get-cluster-api-endpoint-ip-access-control }
 You can view IP access control information applied to your cluster API endpoints.
 
 ```
@@ -866,6 +906,7 @@ OpenStack-API-Version: container-infra latest
 X-Auth-Token: {tokenId}
 ```
 
+<a id="get-cluster-api-endpoint-ip-access-control-request"></a>
 #### Request
 This API does not require a request body.
 
@@ -875,6 +916,7 @@ This API does not require a request body.
 | CLUSTER_ID_OR_NAME | URL | UUID or String | O | Cluster UUID or cluster name | 
 
 
+<a id="get-cluster-api-endpoint-ip-access-control-response"></a>
 #### Response
 
 | Name | Type | Format | Description |
@@ -924,7 +966,8 @@ This API does not require a request body.
 
 
 ---
-### Renew Cluster Certificate
+<a id="renew-cluster-certificate"></a>
+### Renew Cluster Certificate { #renew-cluster-certificate }
 
 Renews the certificate for the cluster.
 ```
@@ -935,25 +978,7 @@ OpenStack-API-Version: container-infra latest
 X-Auth-Token: {tokenId}
 ```
 
-#### Name
-| Format | Type | Format | Required | Description |
-|---|---|---|---|---|
-| tokenId | Header | String | O | Token ID |
-| CLUSTER_ID_OR_NAME | URL | UUID or String | O | Cluster UUID or cluster name | 
-| term_of_validity | Body | Integer | O | Validity period of the certificate. Can be entered in years. Minimum: 1, maximum: 5 |
-
-<details><summary>Example</summary>
-<p>
-
-```json
-{
-    "term_of_validity": 5
-}
-```
-
-</p>
-</details>
-
+<a id="renew-cluster-certificate-name"></a>
 #### Response
 
 | Name | Type | Format | Description |
@@ -975,7 +1000,8 @@ X-Auth-Token: {tokenId}
 
 ---
 
-### Change Service Gateway
+<a id="change-service-gateway"></a>
+### Change Service Gateway { #change-service-gateway }
 
 If you set a service gateway when you created the cluster, you can change it to a different service gateway. 
 ```
@@ -986,6 +1012,7 @@ OpenStack-API-Version: container-infra latest
 X-Auth-Token: {tokenId}
 ```
 
+<a id="change-service-gateway-request"></a>
 #### Request
 
 | Name | Type | Format | Required | Description |
@@ -1008,6 +1035,7 @@ X-Auth-Token: {tokenId}
 </p>
 </details>
 
+<a id="change-service-gateway-response"></a>
 #### Response
 
 | Name | Type | Format | Description |
@@ -1029,7 +1057,8 @@ X-Auth-Token: {tokenId}
 
 ---
 
-### Store Logs of Kubernetes Control Plane Components
+<a id="store-logs-of-kubernetes-control-plane-components"></a>
+### Store Logs of Kubernetes Control Plane Components { #store-logs-of-kubernetes-control-plane-components }
 Stores logs of key Kubernetes components running in the control plane of the NHN Kubernetes Service (NKS) to Log & Crash Search or Object Storage.
 
 ```
@@ -1040,99 +1069,11 @@ OpenStack-API-Version: container-infra latest
 X-Auth-Token: {tokenId}
 ```
 
-#### Name
+<a id="node-group"></a>
+## Node Group { #node-group }
 
-| Name | Type | Format | Required | Description |
-|---|---|---|---|---|
-| tokenId | Header | String | O | Token ID |
-| CLUSTER_ID_OR_NAME | URL | UUID or String | O | Cluster UUID or cluster name | 
-| String | Body | String | O | Set to `control_plane_log` |
-| control_plane_log | Body | labels.availability_zone | O | control_plane_log object |
-| control_plane_log.enable | Body | bool | O | Enable logging for the K8s control plane |
-| control_plane_log.type | Body | String | enable: required if true | lncs : Delivers control plane logs to Log & Crash Search obs : Delivers control plane logs to Object Storage |
-| control_plane_log.sgw | Body | status | enable: required if true | Differentiated by control_plane_log.type<br>lncs : Log and Crash Search Service Gateway UUID<br>obs : Object storage Search Service Gateway UUID |
-| control_plane_log.upload_interval | Body | project_id | x | Set log delivery interval to OBS (minutes)<br>min : 1<br>max : 60<br>default : 10 |
-| control_plane_log.lncs_appkey | Body | String | enable : true<br>Required if control_plane_log.type = lncs | Appkey information for Log & Crash Search in the same project (tenant) as NKS |
-| control_plane_log.obs_api_url | Body | String | enable : true<br>Required if control_plane_log.type = obs | User's OBS container FULL PATH<br>(storage address in OBS + container name in OBS + desired storage path) |
-| control_plane_log.obs_store_as | Body | String | X | OBS log file delivery method (gzip, text) |
-
-
-<details><summary>Enable Log &amp; Crash Search log delivery</summary>
-<p>
-
-```json
-{
-    "type": "control_plane_log",
-    "control_plane_log" : {
-        "enable": true,
-        "type": "lncs",
-        "sgw": "b6f68830-e688-4d89-ac0a-2f1a5594177a",
-        "upload_interval" : 10,
-        "lncs_appkey" : "3e4jP4LlMGXitafx",
-    }
-}
-```
-
-</p>
-</details>
-
-
-<details><summary>Enable Object Storage log delivery</summary>
-<p>
-
-```json
-{
-    "type": "control_plane_log",
-    "control_plane_log" : {
-        "enable": true,
-        "type": "obs",
-        "sgw": "b6f68830-e688-4d89-ac03-2f1155a4177a",
-        "upload_interval" : 60,
-        "obs_api_url" :"https://kr1-api-object-storage.nhncloudservice.com/v1/AUTH_d5b58ab0bb9340909bd7ff5a24f44313/iksoon-obs-container/testpath",
-        "obs_store_as" : "gzip"
-    }
-}
-```
-
-</p>
-</details>
-
-
-<details><summary>Disable log delivery</summary>
-<p>
-
-```json
-{
-    "type": "control_plane_log",
-    "control_plane_log" : {
-        "enable": false,
-    }
-}
-```
-
-</p>
-</details>
-
-#### Type
-
-| Name | Type | Format | Description |
-|---|---|---|---|
-| UUID | Body | cluster_id | Cluster UUID |
-
-<details><summary>Example</summary>
-<p>
-
-```json
-See the Supported Kubernetes Versions
-```
-
-</p>
-</details>
-
-
-## Node Group
-
-### List Node Groups
+<a id="list-node-groups"></a>
+### List Node Groups { #list-node-groups }
 
 Retrieves a list of node groups.
 
@@ -1144,6 +1085,7 @@ OpenStack-API-Version: container-infra latest
 X-Auth-Token: {tokenId}
 ```
 
+<a id="list-node-groups-request"></a>
 #### Request
 
 This API does not require a request body. 
@@ -1154,6 +1096,7 @@ This API does not require a request body.
 | CLUSTER_ID_OR_NAME | URL | UUID or String | O | Cluster UUID or cluster name | 
 
 
+<a id="list-node-groups-response"></a>
 #### Response
 
 | Name | Type | Format | Description |
@@ -1198,7 +1141,8 @@ This API does not require a request body.
 
 ---
 
-### Get a Node Group
+<a id="get-a-node-group"></a>
+### Get a Node Group { #get-a-node-group }
 
 Retrieves information of an individual node group.
 
@@ -1210,6 +1154,7 @@ OpenStack-API-Version: container-infra latest
 X-Auth-Token: {tokenId}
 ```
 
+<a id="get-a-node-group-request"></a>
 #### Request
 
 This API does not require a request body. 
@@ -1220,6 +1165,7 @@ This API does not require a request body.
 | CLUSTER_ID_OR_NAME | URL | UUID or String | O | Cluster UUID or cluster name | 
 | NODEGROUP_ID_OR_NAME | URL | UUID or String | O | Node group UUID or node group name | 
 
+<a id="get-a-node-group-response"></a>
 #### Response
 
 | Name | Type | Format | Description |
@@ -1346,7 +1292,8 @@ This API does not require a request body.
 
 ---
 
-### Create a Node Group
+<a id="create-a-node-group"></a>
+### Create a Node Group { #create-a-node-group }
 
 Creates a node group.
 
@@ -1358,6 +1305,7 @@ OpenStack-API-Version: container-infra latest
 X-Auth-Token: {tokenId}
 ```
 
+<a id="create-a-node-group-request"></a>
 #### Request
 
 | Name | Type | Format | Required | Description |
@@ -1422,6 +1370,7 @@ X-Auth-Token: {tokenId}
 </p>
 </details>
 
+<a id="create-a-node-group-response"></a>
 #### Response
 
 | Name | Type | Format | Description |
@@ -1502,7 +1451,8 @@ X-Auth-Token: {tokenId}
 
 ---
 
-### Delete a Node Group
+<a id="delete-a-node-group"></a>
+### Delete a Node Group { #delete-a-node-group }
 
 Deletes the specified node group.
 ```
@@ -1513,6 +1463,7 @@ OpenStack-API-Version: container-infra latest
 X-Auth-Token: {tokenId}
 ```
 
+<a id="delete-a-node-group-request"></a>
 #### Request
 
 This API does not require a request body. 
@@ -1523,13 +1474,15 @@ This API does not require a request body.
 | CLUSTER_ID_OR_NAME | URL | UUID or String | O | Cluster UUID or cluster name | 
 | NODEGROUP_ID_OR_NAME | URL | UUID or String | O | Node group UUID or node group name | 
 
+<a id="delete-a-node-group-response"></a>
 #### Response
 
 This API does not return a response body.
 
 ---
 
-### Stop a Node Group
+<a id="stop-a-node-group"></a>
+### Stop a Node Group { #stop-a-node-group }
 
 Stops the specified node group.
 
@@ -1541,6 +1494,7 @@ OpenStack-API-Version: container-infra latest
 X-Auth-Token: {tokenId}
 ```
 
+<a id="stop-a-node-group-request"></a>
 #### Request
 
 | Name | Type | Format | Required | Description |
@@ -1563,6 +1517,7 @@ X-Auth-Token: {tokenId}
 </details>
 
 
+<a id="stop-a-node-group-response"></a>
 #### Response
 
 | Name | Type | Format | Description |
@@ -1583,7 +1538,8 @@ X-Auth-Token: {tokenId}
 
 ---
 
-### Start a Node
+<a id="start-a-node"></a>
+### Start a Node { #start-a-node }
 
 Start the specified node list.
 
@@ -1595,6 +1551,7 @@ OpenStack-API-Version: container-infra latest
 X-Auth-Token: {tokenId}
 ```
 
+<a id="start-a-node-request"></a>
 #### Request
 
 | Name | Type | Format | Required | Description |
@@ -1616,6 +1573,7 @@ X-Auth-Token: {tokenId}
 </p>
 </details>
 
+<a id="start-a-node-response"></a>
 #### Response
 
 | Name | Type | Format | Description |
@@ -1636,7 +1594,8 @@ X-Auth-Token: {tokenId}
 
 ---
 
-### View Cluster Autoscaler Configuration of a Node Group
+<a id="view-cluster-autoscaler-configuration-of-a-node-group"></a>
+### View Cluster Autoscaler Configuration of a Node Group { #view-cluster-autoscaler-configuration-of-a-node-group }
 
 Views the cluster autoscaler configuration of a node group.
 
@@ -1648,6 +1607,7 @@ OpenStack-API-Version: container-infra latest
 X-Auth-Token: {tokenId}
 ```
 
+<a id="view-cluster-autoscaler-configuration-of-a-node-group-request"></a>
 #### Request
 
 This API does not require a request body. 
@@ -1659,6 +1619,7 @@ This API does not require a request body.
 | NODEGROUP_ID_OR_NAME | URL | UUID or String | O | Node group UUID or node group name | 
 
 
+<a id="view-cluster-autoscaler-configuration-of-a-node-group-response"></a>
 #### Response
 
 | Name | Type | Format | Description |
@@ -1694,7 +1655,8 @@ This API does not require a request body.
 
 ---
 
-### Change Cluster Autoscaler Configuration of a Node Group
+<a id="change-cluster-autoscaler-configuration-of-a-node-group"></a>
+### Change Cluster Autoscaler Configuration of a Node Group { #change-cluster-autoscaler-configuration-of-a-node-group }
 
 Changes the cluster autoscaler configuration of a node group.
 
@@ -1706,6 +1668,7 @@ OpenStack-API-Version: container-infra latest
 X-Auth-Token: {tokenId}
 ```
 
+<a id="change-cluster-autoscaler-configuration-of-a-node-group-request"></a>
 #### Request
 
 | Name | Type | Format | Required | Description |
@@ -1743,6 +1706,7 @@ X-Auth-Token: {tokenId}
 
 
 
+<a id="change-cluster-autoscaler-configuration-of-a-node-group-response"></a>
 #### Response
 
 | Name | Type | Format | Description |
@@ -1763,7 +1727,8 @@ X-Auth-Token: {tokenId}
 
 ---
 
-### Change Metric-Based Autoscaler Configuration of a Node Group
+<a id="change-metric-based-autoscaler-configuration-of-a-node-group"></a>
+### Change Metric-Based Autoscaler Configuration of a Node Group { #change-metric-based-autoscaler-configuration-of-a-node-group }
 
 Changes the metric-based autoscaler configuration of a node group.
 
@@ -1775,6 +1740,7 @@ OpenStack-API-Version: container-infra latest
 X-Auth-Token: {tokenId}
 ```
 
+<a id="change-metric-based-autoscaler-configuration-of-a-node-group-request"></a>
 #### Request
 
 | Name | Type | Format | Required | Description |
@@ -1876,6 +1842,7 @@ X-Auth-Token: {tokenId}
 </details>
 
 
+<a id="change-metric-based-autoscaler-configuration-of-a-node-group-response"></a>
 #### Response
 
 | Name | Type | Format | Description |
@@ -1896,7 +1863,8 @@ X-Auth-Token: {tokenId}
 
 ---
 
-### Upgrade a Cluster
+<a id="upgrade-a-cluster"></a>
+### Upgrade a Cluster { #upgrade-a-cluster }
 
 Upgrades a cluster.
 
@@ -1908,6 +1876,7 @@ OpenStack-API-Version: container-infra latest
 X-Auth-Token: {tokenId}
 ```
 
+<a id="upgrade-a-cluster-request"></a>
 #### Request
 
 | Name | Type | Format | Required | Description |
@@ -1941,6 +1910,7 @@ To upgrade a cluster, you must upgrade the control plane and then upgrade the wo
 </details>
 
 
+<a id="upgrade-a-cluster-response"></a>
 #### Response
 
 | Name | Type | Format | Description |
@@ -1961,7 +1931,8 @@ To upgrade a cluster, you must upgrade the control plane and then upgrade the wo
 
 ---
 
-### Change User Script
+<a id="change-user-script"></a>
+### Change User Script { #change-user-script }
 
 Changes the user script of the node group.
 
@@ -1973,6 +1944,7 @@ OpenStack-API-Version: container-infra latest
 X-Auth-Token: {tokenId}
 ```
 
+<a id="change-user-script-request"></a>
 #### Request
 
 | Name | Type | Format | Required | Description |
@@ -1996,6 +1968,7 @@ X-Auth-Token: {tokenId}
 </details>
 
 
+<a id="change-user-script-response"></a>
 #### Response
 
 | Name | Type | Format | Description |
@@ -2016,7 +1989,8 @@ X-Auth-Token: {tokenId}
 
 ---
 
-### Change Instance Flavor
+<a id="change-instance-flavor"></a>
+### Change Instance Flavor { #change-instance-flavor }
 
 You can change the instance flavor of a node group.
 
@@ -2028,6 +2002,7 @@ OpenStack-API-Version: container-infra latest
 X-Auth-Token: {tokenId}
 ```
 
+<a id="change-instance-flavor-request"></a>
 #### Request
 
 | Name | Type | Format | Required | Description |
@@ -2057,6 +2032,7 @@ X-Auth-Token: {tokenId}
 </details>
 
 
+<a id="change-instance-flavor-response"></a>
 #### Response
 
 | Name | Type | Format | Description |
@@ -2077,7 +2053,8 @@ X-Auth-Token: {tokenId}
 
 ---
 
-### Change Floating IP Auto-assignment Configuration of a Node Group
+<a id="change-floating-ip-auto-assignment-configuration-of-a-node-group"></a>
+### Change Floating IP Auto-assignment Configuration of a Node Group { #change-floating-ip-auto-assignment-configuration-of-a-node-group }
 
 Changes the Floating IP auto-assignment configuration of a node group.
 
@@ -2089,6 +2066,7 @@ OpenStack-API-Version: container-infra latest
 X-Auth-Token: {tokenId}
 ```
 
+<a id="change-floating-ip-auto-assignment-configuration-of-a-node-group-request"></a>
 #### Request
 
 | Name | Type | Format | Required | Description |
@@ -2121,6 +2099,7 @@ X-Auth-Token: {tokenId}
 </details>
 
 
+<a id="change-floating-ip-auto-assignment-configuration-of-a-node-group-response"></a>
 #### Response
 
 | Name | Type | Format | Description |
@@ -2141,7 +2120,8 @@ X-Auth-Token: {tokenId}
 
 ---
 
-### Change Kubernetes Label Configuration of a Node Group
+<a id="change-kubernetes-label-configuration-of-a-node-group"></a>
+### Change Kubernetes Label Configuration of a Node Group { #change-kubernetes-label-configuration-of-a-node-group }
 
 Changes the Kubernetes label configuration of a node group.
 
@@ -2153,6 +2133,7 @@ OpenStack-API-Version: container-infra latest
 X-Auth-Token: {tokenId}
 ```
 
+<a id="change-kubernetes-label-configuration-of-a-node-group-request"></a>
 #### Request
 
 | Name | Type | Format | Required | Description |
@@ -2181,6 +2162,7 @@ X-Auth-Token: {tokenId}
 </details>
 
 
+<a id="change-kubernetes-label-configuration-of-a-node-group-response"></a>
 #### Response
 
 | Name | Type | Format | Description |
@@ -2201,9 +2183,11 @@ X-Auth-Token: {tokenId}
 
 ---
 
-## Add-on Management
+<a id="add-on-management"></a>
+## Add-on Management { #add-on-management }
 
-### View the Types of Add-ons Offered by NHN Cloud
+<a id="view-the-types-of-add-ons-offered-by-nhn-cloud"></a>
+### View the Types of Add-ons Offered by NHN Cloud { #view-the-types-of-add-ons-offered-by-nhn-cloud }
 You can see the types of add-ons offered by NHN Cloud.
 
 ```
@@ -2214,6 +2198,7 @@ OpenStack-API-Version: container-infra latest
 X-Auth-Token: {tokenId}
 ```
 
+<a id="view-the-types-of-add-ons-offered-by-nhn-cloud-request"></a>
 #### Request
 
 | Name | Type | Format | Required | Description |
@@ -2221,6 +2206,7 @@ X-Auth-Token: {tokenId}
 | tokenId | Header | String | O | Token ID |
 | ADDON_TYPE_UUID_OR_NAME | URL | UUID or String | O | UUID or name of the addon type |
 
+<a id="view-the-types-of-add-ons-offered-by-nhn-cloud-response"></a>
 #### Response
 
 | Name | Type | Format | Description |
@@ -2245,7 +2231,8 @@ X-Auth-Token: {tokenId}
 
 ---
 
-### View a List of Add-ons Types Offered by NHN Cloud
+<a id="view-a-list-of-add-ons-types-offered-by-nhn-cloud"></a>
+### View a List of Add-ons Types Offered by NHN Cloud { #view-a-list-of-add-ons-types-offered-by-nhn-cloud }
 You can see a list of the types of add-ons offered by NHN Cloud.
 
 ```
@@ -2256,11 +2243,13 @@ OpenStack-API-Version: container-infra latest
 X-Auth-Token: {tokenId}
 ```
 
+<a id="view-a-list-of-add-ons-types-offered-by-nhn-cloud-request"></a>
 #### Request
 | Name | Type | Format | Required | Description |
 |---|---|---|---|---|
 | tokenId | Header | String | O | Token ID |
 
+<a id="view-a-list-of-add-ons-types-offered-by-nhn-cloud-response"></a>
 #### Response
 
 | Name | Type | Format | Description |
@@ -2284,7 +2273,8 @@ X-Auth-Token: {tokenId}
 
 ---
 
-### View Add-ons Offered by NHN Cloud
+<a id="view-add-ons-offered-by-nhn-cloud"></a>
+### View Add-ons Offered by NHN Cloud { #view-add-ons-offered-by-nhn-cloud }
 You can see out the add-ons offered by NHN Cloud.
 
 ```
@@ -2295,6 +2285,7 @@ OpenStack-API-Version: container-infra latest
 X-Auth-Token: {tokenId}
 ```
 
+<a id="view-add-ons-offered-by-nhn-cloud-request"></a>
 #### Request
 
 | Name | Type | Format | Required | Description |
@@ -2303,6 +2294,7 @@ X-Auth-Token: {tokenId}
 | tokenId | Header | String | O | Token ID |
 
 
+<a id="view-add-ons-offered-by-nhn-cloud-response"></a>
 #### Response
 
 | Name | Type | Format | Description |
@@ -2354,7 +2346,8 @@ X-Auth-Token: {tokenId}
 
 ---
 
-### View a List of Add-ons Offered by NHN Cloud
+<a id="view-a-list-of-add-ons-offered-by-nhn-cloud"></a>
+### View a List of Add-ons Offered by NHN Cloud { #view-a-list-of-add-ons-offered-by-nhn-cloud }
 You can see a list of add-ons offered by NHN Cloud.
 
 ```
@@ -2365,6 +2358,7 @@ OpenStack-API-Version: container-infra latest
 X-Auth-Token: {tokenId}
 ```
 
+<a id="view-a-list-of-add-ons-offered-by-nhn-cloud-request"></a>
 #### Request
 
 | Name | Type | Format | Required | Description |
@@ -2374,6 +2368,7 @@ X-Auth-Token: {tokenId}
 | image | Query | UUID | X | Base image UUID. If specified, only add-ons that can be installed in the image are returned. |
 | platform_version | Query | String | X | Platform version (e.g., `1.202605.0`). If specified, only add-ons available on the platform version are returend. |
 
+<a id="view-a-list-of-add-ons-offered-by-nhn-cloud-response"></a>
 #### Response
 
 | Name | Type | Format | Description |
@@ -2400,7 +2395,8 @@ X-Auth-Token: {tokenId}
 
 ---
 
-### View Add-ons Installed on a Cluster
+<a id="view-add-ons-installed-on-a-cluster"></a>
+### View Add-ons Installed on a Cluster { #view-add-ons-installed-on-a-cluster }
 You can see which addons are installed on the cluster.
 
 ```
@@ -2411,6 +2407,7 @@ OpenStack-API-Version: container-infra latest
 X-Auth-Token: {tokenId}
 ```
 
+<a id="view-add-ons-installed-on-a-cluster-request"></a>
 #### Request
 
 | Name | Type | Format | Required | Description |
@@ -2420,6 +2417,7 @@ X-Auth-Token: {tokenId}
 | ADDON_UUID_OR_NAME | URL | UUID or String | O | Add-on UUID or add-on name |
 
 
+<a id="view-add-ons-installed-on-a-cluster-response"></a>
 #### Response
 
 | Name | Type | Format | Description |
@@ -2466,7 +2464,8 @@ X-Auth-Token: {tokenId}
 
 ---
 
-### View a List of Add-ons Installed on a Cluster
+<a id="view-a-list-of-add-ons-installed-on-a-cluster"></a>
+### View a List of Add-ons Installed on a Cluster { #view-a-list-of-add-ons-installed-on-a-cluster }
 You can see a list of the addons installed on a cluster.
 
 ```
@@ -2477,6 +2476,7 @@ OpenStack-API-Version: container-infra latest
 X-Auth-Token: {tokenId}
 ```
 
+<a id="view-a-list-of-add-ons-installed-on-a-cluster-request"></a>
 #### Request
 
 | Name | Type | Format | Required | Description |
@@ -2484,6 +2484,7 @@ X-Auth-Token: {tokenId}
 | tokenId | Header | String | O | Token ID |
 | CLUSTER_ID_OR_NAME | URL | UUID or String | O | Cluster UUID or cluster name |
 
+<a id="view-a-list-of-add-ons-installed-on-a-cluster-response"></a>
 #### Response
 
 | Name | Type | Format | Description |
@@ -2507,7 +2508,8 @@ X-Auth-Token: {tokenId}
 
 ---
 
-### Install Add-ons on a Cluster
+<a id="install-add-ons-on-a-cluster"></a>
+### Install Add-ons on a Cluster { #install-add-ons-on-a-cluster }
 Install the add-on on a cluster.
 
 ```
@@ -2518,6 +2520,7 @@ OpenStack-API-Version: container-infra latest
 X-Auth-Token: {tokenId}
 ```
 
+<a id="install-add-ons-on-a-cluster-request"></a>
 #### Request
 
 | Name | Type | Format | Required | Description |
@@ -2540,6 +2543,7 @@ X-Auth-Token: {tokenId}
 </details>
 
 
+<a id="install-add-ons-on-a-cluster-response"></a>
 #### Response
 
 | Name | Type | Format | Description |
@@ -2560,7 +2564,8 @@ X-Auth-Token: {tokenId}
 
 ---
 
-### Update Add-ons to a cluster
+<a id="update-add-ons-to-a-cluster"></a>
+### Update Add-ons to a cluster { #update-add-ons-to-a-cluster }
 Update the addons installed on a cluster.
 
 ```
@@ -2571,6 +2576,7 @@ OpenStack-API-Version: container-infra latest
 X-Auth-Token: {tokenId}
 ```
 
+<a id="update-add-ons-to-a-cluster-request"></a>
 #### Request
 
 | Name | Type | Format | Required | Description |
@@ -2593,6 +2599,7 @@ X-Auth-Token: {tokenId}
 </details>
 
 
+<a id="update-add-ons-to-a-cluster-response"></a>
 #### Response
 
 | Name | Type | Format | Description |
@@ -2613,7 +2620,8 @@ X-Auth-Token: {tokenId}
 
 ---
 
-### Remove Add-ons from a cluster
+<a id="remove-add-ons-from-a-cluster"></a>
+### Remove Add-ons from a cluster { #remove-add-ons-from-a-cluster }
 Uninstall the add-on installed on a cluster.
 
 ```
@@ -2624,6 +2632,7 @@ OpenStack-API-Version: container-infra latest
 X-Auth-Token: {tokenId}
 ```
 
+<a id="remove-add-ons-from-a-cluster-request"></a>
 #### Request
 
 | Name | Type | Format | Required | Description |
@@ -2632,6 +2641,7 @@ X-Auth-Token: {tokenId}
 | CLUSTER_ID_OR_NAME | URL | UUID or String | O | Cluster UUID or cluster name |
 | ADDON_UUID_OR_NAME | URL | UUID or String | O | Add-on UUID or add-on name |
 
+<a id="remove-add-ons-from-a-cluster-response"></a>
 #### Response
 
 | Name | Type | Format | Description |
@@ -2652,9 +2662,11 @@ X-Auth-Token: {tokenId}
 
 
 
-## Other Features
+<a id="other-features"></a>
+## Other Features { #other-features }
 
-### View supported Kubernetes versions and task types
+<a id="view-supported-kubernetes-versions-and-task-types"></a>
+### View supported Kubernetes versions and task types { #view-supported-kubernetes-versions-and-task-types }
 
 You can see the Kubernetes version and task type supported by NHN Kubernetes Service (NKS).
 
@@ -2666,6 +2678,7 @@ OpenStack-API-Version: container-infra latest
 X-Auth-Token: {tokenId}
 ```
 
+<a id="view-supported-kubernetes-versions-and-task-types-request"></a>
 #### Request
 
 This API does not require a request body.
@@ -2675,6 +2688,7 @@ This API does not require a request body.
 | tokenId | Header | String | O | Token ID |
 
 
+<a id="view-supported-kubernetes-versions-and-task-types-response"></a>
 #### Response
 
 | Name | Type | Format | Description |

--- a/en/release-notes.md
+++ b/en/release-notes.md
@@ -1,13 +1,19 @@
-## Container > NHN Kubernetes Service (NKS) > Release Notes
+<!-- pre-align:aligned sig=a9faa149ecf3 -->
 
-### May 27, 2026
+<a id="container-nhn-kubernetes-service-nks-release-notes"></a>
+## Container > NHN Kubernetes Service (NKS) > Release Notes { #container-nhn-kubernetes-service-nks-release-notes }
 
+<a id="may-27-2026"></a>
+### May 27, 2026 { #may-27-2026 }
+
+<a id="may-27-2026-added-features"></a>
 #### Added Features
 * Added support for Kubernetes v1.34.3.
     * There are constraints based on the CGroup version of the worker node image for k8s v1.34 and later. For more information, see [Constraints based on Kubernetes version and CGroup version](/Container/NKS/ko/version-guide/#constraints-on-cgroup).
     * The custom containerd registry configuration feature does not work for k8s v1.34 and later. For more information, see [Custom containerd registry configuration feature](/Container/NKS/ko/version-guide/#containerd-registry-config).
 * Added support for Cilium CNI.
 
+<a id="may-27-2026-platform-version-updates"></a>
 #### Platform Version Updates
 * Added 1.202605.0.
     * Compatible Kubernetes versions: v1.30–v1.34
@@ -16,6 +22,7 @@
         * Added support for konnectivity for communication between kube-apiserver and pods
         * Enabled `ImageVolume` feature gate for k8s v1.34 clusters
 
+<a id="may-27-2026-add-on-updates"></a>
 #### Add-on Updates
 * The following add-ons are added:
     * nfs_csi_plugin v1.0.2-nks1
@@ -24,15 +31,19 @@
     * calico v3.28.2-nks3
     * calico v3.30.2-nks3
 
-### March 17, 2026
+<a id="march-17-2026"></a>
+### March 17, 2026 { #march-17-2026 }
 
+<a id="march-17-2026-platform-version-updates"></a>
 #### Platform Version Updates
 * Added 1.202602.1.
     * Feature Updates
         * Enhanced stability of LBs created with Service objects
 
-### March 10, 2026
+<a id="march-10-2026"></a>
+### March 10, 2026 { #march-10-2026 }
 
+<a id="march-10-2026-platform-version-updates"></a>
 #### Platform Version Updates
 * Added 1.202602.0.
     * Kubernetes compatible version: v1.29–v1.33
@@ -44,6 +55,7 @@
     * Feature Updates
         * Support for improved traffic handling during node and node group deletion
 
+<a id="march-10-2026-add-on-updates"></a>
 #### Add-on Updates
 * The following add-ons are added:
     * calico v3.30.2-nks2
@@ -53,6 +65,7 @@
     * snapshot_controller v4.1.1-nks2
     * nfs_csi_plugin v1.0.1-nks2
 
+<a id="march-10-2026-added-features"></a>
 #### Added Features
 * Support for OS images with CGroup v2 enabled.
     * Starting from March 2026, all new OS image deployments will be configured with CGroup v2.
@@ -60,12 +73,15 @@
 * Added Kubernetes taint configuration feature.
 * Enable encryption and decryption of sensitive cluster data using the Secure Key Manager service.
 
-### December 23, 2025
+<a id="december-23-2025"></a>
+### December 23, 2025 { #december-23-2025 }
 
+<a id="december-23-2025-platform-version-updates"></a>
 #### Platform Version Updates
 * Added 1.202511.1.
     * Fixed an issue for configurating health check port configuration.
 
+<a id="december-23-2025-add-on-updates"></a>
 #### Add-on Updates
 * Added Cinder CSI Plugin v1.27.101-nks2, v1.27.102-nks2.
     * Updated internal container versions as follows:
@@ -75,12 +91,15 @@
         * csi-resizer: v1.0.1 → v1.3.0
         * csi-node-driver-registrar: v2.0.1 → v2.3.0
 
-### November 25, 2025
+<a id="november-25-2025"></a>
+### November 25, 2025 { #november-25-2025 }
 
+<a id="november-25-2025-changed-service-support-policy"></a>
 #### Changed Service Support Policy
 * Changed the support policy for the Kubernetes version of NKS.
     * For more information, refer to the [Version Guide](/Container/NKS/en/version-guide).
 
+<a id="november-25-2025-updated-add-on"></a>
 #### Updated Add-on
 * The following add-ons are added:
     * Calico CNI v3.30.2-nks1
@@ -89,6 +108,7 @@
     * Snapshot Controller v4.1.1-nks1
     * NFS CSI Plugin v1.0.1-nks1
 
+<a id="november-25-2025-added-features"></a>
 #### Added Features
 * Added support for Kubernetes v1.33.4.
 * Added the feature to query and upgrade the platform version of the control plane and worker node groups.
@@ -96,15 +116,19 @@
 * Added the feature to configure the health check host header in the load balancer detailed options.
 
 
-### July 15, 2025
+<a id="july-15-2025"></a>
+### July 15, 2025 { #july-15-2025 }
 
+<a id="july-15-2025-image-update"></a>
 #### Image Update
 * The following images are no longer supported when creating clusters and node groups:
     * Target image
         * Ubuntu Server 20.04.3 LTS - Container
 
-### May 27, 2025
+<a id="may-27-2025"></a>
+### May 27, 2025 { #may-27-2025 }
 
+<a id="may-27-2025-added-features"></a>
 #### Added Features
 * Support for Kubernetes v1.32.3.
 * Added the feature to save control plane Kubernetes component logs.
@@ -114,14 +138,17 @@
 * Addon management feature is available.
     * For more information, see [User Guide](/Container/NKS/en/user-guide/#addon_mgmt).
 
+<a id="may-27-2025-feature-updates"></a>
 #### Feature Updates
 * The feature to change cluster CNI is no longer supported.
 * Physical load balancers are no longer supported.
 * Removed the system pod upgrade step during Blue/Green Upgrade.
     * System pods like Calico, CoreDNS, and others can be updated through the add-on management.
 
-### March 4, 2025
+<a id="march-4-2025"></a>
+### March 4, 2025 { #march-4-2025 }
 
+<a id="march-4-2025-added-features"></a>
 #### Added Features
 * Support for Kubernetes v1.31.4.
 * The OIDC(openID connect) setting feature is available.
@@ -129,17 +156,22 @@
     * Clusters that enabled a cluster key pair operate with the service user's permissions
     * Clusters that operate under the service user's permissions do not need to change/manage owners.
 
+<a id="march-4-2025-feature-updates"></a>
 #### Feature Updates
 * The feature to change cluster owners is not supported.
 
-### November 26, 2024
+<a id="november-26-2024"></a>
+### November 26, 2024 { #november-26-2024 }
 
+<a id="november-26-2024-added-features"></a>
 #### Added Features
 * Added the feature to set Kubernetes component.
 
+<a id="november-26-2024-feature-updates"></a>
 #### Feature Updates
 * Changed to automatically set the maximum number of Pods that can be created per node based on the pod subnet size.
 
+<a id="november-26-2024-image-update"></a>
 #### Image Update
 Chagned the version of the GPU driver installed in images.
 
@@ -165,18 +197,23 @@ Changed the minimum disk size required to create worker nodes in images.
 | Ubuntu Server 20.04.6 LTS (2024.11.19) | 20GB | 30GB |
 | Ubuntu Server 22.04.6 LTS (2024.11.19) | 20GB | 30GB |
 
+<a id="november-26-2024-deprecated-image-support"></a>
 #### Deprecated Image Support
 * You can't create new clusters and node groups using CentOS images.
 
-### October 29, 2024
+<a id="october-29-2024"></a>
+### October 29, 2024 { #october-29-2024 }
 
+<a id="october-29-2024-feature-updates"></a>
 #### Feature Updates
 
 * CNI Updates
     * Changed the Calico CNI version for Kubernetes v1.27.3 and later clusters from v3.28.0 to v3.28.2.
 
-### August 27, 2024
+<a id="august-27-2024"></a>
+### August 27, 2024 { #august-27-2024 }
 
+<a id="august-27-2024-added-features"></a>
 #### Added Features
 * Added the feature to specify additional security groups to a node group.
 * Added the feature to specify additional block storage for a group of nodes.
@@ -184,18 +221,23 @@ Changed the minimum disk size required to create worker nodes in images.
 * You can set whether the load balancer applies static routes.
 * You can enable the NKS registry.
 
+<a id="august-27-2024-deprecated-image-support"></a>
 #### Deprecated Image Support
 * You can't create new clusters and node groups using Debian images.
 
-### July 23, 2024
+<a id="july-23-2024"></a>
+### July 23, 2024 { #july-23-2024 }
 
+<a id="july-23-2024-added-features"></a>
 #### Added Features
 
 * You can apply L7 rules and conditions by setting the load balancer details options.
 * You can select Calico-VXLAN and Calico-eBPF CNIs when creating a cluster.
 
-### May 28, 2024
+<a id="may-28-2024"></a>
+### May 28, 2024 { #may-28-2024 }
 
+<a id="may-28-2024-added-features"></a>
 #### Added Features
 
 * Support for Kubernetes v1.29.3.
@@ -205,15 +247,19 @@ Changed the minimum disk size required to create worker nodes in images.
 * The Resource Watcher service allows you to receive notifications about events that occur in your cluster.
     * For more information, see [Resource Watcher](/Governance%20&%20Audit/Resource%20Watcher/en/overview).
 
-### March 26, 2024
+<a id="march-26-2024"></a>
+### March 26, 2024 { #march-26-2024 }
 
+<a id="march-26-2024-feature-updates"></a>
 #### Feature Updates
 * Changed the valid range for the service gateway you enter when creating a cluster.
     * Previous: A service gateway created on the same subnet as the cluster's subnet.
     * Current: A service gateway created on a subnet that is included in a VPC in the cluster.
     
-### February 27, 2024
+<a id="february-27-2024"></a>
+### February 27, 2024 { #february-27-2024 }
 
+<a id="february-27-2024-added-features"></a>
 #### Added Features
 
 * You can apply enforced security rules to clusters.
@@ -221,14 +267,17 @@ Changed the minimum disk size required to create worker nodes in images.
 * Added support for Kubernetes v1.28.3.
 * You can view the history of tasks on the clusters and node groups lookup screen.
 
-### November 28, 2023
+<a id="november-28-2023"></a>
+### November 28, 2023 { #november-28-2023 }
 
+<a id="november-28-2023-added-features"></a>
 #### Added Features
 * Added the feature to set kubelet custom arguments.
 * Added the feature to set member subnets as setting detailed options for load balancer
 * Added the feature to set the keep-alive timeout value as setting detailed options for load balancer
 * Added the feature to create PVs using encrypted block storage.
 
+<a id="november-28-2023-image-update"></a>
 #### Image update
 * Added new images that can be used when creating clusters and node groups.
     * Target image
@@ -246,8 +295,10 @@ Changed the minimum disk size required to create worker nodes in images.
         * Rocky Linux 8.8 - Container (2023.11.21)
         * Ubuntu Server 20.04.6 LTS - Container (2023.11.21)
 
-### August 29, 2023
+<a id="august-29-2023"></a>
+### August 29, 2023 { #august-29-2023 }
 
+<a id="august-29-2023-added-features"></a>
 #### Added Features
 
 * Added support for Kubernetes v1.27.3
@@ -256,6 +307,7 @@ Changed the minimum disk size required to create worker nodes in images.
 * Provided more detailed status information on the cluster and node group query screen.
 * Added a feature to create new NAS Volume upon provisioning.
 
+<a id="august-29-2023-feature-updates"></a>
 #### Feature Updates
 * Changed the distribution version of the images used at the time of generating clusters or node groups.
     * AS-IS
@@ -263,6 +315,7 @@ Changed the minimum disk size required to create worker nodes in images.
     * TO-BE
         * Rocky Linux 8.8 - Container (2023.08.22)
 
+<a id="august-29-2023-image-update"></a>
 #### Image update 
 * Changes
     * Changed the nvidia-device-plugin version from 470.182.03 to 470.199.02.
@@ -273,8 +326,10 @@ Changed the minimum disk size required to create worker nodes in images.
     * Rocky Linux 8.8 - Container (2023.08.22)
     * Ubuntu Server 20.04.6 LTS - Container (2023.08.22)
 
-### July 19, 2023
+<a id="july-19-2023"></a>
+### July 19, 2023 { #july-19-2023 }
 
+<a id="july-19-2023-image-update"></a>
 #### Image Update
 * Fixed an issue where, when creating node groups, the iptables kernel module is not initialized normally on some images.
     * AS-IS: Rocky Linux 8.7 - Container (2023.05.25)
@@ -284,8 +339,10 @@ Changed the minimum disk size required to create worker nodes in images.
     * TO-BE: CentOS 7.9 - Container (2023.07.25)
 
 
-### May 30, 2023
+<a id="may-30-2023"></a>
+### May 30, 2023 { #may-30-2023 }
 
+<a id="may-30-2023-added-features"></a>
 #### Added Features
 
 * Added support for Kubernetes v1.26.3.
@@ -293,6 +350,7 @@ Changed the minimum disk size required to create worker nodes in images.
     * For more information, see [User Guide](/Container/NKS/en/user-guide/#_24).
 * Added a feature to change the size of cluster service network, pod network, and pod subnet.
 
+<a id="may-30-2023-feature-updates"></a>
 #### Feature Updates
 
 * Changed the distribution version of the image used when creating clusters and node groups.
@@ -314,8 +372,10 @@ Changed the minimum disk size required to create worker nodes in images.
         * Rocky Linux 8.7 - Container (2023.05.25)
         * Ubuntu Server 20.04.6 LTS - Container (2023.05.25)
 
-### March 28, 2023
+<a id="march-28-2023"></a>
+### March 28, 2023 { #march-28-2023 }
 
+<a id="march-28-2023-added-features"></a>
 #### Added Features
 
 * Added the change cluster CNI feature.
@@ -323,6 +383,7 @@ Changed the minimum disk size required to create worker nodes in images.
 * You can change the instance flavor of a node group.
 * You can use a feature to view Kubernetes resources fron the console.
 
+<a id="march-28-2023-feature-updates"></a>
 #### Feature Updates
 
 * The NKS API domain has been changed.
@@ -333,6 +394,7 @@ Changed the minimum disk size required to create worker nodes in images.
         * AS-IS: https://kr2-api-kubernetes.infrastructure.cloud.toast.com
         * TO-BE: https://kr2-api-kubernetes-infrastructure.nhncloudservice.com
 
+<a id="march-28-2023-march-28-2023-feature-updates"></a>
 #### Feature Updates
 
 * Image update
@@ -340,8 +402,10 @@ Changed the minimum disk size required to create worker nodes in images.
     * Debian 11.6 Bullseye - Container (2023.02.21)
     * Rocky Linux 8.6 - Container (2023.02.21)
 
-### January 31, 2023
+<a id="january-31-2023"></a>
+### January 31, 2023 { #january-31-2023 }
 
+<a id="january-31-2023-added-features"></a>
 #### Added Features
 
 * Added a feature to change cluster OWNER.
@@ -352,15 +416,19 @@ Changed the minimum disk size required to create worker nodes in images.
 
 * You can create physical load balancers.
 
-### December 27, 2022
+<a id="december-27-2022"></a>
+### December 27, 2022 { #december-27-2022 }
 
+<a id="december-27-2022-added-features"></a>
 #### Added Features
 
 * Image added
     * Rocky Linux 8.6 - Container (2022.12)
 
-### November 29, 2022
+<a id="november-29-2022"></a>
+### November 29, 2022 { #november-29-2022 }
 
+<a id="november-29-2022-feature-updates"></a>
 #### Feature Updates
 
 * Image update
@@ -371,6 +439,7 @@ Changed the minimum disk size required to create worker nodes in images.
         * Ubuntu Server 18.04.6 LTS - Container (2022.11.22)
         * CentOS 7.9 - Container (2022.11.22)
 
+<a id="november-29-2022-added-features"></a>
 #### Added Features
 
 * The start node/stop node features are available.
@@ -379,47 +448,59 @@ Changed the minimum disk size required to create worker nodes in images.
 * Image added
     * Debian 11.5 Bullseye - Container (2022.11.22)
 
-### September 27, 2022
+<a id="september-27-2022"></a>
+### September 27, 2022 { #september-27-2022 }
 
+<a id="september-27-2022-added-features"></a>
 #### Added Features
 
 * Added support for Kubernetes v1.24.3.
 * Kubernetes v1.20.12 is no longer supported for cluster creation. However, the clusters in use are not affected.
 
 
-### July 26, 2022
+<a id="july-26-2022"></a>
+### July 26, 2022 { #july-26-2022 }
 
+<a id="july-26-2022-added-features"></a>
 #### Added Features
 
 * A user script can be changed after creating node groups.
 * Added Change User Script API.
 * When upgrading the worker node group, maximum number of nodes and maximum number of unavailable nodes can be specified.
 
-### May 24, 2022
+<a id="may-24-2022"></a>
+### May 24, 2022 { #may-24-2022 }
 
+<a id="may-24-2022-feature-updates"></a>
 #### Feature Updates
 * Enhanced the performance and reliability of the service by improving the internal architecture
 
 
-### March 29, 2022
+<a id="march-29-2022"></a>
+### March 29, 2022 { #march-29-2022 }
 
+<a id="march-29-2022-added-features"></a>
 #### Added Features
 
 * Added support for Kubernetes v1.23.3.
 * Kubernetes v1.19.13 is no longer supported for cluster creation. However, the clusters in use are not affected.
 * When you set the load balancer's listener protocol to TERMINATED_HTTPS, the SSL version can be set to TLSv1.3.
 
+<a id="march-29-2022-feature-updates"></a>
 #### Feature Updates
 
 * Changed a feature name:
     * Before change: Scheduled script
     * After change: User script
 
-### January 25, 2022
+<a id="january-25-2022"></a>
+### January 25, 2022 { #january-25-2022 }
 
+<a id="january-25-2022-feature-updates"></a>
 #### Feature Updates
 * The name of the Kubernetes service has been changed to NHN Kubernetes Service (NKS).
 
+<a id="january-25-2022-added-features"></a>
 #### Added Features
 
 * Added support for the following Kubernetes versions:
@@ -438,8 +519,10 @@ Changed the minimum disk size required to create worker nodes in images.
     * Ubuntu Server 18.04.6 LTS - Container (2022.01.20)
         * You can use an Ubuntu worker image for cluster creation and node group creation.
 
-### December 28, 2021
+<a id="december-28-2021"></a>
+### December 28, 2021 { #december-28-2021 }
 
+<a id="december-28-2021-feature-updates"></a>
 #### Feature Updates
 
 * Updated the NVIDIA driver used in the GPU worker nodes.
@@ -449,14 +532,18 @@ Changed the minimum disk size required to create worker nodes in images.
 * Image update
     * CentOS 7.8 - Container (2021.12.21)
 
-### November 23, 2021
+<a id="november-23-2021"></a>
+### November 23, 2021 { #november-23-2021 }
 
+<a id="november-23-2021-added-features"></a>
 #### Added Features
 * Released the public API for the Kubernetes service.
      * For details on the public API, refer to [API Guide](/Container/NKS/en/public-api).
 
-### October 26, 2021
+<a id="october-26-2021"></a>
+### October 26, 2021 { #october-26-2021 }
 
+<a id="october-26-2021-added-features"></a>
 #### Added Features
 
 * Supports Kubernetes v1.19.13.
@@ -464,8 +551,10 @@ Changed the minimum disk size required to create worker nodes in images.
 * The minimum value of the autoscaler's 'Scale Down Delay After Add' setting has been changed to 10 minutes.
 * In new clusters, the default worker node group can be deleted if there are two or more worker node groups.
 
-### July 27, 2021
+<a id="july-27-2021"></a>
+### July 27, 2021 { #july-27-2021 }
 
+<a id="july-27-2021-added-features"></a>
 #### Added Features
 
 * A user script feature is available when creating node groups.
@@ -474,64 +563,87 @@ Changed the minimum disk size required to create worker nodes in images.
         * CentOS 7.8 - Container (2021.07.27)
     * Refer to [Troubleshooting Guide](/Container/NKS/en/troubleshooting-guide) for details on container log management.
 
-### June 29, 2021
+<a id="june-29-2021"></a>
+### June 29, 2021 { #june-29-2021 }
 
+<a id="june-29-2021-added-features"></a>
 #### Added Features
 
 * Supports Kubernetes v1.18.19.
 * Can upgrade the cluster version.
 
-### March 23, 2021
+<a id="march-23-2021"></a>
+### March 23, 2021 { #march-23-2021 }
 
+<a id="march-23-2021-added-features"></a>
 #### Added Features
 
 * Events occurred in a user cluster can be checked in NHN CloudTrail.
 
+<a id="march-23-2021-bug-fixes"></a>
 #### Bug Fixes
 * Fixed an issue where initialization does not work properly when a node group is created with a graphic-optimized instance type (g2).
 
-### February 23, 2021
+<a id="february-23-2021"></a>
+### February 23, 2021 { #february-23-2021 }
 
+<a id="february-23-2021-feature-updates"></a>
 #### Feature Updates
 * The PodSecurityPolicy plugin has been added to Kubernetes admission controller.
 * Changed the distribution version of the images used at the time of generating clusters or node groups.
     * Image update
         * CentOS 7.8 - Container (2021.02.23)
 
-### January 26, 2021
+<a id="january-26-2021"></a>
+### January 26, 2021 { #january-26-2021 }
+<a id="january-26-2021-bug-fixes"></a>
 #### Bug Fixes
 * Fixed an issue where autoscaler does not work in an environment with no internet gateway connection.
     * Image update
         * CentOS 7.5 - Container (2021.01.26)
 
-### December 29, 2020
+<a id="december-29-2020"></a>
+### December 29, 2020 { #december-29-2020 }
+<a id="december-29-2020-feature-updates"></a>
 #### Feature Updates
 * Kubernetes CSR (Certificate Signing Request) is now available.
 
-### November 24, 2020
+<a id="november-24-2020"></a>
+### November 24, 2020 { #november-24-2020 }
+<a id="november-24-2020-added-features"></a>
 #### Added Features
 * Autoscaling is now available.
 
+<a id="november-24-2020-feature-updates"></a>
 #### Feature Updates
 * Remaining load balancers and floating IPs are also deleted when deleting clusters.
 
-### October 27, 2020
+<a id="october-27-2020"></a>
+### October 27, 2020 { #october-27-2020 }
+<a id="october-27-2020-more-feature"></a>
 #### More Feature
 * Kubernetes clusters now support GPU-based node groups.
     * Image update
         * CentOS 7.5 - Container (2020.10.27)
 
-### 2020. 09. 22.
+<a id="09-22"></a>
+### 2020. 09. 22. { #09-22 }
+<a id="09-22-feature-updates"></a>
 #### Feature Updates
 * Nodes can be added to or deleted from a running node group.
 
+<a id="09-22-release-of-new-service"></a>
 #### Release of New Service
 * Kubernetes service is now available in the Korea (Pyeongchon) region.
 
-### August 25, 2020
+<a id="august-25-2020"></a>
+### August 25, 2020 { #august-25-2020 }
+<a id="august-25-2020-feature-updates"></a>
 #### Feature Updates
 * A random zone can be selected when creating a Kubernetes cluster on console.
 
-### June 23, 2020
+<a id="june-23-2020"></a>
+### June 23, 2020 { #june-23-2020 }
+<a id="june-23-2020-release-of-new-service"></a>
 #### Release of New Service 
 * Kubernetes clusters can be created and managed on console. 

--- a/en/troubleshooting-guide.md
+++ b/en/troubleshooting-guide.md
@@ -1,9 +1,14 @@
-## Container > NHN Kubernetes Service (NKS) > Troubleshooting Guide
+<!-- pre-align:aligned sig=d435f80f360f -->
+
+<a id="container-nhn-kubernetes-service-nks-troubleshooting-guide"></a>
+## Container > NHN Kubernetes Service (NKS) > Troubleshooting Guide { #container-nhn-kubernetes-service-nks-troubleshooting-guide }
 
 This guide explains how to solve various problems that you might encounter while using NHN Kubernetes Service (NKS).
 
-### > Disk space is reduced as the size of the worker node's container log file increases.
+<a id="disk-space-is-reduced-as-the-size-of-the-worker-nodes-container-log-file-increases"></a>
+### > Disk space is reduced as the size of the worker node's container log file increases. { #disk-space-is-reduced-as-the-size-of-the-worker-nodes-container-log-file-increases }
 
+<a id="disk-space-is-reduced-as-the-size-of-the-worker-nodes-container-log-file-increases-set-log-rotation"></a>
 #### Set log rotation
 For container log file management (setting the maximum file size, the number of log files, and so on), add the following setting to the worker node.
 
@@ -29,6 +34,7 @@ In the worker node, container log rotation based on the setting above is perform
 > [Note] For instance images later than `CentOS 7.8 - Container (2021.07.27)`, the log rotation setting as above is provided by default.
 <br>
 
+<a id="disk-space-is-reduced-as-the-size-of-the-worker-nodes-container-log-file-increases-synchronize-log-rotation-setting"></a>
 #### Synchronize log rotation setting
 
 While operating clusters, log rotation setting for some of the worker nodes might change in the following cases.
@@ -127,7 +133,8 @@ $
 > [Note] The description above is only one of the methods for synchronization. If there is a better way for your environment, you can use it to perform synchronization.
 
 
-### > The status of the Pod appears as ImagePullBackOff.
+<a id="the-status-of-the-pod-appears-as-imagepullbackoff"></a>
+### > The status of the Pod appears as ImagePullBackOff. { #the-status-of-the-pod-appears-as-imagepullbackoff }
 
 Since November 20, 2020, dockerhub has implemented a policy that places the following limits on the number of pull requests for container image. For more information on limits, see [Understanding Docker Hub Rate Limiting](https://www.docker.com/increase-rate-limits) and [Pricing & Subscriptions](https://www.docker.com/pricing).
 
@@ -146,7 +153,8 @@ The workaround is as follows.
 * If you want to be limited by an independent public IP without logging in to dockerhub, assign a floating IP to the worker node. 
 
 
-### > Failed to pull image `k8s.gcr.io/pause:3.2` in a closed network environment.
+<a id="failed-to-pull-image-k8sgcriopause32-in-a-closed-network-environment"></a>
+### > Failed to pull image `k8s.gcr.io/pause:3.2` in a closed network environment. { #failed-to-pull-image-k8sgcriopause32-in-a-closed-network-environment }
 This issue is caused by clusters in a closed network environment not receiving images from the public registry, and can occur in clusters created before August 2024. Images that are deployed by default, such as the `k8s.gcr.io/pause:3.2` image, are pulled from the NHN Cloud internal registry when a worker node is created. However, if the image is deleted after the initial image is pulled, the problem may occur. The list of images that are deployed by default when creating a cluster is shown below.
 
 * kubernetesui/dashboard
@@ -186,11 +194,13 @@ imageGCHighThresholdPercent=85: Always run image Garbage Collection to remove un
 imageGCLowThresholdPercent=80: Do not run image Garbage Collection when disk utilization is 80% or less.
 ```
 
+<a id="failed-to-pull-image-k8sgcriopause32-in-a-closed-network-environment-workaround"></a>
 #### Workaround
 By enabling NKS registry, you can change the cluster settings to receive container images from the NHN Cloud internal registry instead of from a public registry in a closed network environment. You can enable the NKS registry from the Cluster inquiry screen.
 
 
-### > Image pull for Flannel CNI related images from `quay.io` fails.
+<a id="image-pull-for-flannel-cni-related-images-from-quayio-fails"></a>
+### > Image pull for Flannel CNI related images from `quay.io` fails. { #image-pull-for-flannel-cni-related-images-from-quayio-fails }
 
 The repository address for Flannel-related container images is based on `quay.io`. The pull service for these images on `quay.io` has been terminated, so they can no longer be pulled.
 
@@ -205,7 +215,8 @@ Here's how to solve the problem:
     * AS-IS: `quay.io/coreos/flannel*`
     * TO-BE: `ghcr.io/flannel-io/flannel*`
 
-### > In k8s v1.24 and later, the `pull from host docker.pkg.github.com failed` error occurs and the image pull fails. 
+<a id="in-k8s-v124-and-later-the-pull-from-host-dockerpkggithubcom-failed-error-occurs-and-the-image-pull-fails"></a>
+### > In k8s v1.24 and later, the `pull from host docker.pkg.github.com failed` error occurs and the image pull fails. { #in-k8s-v124-and-later-the-pull-from-host-dockerpkggithubcom-failed-error-occurs-and-the-image-pull-fails }
 
 This issue is caused by the change of the package registry on github from the Docker registry to the Container registry. Clusters in v1.24 or earlier used Docker as the container runtime and could pull images from the `docker.pkg.github.com` registry, but NKS clusters in v1.24 and later use cotainerd as the container runtime and can no longer pull images from the `docker.pkg.github.com` registry. For more information about package registry migration, see Migration to Container registry from the Docker registry[migrating](https://docs.github.com/en/packages/working-with-a-github-packages-registry/migrating-to-the-container-registry-from-the-docker-registry).
 
@@ -213,10 +224,12 @@ This issue is caused by the change of the package registry on github from the Do
 The workaround is as follows
 Change the base of the image URL defined in the Pod manifest `from docker.pkg.github.com` to `gchr.io`.
 
-### > `cannot allocate memory` error occurs and the Pod's status appears `as FailedCreatePodContainer`.
+<a id="cannot-allocate-memory-error-occurs-and-the-pods-status-appears-as-failedcreatepodcontainer"></a>
+### > `cannot allocate memory` error occurs and the Pod's status appears `as FailedCreatePodContainer`. { #cannot-allocate-memory-error-occurs-and-the-pods-status-appears-as-failedcreatepodcontainer }
 
 A bug in the Linux kernel's kernel object accounting feature for memory cgroups. It occurs primarily in versions 3.x and 4.x of the Linux kernel and is known as the dying memory cgroup problem issue. Users can bypass this issue by disabling the kernel object accounting feature for memory cgroups at the image level. 
 
+<a id="cannot-allocate-memory-error-occurs-and-the-pods-status-appears-as-failedcreatepodcontainer-apply-the-workaround-to-existing-clusters"></a>
 #### Apply the workaround to existing clusters
 Connect to the worker node, change the boot options, and restart it.
 
@@ -240,6 +253,7 @@ $ reboot
 
 This issue may not always occur, and may depend on the nature of your application. If you are concerned about this issue, you can use the custom image feature in NKS to use a worker node image with the above workaround applied from the start.
 
+<a id="cannot-allocate-memory-error-occurs-and-the-pods-status-appears-as-failedcreatepodcontainer-apply-the-workaround-to-newly-created-clusters-using-the-nks-custom-image-feature"></a>
 #### Apply the workaround to newly created clusters using the NKS Custom Image feature
 NKS provides the feature to create a group of worker nodes based on your custom image. You can use the NKS custom image feature to create an image with kernel object accounting disabled for memory cgroups and utilize it when creating a cluster. For more information about the feature, see [](/Container/NKS/en/user-guide/#_25)Use Custom Image as Worker Image[](/Container/NKS/en/user-guide/#custom-image).
 
@@ -253,7 +267,8 @@ sudo sed -i "s/GRUB_CMDLINE_LINUX=\"\(.*\)\"/GRUB_CMDLINE_LINUX=\"\1 $args\"/" "
 sudo grub2-mkconfig -o /boot/grub2/grub.cfg
 ```
 
-### > rpc.statd is not running but is required for remote locking error occurs and the Pod fails to mount the NAS volume.
+<a id="rpcstatd-is-not-running-but-is-required-for-remote-locking-error-occurs-and-the-pod-fails-to-mount-the-nas-volume"></a>
+### > rpc.statd is not running but is required for remote locking error occurs and the Pod fails to mount the NAS volume. { #rpcstatd-is-not-running-but-is-required-for-remote-locking-error-occurs-and-the-pod-fails-to-mount-the-nas-volume }
 
 This issue is caused by the rpc.statd process on the worker node becoming a zombie process or being stopped by an administrator command. The rpcbind and rpc.statd processes on the worker node must be running normally in order to mount the volume. The workaround is as follows
 ```
@@ -261,7 +276,8 @@ systemctl restart rpc-statd
 systemctl restart rpcbind
 ```
 
-### > The Pod's file system does not reflect the increased capacity after the PV capacity is increased.
+<a id="the-pods-file-system-does-not-reflect-the-increased-capacity-after-the-pv-capacity-is-increased"></a>
+### > The Pod's file system does not reflect the increased capacity after the PV capacity is increased. { #the-pods-file-system-does-not-reflect-the-increased-capacity-after-the-pv-capacity-is-increased }
 This is an issue that can occur in clusters with version 1.20 or later that were created before August 2024. You can run the script below to update the cinder-csi-driver deployed in your cluster to resolve the issue. Only newly created or increased capacity PVs after running the script will reflect the configuration update.
 
 Define the absolute path value where the cluster's kubeconfig file is located in the kubeconfig_file_path variable, and then run the script.
@@ -297,13 +313,15 @@ kubectl -n kube-system rollout restart daemonet cinder-csi-nodeplugin
 kubectl -n kube-system rollout restart statefulset cinder-csi-controllerplugin
 ```
 
-### > Error of timed out waiting for condition occurs and the volume mount to the Pod fails.
+<a id="error-of-timed-out-waiting-for-condition-occurs-and-the-volume-mount-to-the-pod-fails"></a>
+### > Error of timed out waiting for condition occurs and the volume mount to the Pod fails. { #error-of-timed-out-waiting-for-condition-occurs-and-the-volume-mount-to-the-pod-fails }
 This is an issue that can occur when you mount large volumes in a Pod. By default, when Kubernetes mounts a volume, it changes the ownership and permissions on the contents of each volume to match the fsGroup specified in the SecurityContext of the Pod. If the volume is large, it can take a lot of time to check and change ownership and permissions, which can cause a timeout. 
 
 To prevent timeouts from occurring, you can use the fsGroupChangePolicy field of the securityContext to change the way Kubernetes checks and manages ownership and permissions for volumes. For more information, see [Configure volume permission and ownership change policy for pods](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#configure-volume-permission-and-ownership-change-policy-for-pods).
 
 
-### > Setting the hostnetwork: true, dnsPolicy: ClusterFirstWithHostNet option on a Pod in a cluster with Calico-eBPF CNI causes UDP communication issues.
+<a id="setting-the-hostnetwork-true-dnspolicy-clusterfirstwithhostnet-option-on-a-pod-in-a-cluster-with-calico-ebpf-cni-causes-udp-communication-issues"></a>
+### > Setting the hostnetwork: true, dnsPolicy: ClusterFirstWithHostNet option on a Pod in a cluster with Calico-eBPF CNI causes UDP communication issues. { #setting-the-hostnetwork-true-dnspolicy-clusterfirstwithhostnet-option-on-a-pod-in-a-cluster-with-calico-ebpf-cni-causes-udp-communication-issues }
 This is caused by the BPF NAT table not handling network packets correctly during UDP communication in Calico v3.28.0. When using eBPF, TCP communicates `in a connect-time load balancing (CTLB)` method and UDP communicates over `a NAT table`managed by BPF. This issue can be resolved by changing UDP communication to CTLB as well.
 
 `Connect-time load balancing (CTLB)` is a network load balancing technique in which a backend server is selected in the first packet when a client first connects to a server, and all subsequent traffic is directed to the selected backend server. This ensures session persistence and reduces the overhead of performing load balancing every time.
@@ -322,24 +340,29 @@ When the Pod template is modified, calico-node will resume on a rolling update b
     value: "Disabled"
 ```
 
+<a id="setting-the-hostnetwork-true-dnspolicy-clusterfirstwithhostnet-option-on-a-pod-in-a-cluster-with-calico-ebpf-cni-causes-udp-communication-issues-cautions-for-setting-up-udp-communication-after-applying-the-workaround"></a>
 #### Cautions for setting up UDP communication after applying the workaround
 UDP is a connectionless protocol, meaning that server/client communication transfers data without establishing or maintaining a separate session. However, UDP's `connect(` ) function, like the Golang `net.DialUDP(` ) function, allows you to associate a UDP socket with a specific address to send and receive data only to the specified address.
 With Calico's eBPF, if you deploy a Pod that uses the UD `connect()` function in a cluster with connect-time load balancing (CTLB) enabled for UDP, you might experience communication issues when the Pod acting as a server is redeployed. This is because the UDP socket only attempts to send data to the initially connected server address. When a server Pod is redeployed, its IP address or network path might change, and because the UDP connect() socket only sends data to the old server address, communication might fail.
 This is a known issue that occurs in CTLB environments due to the way UDP connect() works and the CTLB environment, you should be aware and careful when using UDP's connect() function in a cluster with Calico eBPF and UDP CTLB that you might encounter this communication issue.
 
-### > istio is not working properly in a Calico-eBPF cluster.
+<a id="istio-is-not-working-properly-in-a-calico-ebpf-cluster"></a>
+### > istio is not working properly in a Calico-eBPF cluster. { #istio-is-not-working-properly-in-a-calico-ebpf-cluster }
 When eBPF is enabled, it performs `connect-time` load balancing `(CTLB)`, which means that when a client tries to connect to a service, it selects a backend pod on the first packet and all subsequent packets are forwarded directly to that backend. Meanwhile, Istio deploys sidecar proxies to organize the service mesh, and the proxies intercept application traffic to act as control and monitoring.
 When CTLB is enabled, packets are forwarded directly from the BPF MAP to the destination Pod, and the packets are tampered with in the process. As a result, packets are forwarded directly to the destination Pod, bypassing Istio's proxy. Because of this eBPF networking structure, Istio might not work properly. If you need to manage a cluster with istio, you must consider using a Calico-VXLAN cluster.
 
 
-### > In a cluster using Calico-eBPF CNI, network failures occur when scaling up after node reduction.
+<a id="in-a-cluster-using-calico-ebpf-cni-network-failures-occur-when-scaling-up-after-node-reduction"></a>
+### > In a cluster using Calico-eBPF CNI, network failures occur when scaling up after node reduction. { #in-a-cluster-using-calico-ebpf-cni-network-failures-occur-when-scaling-up-after-node-reduction }
 This issue is caused by a bug found in calico/kube-controllers in Calico v3.28.0. During a node reduction, if the node on which the calico/kube-controllers pod is deployed is removed, the pod is scheduled and run on a different node. While calico/kube-controllers is being rerun, the node information is out of sync. In this state, if a node with the same name as the node that was removed is added, a network failure can occur.
 
 This issue has been resolved in Calico v3.28.2. To use Calico v3.28.2, you must upgrade your Kubernetes version or recreate your cluster. 
 
 
-### > Failed to upgrade clusters.
+<a id="failed-to-upgrade-clusters"></a>
+### > Failed to upgrade clusters. { #failed-to-upgrade-clusters }
 
+<a id="failed-to-upgrade-clusters-when-creating-an-nks-check-whether-finalizers-are-set-on-the-resources-that-are-deployed-by-default"></a>
 #### When creating an NKS, check whether finalizers are set on the resources that are deployed by default.
 If finalizers are set on deployed resources when the NKS is created, the upgrade fails because the resources cannot be removed. When the upgrade of all worker node groups is complete, the NKS initial deployment resources are redeployed.If finalizers are set on the NKS initial deployment resource during this process, the redeployment of the resources will fail and the upgrade will be stopped. To resolve this issue, you must remove the finalizers setting on the NKS initial deployment resource before upgrading.
 
@@ -353,17 +376,20 @@ kubectl patch clusterrole calico-kube-controllers --type=json -p='[{"op": "remov
 ```
 
 
-### > When scaling out nodes or adding node groups in a cluster running v1.29.3 or earlier with an inactive NKS registry, the calico-node pod deployment fails, causing the node initialization task to fail.
+<a id="when-scaling-out-nodes-or-adding-node-groups-in-a-cluster-running-v1293-or-earlier-with-an-inactive-nks-registry-the-calico-node-pod-deployment-fails-causing-the-node-initialization-task-to-fail"></a>
+### > When scaling out nodes or adding node groups in a cluster running v1.29.3 or earlier with an inactive NKS registry, the calico-node pod deployment fails, causing the node initialization task to fail. { #when-scaling-out-nodes-or-adding-node-groups-in-a-cluster-running-v1293-or-earlier-with-an-inactive-nks-registry-the-calico-node-pod-deployment-fails-causing-the-node-initialization-task-to-fail }
 This issue occurs when calico-related pods (calico-node, calico-kube-controllers, calico-typha) are not deployed when scaling out nodes or adding node groups due to incorrect image repository settings.
 
 This issue mainly results from clusters created before May 2024. The cluster created at that time had the NKS-specific image registry disabled by default, and the repository path for the Calico container image was incorrect, making image downloads impossible.
 
+<a id="when-scaling-out-nodes-or-adding-node-groups-in-a-cluster-running-v1293-or-earlier-with-an-inactive-nks-registry-the-calico-node-pod-deployment-fails-causing-the-node-initialization-task-to-fail-how-to-check-if-the-symptom-occurs"></a>
 #### How to check if the symptom occurs
 When checking with the `kubectl get all -n kube-system` command, the status of the pods below deployed on the node where the scale-out failed remains as **ImagePullBackOff** or **ErrImagePull**.
 - calico-node
 - calico-kube-controllers
 - calico-typha
 
+<a id="when-scaling-out-nodes-or-adding-node-groups-in-a-cluster-running-v1293-or-earlier-with-an-inactive-nks-registry-the-calico-node-pod-deployment-fails-causing-the-node-initialization-task-to-fail-solution"></a>
 #### Solution
 You can resolve this issue by changing the Calico-related image repository URL to a public repository. However, this only applies to clusters with internet access. Caution is required during this process, as cluster pod networking may be temporarily interrupted during the process. The steps are as follows:
 

--- a/en/user-guide.md
+++ b/en/user-guide.md
@@ -1,11 +1,12 @@
-## Container > NHN Kubernetes Service (NKS) > User Guide
+<a id="container-nhn-kubernetes-service-nks-user-guide"></a>
+## Container > NHN Kubernetes Service (NKS) > User Guide { #container-nhn-kubernetes-service-nks-user-guide }
 
 <a id="cluster-headings"></a>
-## Cluster
+## Cluster { #cluster-headings }
 Cluster refers to a group of instances that comprise user's Kubernetes.
 
 <a id="cluster-create"></a>
-### Creating Clusters
+### Creating Clusters { #cluster-create }
 To use NHN Kubernetes Service (NKS), you must create clusters first.
 
 > [Caution] Setting up permissions to use clusters<br>
@@ -79,7 +80,7 @@ Example:
 >  - Calculate: 254 (maximum number of IPs that can be assigned to a Pod for each node) * 253 (maximum number of nodes that can be created) = 64,262 IPs available at most
 
 <a id="cluster-show"></a>
-### Querying Clusters
+### Querying Clusters { #cluster-show }
 A newly created cluster can be found in the **Container > NHN Kubernetes Service (NKS)** page. Select a cluster and the information is displayed at the bottom.
 
 | Item | Description |
@@ -135,11 +136,11 @@ When you select a cluster, cluster information appears at the bottom.
 | Configuration File | Download button of configuration file required to access cluster for operation |
 
 <a id="cluster-delete"></a>
-### Deleting Clusters
+### Deleting Clusters { #cluster-delete }
 Select a cluster to delete, and click **Delete Clusters** and it is deleted. It takes about 5 minutes to delete. More time may be required depending on the cluster status.
 
 <a id="change-keypair"></a>
-### Change Cluster Key Pair
+### Change Cluster Key Pair { #change-keypair }
 
 Change the key pair of all worker nodes in the cluster. To set the key pair, select one of the key pairs of the logged-in user. When you change the key pair, the following applies
 
@@ -154,11 +155,11 @@ A cluster with key pairing operates with the permissions of a service user. A se
 > * The Change cluster owner feature is no longer available. If you want the cluster to act as a service user, use the Change key pair feature.
 
 <a id="nodegroup-headings"></a>
-## Node Group
+## Node Group { #nodegroup-headings }
 A node group is comprised of worker node instances that comprise a Kubernetes.
 
 <a id="nodegroup-show"></a>
-### Querying Node Groups
+### Querying Node Groups { #nodegroup-show }
 Click a cluster name on the list to find the list of node groups. Select a node group and the brief information shows at the bottom.
 
 | Item | Description |
@@ -211,7 +212,7 @@ On the **Basic Information** tab, you can check the following:
 Find the list of instances comprising a node group from the **List of Nodes** tab.
 
 <a id="nodegroup-create"></a>
-### Creating Node Groups
+### Creating Node Groups { #nodegroup-create }
 Along with a new cluster, a default node group is created, but more node groups can be created depending on the needs. If higher specifications are required to run a container, or more worker node instances are required to scale out, node groups may be additionally created. Click **Create Node Groups** from the page of node group list, and the page of creating a node group shows up. The following items are required to create a node group:
 
 | Item | Description |
@@ -231,7 +232,7 @@ Enter information as required and click **Create Node Groups**, and a node group
 Only the user who created the cluster can create node groups.
 
 <a id="nodegroup-delete"></a>
-### Deleting Node Groups
+### Deleting Node Groups { #nodegroup-delete }
 Select a node group to delete from the list of node groups, and click **Delete Node Groups** and it is deleted. It takes about 5 minutes to delete a node group; more time may be required depending on the node group status.
 
 All nodes in a node group are deleted in the following order:
@@ -241,14 +242,14 @@ All nodes in a node group are deleted in the following order:
 * The node is deleted from the instance level.
 
 <a id="nodegroup-scale-out"></a>
-### Adding node to node group
+### Adding node to node group { #nodegroup-scale-out }
 Nodes can be added to operating node groups. The current list of nodes will appear upon clicking the node list tab on the node group information query page. Nodes can be added by selecting the Add Node button and entering the number of nodes you want.
 
 >[Caution]
 Nodes cannot be manually added to node groups on which autoscaler is enabled.
 
 <a id="nodegroup-scale-in"></a>
-### Deleting node from node group
+### Deleting node from node group { #nodegroup-scale-in }
 Nodes can be deleted from operating node groups. The current list of nodes will appear upon clicking the node list tab on the node group information query page. A confirmation dialog box will appear when a user selects nodes for deletion and clicks the Delete Node button. When the user confirms the node name and selects the OK button, the node will be deleted.
 
 All nodes in a node group are deleted in the following order:
@@ -261,9 +262,10 @@ All nodes in a node group are deleted in the following order:
 Nodes cannot be manually deleted from node groups on which autoscaler is enabled.
 
 <a id="node-start-stop"></a>
-### Stop and start node
+### Stop and start node { #node-start-stop }
 Nodes can be stopped from node groups and started again. The current list of nodes will appear upon clicking the node list tab on the node group information query page. Nodes can be stopped when a user selects nodes and click the stop button. The stopped nodes can be restarted when the user select them and click the start button.
 
+<a id="node-start-stop-action-process"></a>
 #### Action process
 
 When you stop a node that is started, the node operates in the following order.
@@ -279,6 +281,7 @@ If you start a stopped node, it operates in the following order.
 * The node is added to Kubernetes node resources again.
 
 
+<a id="node-start-stop-constraints"></a>
 #### Constraints
 
 Stop and start node feature has the following constraints.
@@ -290,6 +293,7 @@ Stop and start node feature has the following constraints.
 * You cannot upgrade node groups that contain stopped nodes.
 
 
+<a id="node-start-stop-display-status"></a>
 #### Display status
 
 The status icon is displayed according to the node status on the node list tab. The status colors are as follows.
@@ -299,7 +303,7 @@ The status icon is displayed according to the node status on the node list tab. 
 * Red: A node in the abnormal status
 
 <a id="use-gpu-nodegroup"></a>
-### Using a GPU node group 
+### Using a GPU node group { #use-gpu-nodegroup }
 When you need to run GPU-based workloads through Kubernetes, you can create a node group composed of GPU instances.
 Select the `g2` type when selecting a flavor while creating the clusters or node groups to create a GPU node group.
 
@@ -309,6 +313,7 @@ nvidia-device-plugin required for Kubernetes to use an NVIDIA GPU will be instal
 
 To check the default setting and run a simple operation test for the created GPU node, use the following method:
 
+<a id="use-gpu-nodegroup-node-level-status-check"></a>
 #### Node level status check
 Access the GPU node and run the `nvidia-smi` command.
 The GPU driver is working normally if the output shows the following:
@@ -334,6 +339,7 @@ Mon Jul 27 14:38:07 2020
 +-----------------------------------------------------------------------------+ 
 ```
 
+<a id="use-gpu-nodegroup-kubernetes-level-status-check"></a>
 #### Kubernetes level status check
 Use the `kubectl` command to view information about available GPU resources at the cluster level.
 Below are commands and execution results that displays the number of GPU cores available for each node.
@@ -344,6 +350,7 @@ NAME                                       GPU Allocatable   GPU Capacity
 my-cluster-default-w-vdqxpwisjjsk-node-1   1                 1
 ```
 
+<a id="use-gpu-nodegroup-sample-workload-execution-for-gpu-testing"></a>
 #### Sample workload execution for GPU testing
 GPU nodes that belong to Kubernetes clusters provide resources such as `nvidia.com/gpu` in addition to CPU and memory.
 To use GPU, enter as shown in the sample file below to be allocated with the `nvidia.com/gpu` resource.
@@ -418,7 +425,7 @@ totalMemory: 14.73GiB freeMemory: 14.62GiB
 To prevent workloads that do not require GPU from being allocated to GPU nodes, see [Taints and Tolerations](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/).
 
 <a id="autoscaler"></a>
-### Autoscaler
+### Autoscaler { #autoscaler }
 An autoscaler is a feature that automatically adjusts the number of nodes when a node group runs out of available resources or when the utilization of when node utilization stays below a certain threshold. It can be configured for each node group and operates independently. NKS supports two types of autoscalers.
 
 * Metric-based autoscaler
@@ -586,7 +593,7 @@ When enabling cluster autoscaler, you can set the following items
 
 
 <a id="cluster-autoscaler-resize"></a>
-#### Scale-up/down Conditions
+##### Scale-up/down Conditions
 Scales up if all of the following conditions are met:
 
 * There are no more available nodes to schedule pods.
@@ -608,7 +615,7 @@ If some nodes contain at least one pod that meets the following conditions, then
 For more information on the conditions for scale-up/down, see [Cluster Autoscaler FAQ](https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/FAQ.md).
 
 <a id="cluster-autoscaler-example"></a>
-#### Operation Example
+##### Operation Example
 Let's check how the autoscaler work through the following example:
 
 **1. Enabling Autoscaler**
@@ -831,7 +838,7 @@ metadata:
 As for the status information, the `Cluster-wide` area has the same information as `NodeGroups.`
 
 <a id="cluster-autoscaler-with-hpa"></a>
-#### Example of an action working with HPA (HorizontalPodAutoscale)
+##### Example of an action working with HPA (HorizontalPodAutoscale)
 Horizontal Pod Autoscaler (HPA) observes resource usage, such as CPU usage, to auto-scale the number of pods of ReplicationController, Deployment, ReplicaSet, and StatefulSet. As the number of pods is adjusted, there could be too many or too few resources available in the node. At this moment, utilize the Autoscaler feature to increase or decrease the number of nodes. In this example, we will see how HPA and Autoscaler can work together to deal with this issue. For more information on HPA, see [Horizontal Pod Autoscaler](https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/). 
 
 **1. Enabling Autoscaler**
@@ -1019,7 +1026,7 @@ autoscaler-test-default-w-ohw5ab5wpzug-node-0   Ready    <none>   22d   v1.28.3
 ```
 
 <a id="user-script-old"></a>
-### User Script (old)
+### User Script (old) { #user-script-old }
 You can register a user script when creating clusters and additional node groups. A user script has the following features.
 
 * Feature setting
@@ -1039,7 +1046,7 @@ You can register a user script when creating clusters and additional node groups
         * Standard output and standard error streams of script: `/var/log/userscript.output`
 
 <a id="user-script"></a>
-### User Script
+### User Script { #user-script }
 The features of a new version of user script are included in the node groups created after July 26, 2022. The following features are found in the new version.
 
 * **You can change the user script content after the worker node group is created.**
@@ -1059,11 +1066,12 @@ The features of a new version of user script are included in the node groups cre
         2. The new version of a user script
 
 <a id="instance-flavor-update"></a>
-### Change Instance Flavor
+### Change Instance Flavor { #instance-flavor-update }
 Change the instance flavor of a worker node group. The instance flavors of all worker nodes in a worker node group are changed.
 
 
 
+<a id="instance-flavor-update-process"></a>
 #### Process
 
 Changing the instance flavor proceeds in the following order.
@@ -1080,6 +1088,7 @@ Changing the instance flavor proceeds in the following order.
 Instance flavor changes work in a similar way to worker component upgrades. For more details on creating and deleting buffer nodes and evicting pods, see [Upgrade a Cluster](/Container/NKS/en/user-guide/#cluster-upgrade).
 
 
+<a id="instance-flavor-update-constraints"></a>
 #### Constraints
 
 You can only change an instance to another flavor that is compatible with its current flavor.
@@ -1089,7 +1098,7 @@ You can only change an instance to another flavor that is compatible with its cu
 * u2 flavor instances cannot be changed to other flavors once they have been created, not even to those of the same u2 flavor.
 
 <a id="custom-image"></a>
-### Use Custom Image as Worker Image
+### Use Custom Image as Worker Image { #custom-image }
 
 You can create a worker node group using your custom images. This requires additional work (conversion to NKS worker node) in NHN Cloud Image Builder so that the custom image can be used as a worker node image. In Image Builder, you can create custom worker node images by creating image templates with the worker node application of NHN Kubernetes Service (NKS). For more information on Image Builder, see [](/Compute/Image%20Builder/en/console-guide/#_1)Image Builder User Guide[](/Compute/Image%20Builder/en/console-guide/#_1).
 
@@ -1097,6 +1106,7 @@ You can create a worker node group using your custom images. This requires addit
 Conversion to NKS worker node involves installing packages and changing settings, so if you work with images that don't work properly, it may fail.
 You may be charged for using the Image Builder service.
 
+<a id="custom-image-constraints"></a>
 #### Constraints
 The supported OS images and the application versions you must select for each OS image are shown in the table below. You must select the correct version of application to match the image of the base instance from which your custom image is created.
 
@@ -1122,6 +1132,7 @@ The supported OS images and the application versions you must select for each OS
 During the process of converting a custom image to a worker node image, GPU drivers are installed according to the options selected.
 So even if you create a custom GPU worker node image, you don't need to create a custom image with a GPU instance.
 
+<a id="custom-image-process"></a>
 #### Process
 
 To use a custom image as a worker node image, perform the following process in the Image Builder service.
@@ -1143,7 +1154,7 @@ To use a custom image as a worker node image, perform the following process in t
 ![nkscustom_image_3.png](http://static.toastoven.net/prod_infrastructure/container/kubernetes/nkscustom_image_3.png)
 
 <a id="extra-volumes"></a>
-### Additional Block Storage
+### Additional Block Storage { #extra-volumes }
 You can use additional block storage for node groups. You can specify and create additional block storage when creating clusters and node groups, or you can create and use additional block storage in an existing node group. Additional block storage has the following characteristics
 
 * You can set up to three additional block stores per node group, and the size of the block stores can range from 1 to 2048 GB.
@@ -1161,7 +1172,7 @@ You can use additional block storage for node groups. You can specify and create
 > Changing the settings for additional block storage might affect the services you are using because it involves unmounting existing volumes.
 
 <a id="extra-security-groups"></a>
-### Additional Security Groups
+### Additional Security Groups { #extra-security-groups }
 You can set additional security groups on node groups. You can specify and create additional security groups when you create clusters and node groups, or you can set additional security groups on existing node groups. Additional security groups have the following characteristics
 
 * You can set up up to eight additional security groups per subnet.
@@ -1177,7 +1188,7 @@ You can set additional security groups on node groups. You can specify and creat
 Changing additional security groups changes network settings, so communication might be temporarily affected while the settings take effect.
 
 <a id="fip-auto-bind"></a>
-### Floating IP Auto-assignment
+### Floating IP Auto-assignment { #fip-auto-bind }
 You can use the floating IP auto-assignment feature for a node group. When this feature is enabled, a floating IP is automatically assigned to each node when it is created. You can choose whether to enable this feature when creating a cluster or an additional node group. Once set, the option cannot be changed later. The following items are required to enable the floating IP auto-assignment feature:
 
 | Item | Description | 
@@ -1196,11 +1207,11 @@ If there are not enough available floating IPs, node scaling may fail.
   * Even if you disable the feature for a node group where it was previously enabled, floating IPs already assigned to existing nodes will not be disabled.
 
 <a id="cluster-management"></a>
-## Cluster Management
+## Cluster Management { #cluster-management }
 To run and manage clusters from a remote host, `kubectl` is required, which is the command-line tool (CLI) provided by Kubernetes.
 
 <a id="kubectl-install"></a>
-### Installing kubectl
+### Installing kubectl { #kubectl-install }
 You can use kubectl by downloading an executable file without any special installation process. The download path for each operating system is as follows.
 
 > [Caution]
@@ -1214,6 +1225,7 @@ If you install Kubernetes-related components such as kubeadm, kubelet, and kubec
 
 For more details on installation and options, see [Install and Set Up kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/).
 
+<a id="kubectl-install-change-permission"></a>
 #### Change Permission
 The downloaded file does not have the execute permission by default. You need to add the execute permission.
 
@@ -1221,6 +1233,7 @@ The downloaded file does not have the execute permission by default. You need to
 $ chmod +x kubectl
 ```
 
+<a id="kubectl-install-change-the-location-or-set-the-path"></a>
 #### Change the Location or Set the Path
 Move the file to the path set in the environment variable so that kubectl can be executed on any path, or add the path including kubectl to the environment variable.
 
@@ -1236,7 +1249,7 @@ $ export PATH=$PATH:$(pwd)
 ```
 
 <a id="kubectl-set-kubeconfig"></a>
-### Configuration
+### Configuration { #kubectl-set-kubeconfig }
 To access Kubernetes cluster with kubectl, cluster configuration file (kubeconfig) is required. On the NHN Cloud web console, open the **Container > NHN Kubernetes Service (NKS)** page and select a cluster to access. From **Basic Information**, click **Download** of **Configuration Files** to download a configuration file. Move the downloaded configuration file to a location of your choice to serve it as a reference for kubectl execution.
 
 > [Caution]
@@ -1251,7 +1264,7 @@ $ export KUBECONFIG={Path of cluster configuration file}
 You may copy cluster configuration file path to `$HOME/.kube/config`, which is the default configuration file of kubectl, if you don't want to save it to an environment variable. However, when there are many clusters, it is easier to change environment variables.
 
 <a id="kubectl-check-connection"></a>
-### Confirming Connection
+### Confirming Connection { #kubectl-check-connection }
 See if it is well set by the `kubectl version` command. If there's no problem, `Server Version` is printed.
 
 ```
@@ -1264,9 +1277,10 @@ Server Version: version.Info{Major:"1", Minor:"15", GitVersion:"v1.15.7", GitCom
 * Server Version: Kubernetes version information comprising a cluster
 
 <a id="certificatesigningrequest"></a>
-### CSR (CertificateSigningRequest)
+### CSR (CertificateSigningRequest) { #certificatesigningrequest }
 Using Certificate API of Kubernetes, you can request and issue the X.509 certificate for a Kubernetes API client . CSR resource lets you request certificate and decide to accept/reject the request. For more information, see the [Certificate Signing Requests](https://kubernetes.io/docs/reference/access-authn-authz/certificate-signing-requests/) document.
 
+<a id="certificatesigningrequest-csr-request-and-issue-approval-example"></a>
 #### CSR Request and Issue Approval Example
 First of all, create a private key. For more information on certificate creation, see the [Certificates](https://kubernetes.io/docs/tasks/administer-cluster/certificates/) document.
 
@@ -1367,11 +1381,12 @@ status:
 > * Pyeongchon region: Cluster created on December 24, 2020 or later
 
 <a id="admission-controller"></a>
-### Admission Controller plugin
+### Admission Controller plugin { #admission-controller }
 The admission controller can intercept a Kubernetes API server request and change objects or deny the request. See [Admission Controller]( https://kubernetes.io/docs/reference/access-authn-authz/admission-controllers/) for more information about the admission controller. For usage examples of the admission controller, see [Admission Controller Guide](https://kubernetes.io/blog/2019/03/21/a-guide-to-kubernetes-admission-controllers/).
 
 The type of plugin applied to the admission controller varies depending on the cluster version and the time of cluster creation. For more information, see the list of plugins available depending on the time of cluster creation by region.
 
+<a id="admission-controller-v11913-or-earlier"></a>
 #### v1.19.13 or earlier
 The following applies to clusters created on February 22, 2021 or earlier for the Pangyo region and clusters created on February 17, 2021 or earlier for the Pyeongchon region.
 
@@ -1398,6 +1413,7 @@ The following applies to clusters created on February 23, 2021 or later for the 
 * ServiceAccount
 * ValidatingAdmissionWebhook
 
+<a id="admission-controller-v12012-or-later"></a>
 #### v1.20.12 or later
 All default active admission controllers per Kubernetes version are enabled. The following controllers are activated in addition to the default active admission controllers.
 
@@ -1405,9 +1421,10 @@ All default active admission controllers per Kubernetes version are enabled. The
 * PodSecurityPolicy
 
 <a id="cluster-upgrade"></a>
-### Cluster upgrade
+### Cluster upgrade { #cluster-upgrade }
 NHN Kubernetes Service (NKS) supports the Kubernetes component upgrade for the currently operating Kubernetes clusters. 
 
+<a id="cluster-upgrade-policy-of-supporting-different-kubernetes-versions"></a>
 #### Policy of supporting different Kubernetes versions
 Kubernetes version is represented as `x.y.z`. `x` is the major, `y` is the minor, and `z` is the patch version. If features are added, it is a major or minor version upgrade. If it provides features compatible with previous versions such as bug fixes, it is a patch version. For more information about this, see [Semantic Versioning 2.0.0](https://semver.org/).
 
@@ -1415,6 +1432,7 @@ Kubernetes clusters can upgrade the Kubernetes components while in operation. To
 
 <br>
 
+<a id="cluster-upgrade-manage-nks-cluster-version"></a>
 #### Manage NKS Cluster Version
 NKS cluster manages Kubernetes and platform versions for each cluster control plane and worker node group. The differences between Kubernetes and platform versions are as follows:
 
@@ -1450,7 +1468,8 @@ The Kubernetes version and platform version of the control plane can be checked 
 
 <br>
 
-##### Upgrade Rules
+<a id="cluster-upgrade-upgrade-rules"></a>
+#### Upgrade Rules
 When upgrading, NKS cluster version control and Kubernetes versioning support policy must be followed to keep the proper sequence. The following rules are applied to NKS's cluster upgrade features.
 
 * Upgrade commands must be given to each control plane and worker node group. 
@@ -1486,6 +1505,7 @@ Notes
 
 <br>
 
+<a id="cluster-upgrade-considerations-for-etcd-version-changes"></a>
 #### Considerations for etcd version changes
 When performing a cluster upgrade, the etcd upgrade is performed together only when the [etcd version](/Container/NKS/en/user-guide/#platform-version-etcd-version) defined in the target platform version differs from the etcd version of the current cluster. Before starting the upgrade, make sure to review the following considerations and take appropriate measures such as scheduling advance notifications and maintenance windows.
 
@@ -1500,6 +1520,7 @@ If an etcd upgrade fails, an automatic recovery procedure is triggered to restor
 
 <br>
 
+<a id="cluster-upgrade-upgrade-strategy"></a>
 #### Upgrade Strategy
 NKS clusters provide two upgrade strategies: Rolling Upgrade and Blue/Green Upgrade. Users can choose the appropriate strategy to upgrade the cluster based on their operational policies.
 
@@ -1579,10 +1600,11 @@ In the newly built Green environment, existing users validate that the resources
 Discarding all resources in the Blue environment will cause the control plane and all worker node groups to have consistent versions.
 
 <a id="api-endpoint-ipacl"></a>
-### Enforce IP Access Control to Cluster API Endpoints
+### Enforce IP Access Control to Cluster API Endpoints { #api-endpoint-ipacl }
 You can enforce or disable IP access control to cluster API endpoints.
 For more information about the IP access control feature, see [IP Access Control](/Network/Load%20Balancer/en/overview/#ip).
 
+<a id="api-endpoint-ipacl-ip-access-control-rules"></a>
 #### IP Access Control Rules
 When you add a Cluster API endpoint to IP access control targets, the rules below apply.
 
@@ -1593,7 +1615,7 @@ When you add a Cluster API endpoint to IP access control targets, the rules belo
 * At least one IP access control target must exist.
 
 <a id="rotate-certificate"></a>
-### Renew Cluster Certificate
+### Renew Cluster Certificate { #rotate-certificate }
 Kubernetes requires a PKI certificate for TLS authentication between components. For more information about PKI certificates, see [PKI Certificates and Requirements](https://kubernetes.io/docs/setup/best-practices/certificates/). When you create an NKS cluster, Kubernetes automatically generates the required certificate for the cluster, which has a default validity of 5 years.
 
 If the certificate expires, key components of the cluster, such as the API server, Controller Manager, etcd, will stop working and the cluster will be unavailable.
@@ -1626,7 +1648,7 @@ Here's how to use the certificate renewal feature
 > To minimize the impact of these operations, you should avoid performing tasks such as creating new Pods while certificate renewal is in progress.
 
 <a id="k8s-component"></a>
-### Set Kubernetes Component
+### Set Kubernetes Component { #k8s-component }
 
 You can set a number of options for Kubernetes components. You can set these options at cluster creation time, and you can also change them after cluster creation is complete.
 
@@ -1637,7 +1659,8 @@ The following components and options can be configured for each functional area.
 > * If you change the settings of a component running on a worker node, the component on the worker node will restart.
 > * You can configure settings for worker node components individually for each node group. (requires platform version 1.202602.0+)
 
-### Control Plain Options
+<a id="control-plain-options"></a>
+### Control Plain Options { #control-plain-options }
 
 | Component | Option | Description |
 | --- | --- | --- |
@@ -1646,7 +1669,8 @@ The following components and options can be configured for each functional area.
 | kube-controller-manager | node-monitor-grace-period | Defines how long to wait before considering a node unhealthy when it is in the NotReady state.<br>(in seconds, default: 40, min: 0, max: 86,400) |
 | kube-controller-manager | unhealthy-zone-threshold | Defines the threshold for the percentage of NotReady nodes that will be considered unhealthy for an availability zone.<br>(unit: percentage, default: 55, min: 0, max: 100) |
 
-### Worker Node Options
+<a id="worker-node-options"></a>
+### Worker Node Options { #worker-node-options }
 
 | Component | Option | Description |
 | --- | --- | --- |
@@ -1654,12 +1678,13 @@ The following components and options can be configured for each functional area.
 | kubelet | max-pods | Defines the maximum number of pods that can run on a node.<br>(default: 110, min: 1, max: maximum number of pod IPs that can be created, calculated based on pod network and subnet size settings)<br>requires platform version 1.202602.0+ |
 
 <a id="k8s-label"></a>
-### Kubernetes Label Settings
+### Kubernetes Label Settings { #k8s-label }
 You can use the Kubernetes label setting for each node group. When this feature is enabled, the user-defined labels are automatically applied to the nodes when they are created. Labels are key-value pairs attached to Kubernetes objects such as pods and nodes, and are used to identify characteristics of those objects. For a detailed description of labels, see [Labels and Selectors](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/).
 
 
 A Kubernetes label consists of a key and value pair, and each valid label key and value must adhere to the following rules.
 
+<a id="k8s-label-label-key"></a>
 #### Label Key
 Label keys can have a structure of prefix and name separated by a slash (/), and the prefix can be omitted.
 
@@ -1673,6 +1698,7 @@ Label keys can have a structure of prefix and name separated by a slash (/), and
   * Alphabetical case, numbers, dashes (-), underscores (_), and dots (.) and must start and end with an alphanumeric character.
 
 
+<a id="k8s-label-label-value"></a>
 #### Label Value
 * It must be blank or 63 characters or less.
 * Alphabetical case, numbers, dashes (-), underscores (_), and dots (.) and must start and end with an alphanumeric character.
@@ -1682,7 +1708,7 @@ Label keys can have a structure of prefix and name separated by a slash (/), and
 > * When you change the Kubernetes label settings, new nodes created afterward will have the changed settings.
 
 <a id="oidc-auth"></a>
-### OIDC Authentication Settings Feature
+### OIDC Authentication Settings Feature { #oidc-auth }
 
 OpenID Connect (OIDC) is an interoperable authentication protocol based on the OAuth 2.0 framework. With OIDC, you can authenticate users with external authentication services. To learn more about how OIDC works, see [What is OpenID Connect](https://openid.net/developers/how-connect-works/).
 
@@ -1701,7 +1727,7 @@ The NKS cluster can be set up to handle authentication using OIDC. The configura
 | Signing Algs| X | List of allowed JOSE asymmetric signature algorithms. Default: 'RS256' |
 
 <a id="control-plane-k8s-log"></a>
-### Store Logs of Kubernetes Control Plane Components
+### Store Logs of Kubernetes Control Plane Components { #control-plane-k8s-log }
 NHN Kubernetes Service (NKS) provides logs for key Kubernetes components running on the control plane. These logs help you better understand various events and operations occurring within the cluster, and can be useful for diagnosing service status and troubleshooting issues.
 
 The characteristics of the control plane Kubernetes component log storage feature is as follows.
@@ -1819,11 +1845,12 @@ Logs are created in the OBS container by the following paths
 nks-test-master-0/kube-apiserver/2025/04/20250428-101500-index0.gz
 
 <a id="k8s-taint"></a>
-### Kubernetes taint configuration
+### Kubernetes taint configuration { #k8s-taint }
 Kubernetes taint configuration is available for each node group. The node group created with this feature will be reset to the state which the user configured. For more information about Taint, refer to [Taints and Tolerations](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/).
 
 Kubernetes taint consist of a key, value, and effect, each of which must adhere to the following rules:
 
+<a id="k8s-taint-taint-key"></a>
 #### Taint Key
 
 The prefix and name in a taint key are separated by a forward slash (/), with the prefix being an optional component.
@@ -1837,11 +1864,13 @@ The prefix and name in a taint key are separated by a forward slash (/), with th
     * Must be 63 characters or less.
     * Only alphanumeric characters, dashes (-), underscores (_), and dots (.) are allowed. It must begin and end with an alphanumeric character.
 
+<a id="k8s-taint-taint-value"></a>
 #### Taint value
 
 * Must be blank, or 63 characters or less.
 * Only alphanumeric characters, dashes (-), underscores (_), and dots (.) are allowed. It must begin and end with an alphanumeric character.
 
+<a id="k8s-taint-taint-effect"></a>
 #### Taint effect
 
 You must specify one of the following three values:
@@ -1859,7 +1888,7 @@ You must specify one of the following three values:
 * Updated Kubernetes taint configuration apply only to newly created nodes.
 
 <a id="konnectivity-description"></a>
-### konnectivity
+### konnectivity { #konnectivity-description }
 
 Konnectivity is a component in Kubernetes that securely proxies network communication between the control plane (API server) and worker nodes. Previously, the API server had to directly access the kubelet or pods on nodes, which made network configuration complex.
 
@@ -1882,27 +1911,32 @@ The Konnectivity Server and Konnectivity Agent first establish a connection to c
 > Konnectivity is available in platform version 1.202605.0 or later.
 
 <a id="worker-node-management"></a>
-## Manage Worker Node
+## Manage Worker Node { #worker-node-management }
 
 <a id="container-management"></a>
-### Manage Container
+### Manage Container { #container-management }
 
+<a id="container-management-clusters-of-kubernetes-v1243-or-older"></a>
 #### Clusters of Kubernetes v1.24.3 or older
 Clusters of Kubernetes v1.24.3 or older use Docker to comprise the container runtime. In the worker node, you can use the docker CLI to view the container status and the container image. For more details and usage on the docker CLI, see [Use the Docker command line](https://docs.docker.com/engine/reference/commandline/cli/).
 
+<a id="container-management-clusters-of-kubernetes-v1243-and-later"></a>
 #### Clusters of Kubernetes v1.24.3 and later
 
 Clusters of Kubernetes v1.24.3 or later use containerd to comprise the container runtime. In the worker node, you can use nerdctl instead of the docker CLI to view the container status and the container image. For more details and usage on nerdctl, see [nerdctl: Docker-compatible CLI for containerd](https://github.com/containerd/nerdctl#nerdctl-docker-compatible-cli-for-containerd).
 
 <a id="network-management"></a>
-### Manage Network
+### Manage Network { #network-management }
 
+<a id="network-management-default-network-interface"></a>
 #### Default Network Interface
 Every worker node has a network interface that connects to the VPC/subnet entered when creating the cluster. This default network interface is named "eth0", and worker nodes connect to the control plane through this network interface.
 
+<a id="network-management-additional-network-interface"></a>
 #### Additional Network Interface
 If you set additional networks when creating a cluster or worker node group, additional network interfaces are created on the worker nodes of that worker node group. Additional network interfaces are named eth1, eth2, ... in the order entered in the additional network settings.
 
+<a id="network-management-default-route-settings"></a>
 #### Default Route Settings
 If multiple network interfaces exist on a worker node, a default route is set for each network interface. If multiple default routes are set on a system, the default route with the lowest metric value acts as the system default route. Default routes per network interface have lower metric values for smaller interface numbers. This causes the smallest numbered network interface among active network interfaces to act as the system default route.
 
@@ -1962,6 +1996,7 @@ Destination     Gateway         Genmask         Flags Metric Ref    Use Iface
 ...
 ```
 
+<a id="network-management-change-default-route-settings-using-user-script"></a>
 #### Change Default Route Settings using User Script
 If you use the User Script feature, the above settings can be maintained even when a node is newly initialized due to node scale-out. The following user script is an example of setting the metric value of eth0 to 100 and the metric value of eth1 to 0 on a worker node using CentOS. This also changes the metric value for default route currently applied to the system, which persist after the worker node restarts.
 ```
@@ -1975,7 +2010,7 @@ route add -net 0.0.0.0/0 gw 192.168.0.1 dev eth1 metric 0
 ```
 
 <a id="kubelet-argument"></a>
-### Set kubelet Custom Arguments
+### Set kubelet Custom Arguments { #kubelet-argument }
 A kubelet is a node agent that runs on all worker nodes. The kubelet receives input for many settings using command-line arguments. The kubelet custom arguments setting feature provided by NKS allows you to add arguments that are input at kubelet startup. You can set up kubelet custom arguments and apply them to your system as follows.
 
 * Enter your custom arguments in the `/etc/kubernetes/kubelet-user-args` file on the worker node in the form `KUBELET_USER_ARGS="custom arguments` ".
@@ -1990,7 +2025,7 @@ A kubelet is a node agent that runs on all worker nodes. The kubelet receives in
 > * The set custom argument will remain in effect even when the system restarts.
 
 <a id="containerd-registry-config"></a>
-### Custom Containerd Registry Settings (deprecated)
+### Custom Containerd Registry Settings (deprecated) { #containerd-registry-config }
 
 
 > [Caution]
@@ -2037,6 +2072,7 @@ The following key/value formats can be set for one registry
 }
 ```
 
+<a id="containerd-registry-config-example-1"></a>
 #### Example 1 
 
 If you want to register additional registries in addition to `docker.io`, you can set up as follows.
@@ -2058,6 +2094,7 @@ If you want to register additional registries in addition to `docker.io`, you ca
 ]
 ```
 
+<a id="containerd-registry-config-example-2"></a>
 #### Example 2 
 
 If you want to remove the `docker.io` registry and only register registries that support HTTP, you can set up as follows.
@@ -2075,6 +2112,7 @@ If you want to remove the `docker.io` registry and only register registries that
 ]
 ```
 
+<a id="containerd-registry-config-example-3"></a>
 #### Example 3
 
 To generate a custom containerd registry configuration file with the contents of Example 2 upon node creation, you can set up a user script as follows
@@ -2095,7 +2133,7 @@ echo '[ { "registry": "user-defined.registry.io", "endpoint_list": [ "http://use
 >     * If you do not want to use the `docker.io` registry, you can simply not include any settings for the `docker.io` registry. However, at least one registry setting must exist.
 
 <a id="constraints-on-cgroup"></a>
-### Constraints based on Kubernetes version and CGroup version
+### Constraints based on Kubernetes version and CGroup version { #constraints-on-cgroup }
 CGroup (Control Group) is a Linux kernel feature that allows you to limit, isolate, and monitor the system resource usage — such as CPU, memory, disk I/O, and network — of process groups. It is one of the core foundations of container technologies, including Kubernetes. CGroup started with the original version 1 (v1) and evolved into version 2 (v2) with enhanced memory and I/O control capabilities. Since it is a Linux kernel feature, CGroup v2 has a dependency on the Linux kernel. Therefore, CGroup v2 is only supported on relatively recent distributions and versions.
 
 Starting from NKS cluster v1.34, worker nodes must operate with CGroup v2. This is a constraint introduced by the Kubernetes community, signaling a shift to use containerd 2.x instead of containerd 1.x and to operate based on CGroup v2 instead of v1.
@@ -2124,13 +2162,13 @@ The OS image distributions and versions that support changing the CGroup version
 Worker node groups created using an OS image whose default CGroup version is v1 and that cannot be changed to v2 are not eligible for a rolling upgrade to Kubernetes v1.34. In this case, the worker node group can be upgraded using the Blue-Green method.
 
 <a id="worker-management-caution"></a>
-### Precautions for Worker Node Management
+### Precautions for Worker Node Management { #worker-management-caution }
 * Do not arbitrarily delete container images that are pulled on worker nodes. This may cause the Pods required by the NKS cluster to stop working. 
 * If you arbitrarily stop the system with commands like `shutdown`, `halt`, `poweroff`, etc., you cannot restart it on the console. Use the worker node start/stop feature.
 * You must not modify various configuration files within the worker node or manipulate system services. Critical issues may occur in the NKS cluster.
 
 <a id="cni"></a>
-## Container Network Interface (CNI)
+## Container Network Interface (CNI) { #cni }
 NHN Kubernetes Service (NKS) provides alternative Container Network Interface (CNI) options through its add-on features. You can select either Calico-VXLAN, Calico-eBPF, and Cilium during cluster creation, with Calico-VXLAN assigned as the default configuration. Calico-eBPF utilizes the BGP routing protocol for container workloads and leverages eBPF technology for direct communication, while certain segments—such as NodePort—rely on VXLAN. For the information about Calico's' eBPF, see [about eBPF](https://docs.tigera.io/calico/latest/about/kubernetes-training/about-ebpf). Cilium is based on a VXLAN overlay network and provides high network performance using eBPF technology. For more information on Cilium's eBPF-related content, see [eBPF Datapath](https://docs.cilium.io/en/stable/network/ebpf/).
 
 OS limitations selectable by CNI are as follows:
@@ -2143,7 +2181,7 @@ OS limitations selectable by CNI are as follows:
 | Cilium | Rocky, Ubuntu |
 
 <a id="calico-cni-types"></a>
-### Calico CNI Types
+### Calico CNI Types { #calico-cni-types }
 Calico-VXLAN and Calic-eBPF provided by the NHN Kubernetes Service (NKS) have the following differences
 
 |  | Calico-VXLAN | Calico-eBPF |
@@ -2166,11 +2204,11 @@ Notes
 > To use these images, you must update Calico to v3.28.2 or later via the Add-on Management feature.
 
 <a id="security-group"></a>
-## Security Group
+## Security Group { #security-group }
 If you set enhanced security rules to True at cluster creation, only mandatory security rules are created at worker node security group creation.
 
 <a id="mandatory-sg-rules"></a>
-### Required Security Rules for Cluster Worker Nodes
+### Required Security Rules for Cluster Worker Nodes { #mandatory-sg-rules }
 
 | Direction | IP protocol | Port range | Ether | Remote | Description | Considerations |
 | :-: | :-: | :-: | :-: | :-: | :-: | :-: |
@@ -2220,7 +2258,7 @@ When using Calico-eBPF CNI, communication between pods and communication from no
 If you are using enhanced security rules, you must manually add ingress and egress security rules for those pod ports.
 
 <a id="cilium-optional-security-group-rules"></a>
-### Additional security group rules when using Cilium CNI optional features
+### Additional security group rules when using Cilium CNI optional features { #cilium-optional-security-group-rules }
 
 To enable optional features such as Hubble, Envoy, and Prometheus in a cluster using Cilium CNI, additional security group rules required for those features must be configured.
 
@@ -2243,7 +2281,7 @@ To enable optional features such as Hubble, Envoy, and Prometheus in a cluster u
 > To use optional features, you must manually modify the Cilium configuration and add the security group rules required for those features.
 
 <a id="relaxd-sg-rules"></a>
-### Rules that are generated when you don't use enhanced security rules
+### Rules that are generated when you don't use enhanced security rules { #relaxd-sg-rules }
 
 If you don't use enhanced security rules, additional security rules are created for services of type NodePort and for external network communication.
 
@@ -2258,20 +2296,22 @@ If you don't use enhanced security rules, additional security rules are created 
 | egress | Random | 1 - 65535 | IPv6 | Allow all | All ports, direction: Worker node → External |
 
 <a id="addon-mgmt"></a>
-## Add-on Management
+## Add-on Management { #addon-mgmt }
 An add-on is a component that is not a required component of a Kubernetes cluster, but is provided to extend the functionality of an NKS cluster or to provide specialized functionality. Add-ons can include components that perform functions such as networking, service discovery, monitoring, storage provisioning, and more. Users can install/change/remove add-ons provided by NHN Cloud to the cluster through the add-on management feature.
 
 > [Caution]
 Add-on management features are not available for clusters that do not have the NKS registry enabled.
 
 <a id="addon-mgmt-operation"></a>
-### How it works
+### How it works { #addon-mgmt-operation }
 This section describes how the add-on management feature works.
 
+<a id="addon-mgmt-operation-server-side-apply"></a>
 #### Server-side apply
 When installing/changing addons to a cluster using the addon management feature, Kubernetes' Server-side apply is used. Client-side apply is where the client computes the resource state locally and sends the entire resource to the API server. Server-side apply, on the other hand, allows the API server to perform resource merging and field ownership management, allowing the API server to perform resource merging and conflict detection. For more information about server-side apply, see [Server-side apply](https://kubernetes.io/docs/reference/using-api/server-side-apply/).
 
 
+<a id="addon-mgmt-operation-conflict-resolution-options"></a>
 #### Conflict Resolution Options
 Conflicts may occur during add-on installation or updates if users have modified fields that are managed by the add-on. Users can resolve these conflicts by selecting the appropriate conflict resolution option during installation or changes. The Add-on Management feature provides the following conflict resolution options.
 
@@ -2286,6 +2326,7 @@ Conflicts may occur during add-on installation or updates if users have modified
 You can't preserve all changes to the resources that make up an add-on.
 If a conflict occurs in a non-preservable field, the install/change operation will fail.
 
+<a id="addon-mgmt-operation-main-features"></a>
 #### Main Features
 You can install/change/remove add-ons to the cluster using the add-on management feature.
 
@@ -2306,11 +2347,12 @@ You can install/change/remove add-ons to the cluster using the add-on management
 Upgrades of components such as CNI and CoreDNS are no longer provided through the Kubernetes version upgrade feature.
 Instead, you can change the version of each add-on using the add-on change feature.
 
+<a id="addon-mgmt-operation-enable-add-on-management"></a>
 #### Enable Add-on Management
 Existing clusters without the Add-on Management feature enabled can still use it. In clusters where add-ons have not been configured, components such as Calico and CoreDNS may still be running, but the system will show that the add-ons are not installed. In this case, you can install each add-on manually, after which they can be managed through the Add-on Management feature. If you have modified the configuration of resources that make up an add-on, selecting the 'Preserve' option during installation allows you to retain the existing resource settings.
 
 <a id="addon-mgmt-types"></a>
-### Add-on types
+### Add-on types { #addon-mgmt-types }
 Add-on types classify the add-ons installed in a cluster based on their characteristics.
 
 | Type | Required | Description|
@@ -2323,7 +2365,7 @@ Add-on types classify the add-ons installed in a cluster based on their characte
 | nfs-csi-plugin | X | A CSI driver that can provision and manage NFS on NHN Cloud. |
 
 <a id="addon-mgmt-addon-list"></a>
-### Add-on list
+### Add-on list { #addon-mgmt-addon-list }
 
 <a id="addon-mgmt-addon-calico"></a>
 #### Calico
@@ -2410,6 +2452,7 @@ CoreDNS is the default DNS server for a Kubernetes cluster.
 
 
 <a id="addon-mgmt-addon-cinder-csi-plugin">
+<a id="addon-mgmt-addon-list-cinder-csi-plugin"></a>
 #### Cinder CSI Plugin
 The Cinder CSI Plugin is a CSI driver that allows you to provision and manage block storage in NHN Cloud.
 
@@ -2441,6 +2484,7 @@ The Cinder CSI Plugin is a CSI driver that allows you to provision and manage bl
     * v1.27.102-nks3: Improved stability for add-on management.
 
 <a id="adoon-mgmt-addon-metrics-server">
+<a id="addon-mgmt-addon-list-metrics-server"></a>
 #### Metrics Server
 Metrics Server is a Kubernetes component that collects resource usage metrics from nodes and pods for autoscaling and monitoring.
 
@@ -2455,6 +2499,7 @@ Metrics Server is a Kubernetes component that collects resource usage metrics fr
     * v0.4.4-nks2: Improved stability for add-on management.
 
 <a id="addon-mgmt-addon-snapshot-controller">
+<a id="addon-mgmt-addon-list-snapshot-controller"></a>
 #### Snapshot Controller
 The Snapshot Controller is a Kubernetes component that manages the lifecycle of volume snapshots, including creating, deleting, and linking PVCs.
 
@@ -2468,6 +2513,7 @@ The Snapshot Controller is a Kubernetes component that manages the lifecycle of 
     * v4.1.1-nks2: Improved stability for add-on management.
 
 <a id="addon-mgmt-addon-nfs-csi-plugin">
+<a id="addon-mgmt-addon-list-nfs-csi-plugin"></a>
 #### NFS CSI Plugin
 The NFS CSI Plugin is a CSI driver that allows you to provision and manage NFS on NHN Cloud.
 
@@ -2492,11 +2538,11 @@ The NFS CSI Plugin is a CSI driver that allows you to provision and manage NFS o
         * Fixed an issue where the optional snapshot setting was incorrectly required as mandatory.      
 
 <a id="loadbalancer-service"></a>
-## LoadBalancer Service
+## LoadBalancer Service { #loadbalancer-service }
 Pod is a basic execution unit of a Kubernetes application and it is connected to a cluster network via CNI (container network interface). By default, pods are not accessible from outside the cluster. To expose a pod's services to the outside of the cluster, you need to create a path to expose to the outside using the Kubernetes `LoadBalancer` Service object. Creating a LoadBalancer service object creates an NHN Cloud Load Balancer outside the cluster and associates it with the service object.
 
 <a id="create-webserver-pod"></a>
-### Creating Web Server Pods
+### Creating Web Server Pods { #create-webserver-pod }
 Write a deployment object manifest file that executes two nginx pods as follows and create an object.
 
 ```yaml
@@ -2537,7 +2583,7 @@ nginx-deployment-7fd6966748-wv7rd   1/1     Running   0          4m13s
 ```
 
 <a id="create-lb-service"></a>
-### Creating LoadBalancer
+### Creating LoadBalancer { #create-lb-service }
 To define service object of Kubernetes, a manifest comprised of the following items is required:
 
 | Item | Description |
@@ -2595,7 +2641,7 @@ You can view the created load balancer on the **Network > Load Balancer** page.
 Load balancer IP is a floating IP allowing external access. You can check it on the **Network > Floating IP** page.
 
 <a id="internet-test-via-service"></a>
-### Testing Service on Internet
+### Testing Service on Internet { #internet-test-via-service }
 Send an HTTP request via floating IP associated with load balancer to see if the web server pod of a Kubernetes cluster responds. Since the TcP/8080 port of a service object is attached to TCP/80 port of a pod, request must be sent to the TCP/8080 port. If external load balancer, service object, and pod are well associated, the web server shall respond to nginx default page.
 
 ```
@@ -2628,7 +2674,7 @@ Commercial support is available at
 ```
 
 <a id="advanced-lb-configuration"></a>
-### Setting Detailed Options for Load Balancer
+### Setting Detailed Options for Load Balancer { #advanced-lb-configuration }
 When defining service objects in Kubernetes, you can set several options for the load balancer. You can set the following.
 
 * Setting Load Balancer Name
@@ -2654,12 +2700,14 @@ When defining service objects in Kubernetes, you can set several options for the
 * Set the status check host header
 * L7 rules and condtions
 
+<a id="advanced-lb-configuration-global-setting-and-per-listener-setting"></a>
 #### Global Setting and Per-Listener Setting
 For each setting item, global setting or per-listener setting is supported. If neither global nor per-listener setting is available, the default value for each setting is used.
 
 * Per-listener setting: A setting that applies only to the target listener.
 * Global setting: If the target listener doesn't have a per-listener setting, this setting is applied.
 
+<a id="advanced-lb-configuration-format-of-per-listener-setting"></a>
 #### Format of Per-Listener Setting
 Per-listener settings can be set by appending a prefix representing the listener to the global settings key. The prefix representing the listener is the service object's port protocol (`spec.ports[].protocol`) and port number (`spec.ports[].port`) concatenated with a dash (`-`). For example, if the protocol is TCP and the port number is 80, the prefix is ​​`TCP-80`. If you want to set session affinity for the listener associated with this port, you can set it in TCP-80.loadbalancer.nhncloud/pool-session-persistence under .metadata.annotations.
 
@@ -2728,6 +2776,7 @@ Once the load balancer update begins, the annotation set by the above command is
 > [Caution]
 > This feature works on clusters with platform version 1.202605.0 or later.
 
+<a id="advanced-lb-configuration-setting-load-balancer-name"></a>
 #### Setting Load Balancer Name
 
 You can set a name for the load balancer.
@@ -2744,6 +2793,7 @@ The following cases can cause serious malfunction of the load balancer.
 > * Modifying the load balancer name after the service object is created
 > * Creating a load balancer with a duplicate name within the same project
 
+<a id="advanced-lb-configuration-set-load-balancer-type"></a>
 #### Set load balancer type
 You can set the load balancer type. For more information, see [Load Balancer Console User Guide](/Network/Load%20Balancer/en/console-guide/).
 
@@ -2760,6 +2810,7 @@ Physical load balancer is only provided in Korea (Pyeongchon) region.
 You cannot attach physical load balancers to floating IPs. Instead, a public IP that is automatically assigned when creating the physical load balancer is used as an IP to receive traffic targeted for balancing. This public IP is shown as a service IP in the console.
 For the above characteristics, you cannot see the exact status of the load balancer (including the associated floating IP) through Kubernetes service objects. Please check the status of physical load balancers in the console.
 
+<a id="advanced-lb-configuration-set-static-routes"></a>
 #### Set Static Routes
 You can set whether the load balancer applies static routes. 
 
@@ -2772,6 +2823,7 @@ You can set whether the load balancer applies static routes.
 > [Caution]
 Static route settings are available for clusters created on or after August 27, 2024 or that have upgraded their version of K8s.
 
+<a id="advanced-lb-configuration-set-the-session-affinity"></a>
 #### Set the session affinity
 You can set the session affinity for the load balancer.
 
@@ -2786,6 +2838,7 @@ You can set the session affinity for the load balancer.
 * Clusters of v1.19.13 or later
     * The setting can be changed even after the load balancer is created.
 
+<a id="advanced-lb-configuration-set-whether-to-keep-a-floating-ip-address"></a>
 #### Set whether to keep a floating IP address
 The load balancer has a floating IP associated with it. You can set whether to delete or keep the floating IP associated with the load balancer when deleting the load balancer and changing the floating IP.
 
@@ -2807,6 +2860,7 @@ The load balancer has a floating IP associated with it. You can set whether to d
 v1.18.19 clusters created before October 26, 2021 have an issue where floating IPs are not deleted when the load balancer is deleted. If you contact us through 1:1 inquiry of the Customer Center, we will provide detailed information on the procedure to solve this issue.
 
 
+<a id="advanced-lb-configuration-set-the-load-balancer-ip"></a>
 #### Set the load balancer IP
 You can set the load balancer IP when creating a load balancer.
 
@@ -2837,6 +2891,7 @@ spec:
   type: LoadBalancer
 ```
 
+<a id="advanced-lb-configuration-set-whether-to-use-the-floating-ip"></a>
 #### Set whether to use the floating IP
 You can set whether to use floating IPs when creating the load balancer.
 
@@ -2880,6 +2935,7 @@ Depending on the combination of floating IP usage and load balancer IP setting, 
 | true | set | Associate a specified VIP with the load balancer. |
 
 
+<a id="advanced-lb-configuration-set-vpc"></a>
 #### Set VPC
 You can set a VPC to which the load balancer is connected when creating a load balancer.
 
@@ -2887,6 +2943,7 @@ You can set a VPC to which the load balancer is connected when creating a load b
 * Per-listener settings cannot be applied.
 * If not set, it is set to the VPC configured when creating the cluster.
 
+<a id="advanced-lb-configuration-set-subnet"></a>
 #### Set Subnet
 You can set a subnet to which the load balancer is connected when creating a load balancer. The load balancer's private IP is connected to the set subnet. If no member subnet is set, worker nodes connected to this subnet are added as load balancer members.
 
@@ -2916,6 +2973,7 @@ spec:
   type: LoadBalancer
 ```
 
+<a id="advanced-lb-configuration-set-member-subnet"></a>
 #### Set Member Subnet
 When creating a load balancer, you can set a subnet to which load balancer members will be connected. Worker nodes connected to this subnet are added as load balancer members.
 
@@ -2974,6 +3032,7 @@ spec:
 > [Caution]
 > Member subnets can be set up on clusters that have been upgraded to v1.24.3 or later after November 28, 2023, or are newly created.
 
+<a id="advanced-lb-configuration-set-the-listener-connection-limit"></a>
 #### Set the listener connection limit
 You can set the connection limit for a listener.
 
@@ -2987,6 +3046,7 @@ You can set the connection limit for a listener.
     * If not set or a value out of range is entered, it is set to the default value of 60000.
 
 
+<a id="advanced-lb-configuration-set-the-listener-protocol"></a>
 #### Set the listener protocol
 You can set the protocol of the listener.
 
@@ -3078,6 +3138,7 @@ metadata:
 > Deleting a certificate from Certificate Manager that is associated with a listener might affect the behavior of the load balancer.
 
 
+<a id="advanced-lb-configuration-set-the-listener-proxy-protocol"></a>
 #### Set the listener proxy protocol
 When the listener protocol is TCP or HTTPS, you set the proxy protocol to the listener. For more information on proxy protocol, see [Load Balancer Proxy Mode](/Network/Load%20Balancer/en/overview/#_4)
 
@@ -3087,6 +3148,7 @@ When the listener protocol is TCP or HTTPS, you set the proxy protocol to the li
     * true: Enable the proxy protocol.
     * false: Disable the proxy protocol. Default when not set.
 
+<a id="advanced-lb-configuration-set-the-load-balancing-method"></a>
 #### Set the load balancing method
 You can set the load balancing method.
 
@@ -3098,6 +3160,7 @@ You can set the load balancing method.
     * SOURCE_IP
 
 
+<a id="advanced-lb-configuration-set-the-health-check-protocol"></a>
 #### Set the health check protocol
 You can set the health check protocol.
 
@@ -3128,6 +3191,7 @@ The HTTP status code can be set as follows:
 * You can enter the value in the form of a single value (e.g. 200), a list (e.g. 200,202), or a range (e.g. 200-204).
 * If not set or a value that does not match the rule is entered, it is set to the default value of 200.
 
+<a id="advanced-lb-configuration-set-the-health-check-interval"></a>
 #### Set the health check interval
 You can set the health check interval.
 
@@ -3137,6 +3201,7 @@ You can set the health check interval.
 * Minimum value of 1, maximum value of 5000.
 * If not set or a value out of range is entered, it is set to the default value of 60.
 
+<a id="advanced-lb-configuration-set-the-health-check-maximum-response-time"></a>
 #### Set the health check maximum response time
 You can set the maximum response time for health checks.
 
@@ -3148,6 +3213,7 @@ You can set the maximum response time for health checks.
 * If not set or a value out of range is entered, it is set to the default value of 30.
 * However, if the input value or setting value is greater than the Health check interval setting, it is set to 1/2 of the Health check interval setting setting value.
 
+<a id="advanced-lb-configuration-set-the-maximum-number-of-retries-for-a-health-check"></a>
 #### Set the maximum number of retries for a health check
 You can set the maximum number of retries for a health check.
 
@@ -3156,6 +3222,7 @@ You can set the maximum number of retries for a health check.
 * Minimum value of 1, maximum value of 10.
 * If not set or a value out of range is entered, it is set to the default value of 3.
 
+<a id="advanced-lb-configuration-health-check-port-settings"></a>
 #### Health Check Port Settings
 You can set the member port for health checks.
 
@@ -3165,6 +3232,7 @@ You can set the member port for health checks.
 * If 0 is specified, health checks will be performed on the specified port number for each member.
 * If not specified or a value out of range is entered, the default value is 0.
 
+<a id="advanced-lb-configuration-health-check-host-header-settings"></a>
 #### Health Check Host Header Settings
 You can set the host header field value to be used for health checks.
 
@@ -3172,6 +3240,7 @@ You can set the host header field value to be used for health checks.
 * You can apply listener-specific settings.
 * If the health check protocol is set to TCP, the value set in this field is ignored.
 
+<a id="advanced-lb-configuration-setting-keep-alive-timeout"></a>
 #### Setting keep-alive timeout
 You can set a keep-alive timeout value.
 
@@ -3184,6 +3253,7 @@ You can set a keep-alive timeout value.
 > [Caution]
 > The keep-alive timeout can be set up on clusters that have been upgraded to v1.24.3 or later after November 28, 2023, or are newly created.
 
+<a id="advanced-lb-configuration-l7-rules"></a>
 #### L7 Rules
 You can set L7 rules on a per-listener basis. L7 rules work as follows
 
@@ -3214,6 +3284,7 @@ L7 rule settings have the following limitations
 * L7 rules that are set on one listener must be set to different index values.
 * L7 rules that are set on one listener must be set to different names.
 
+<a id="advanced-lb-configuration-l7-conditions"></a>
 #### L7 Conditions
 You can set L7 conditions per L7 rule. L7 conditions work as follows
 
@@ -3315,19 +3386,20 @@ spec:
   type: LoadBalancer
 ```
 <a id="ingress-controller"></a>
-## Ingress Controller
+## Ingress Controller { #ingress-controller }
 Ingress Controller routes HTTP and HTTPS requests from cluster externals to internal services, in reference of the rules that are defined at ingress object so as to provide SSL/TSL closure and virtual hosting. For more details on Ingress Controller and Ingress, see [Ingress Controller](https://kubernetes.io/docs/concepts/services-networking/ingress-controllers/), [Ingress](https://kubernetes.io/docs/concepts/services-networking/ingress/).
 
 <a id="install-nginx-ingress-controller"></a>
-### Installing NGINX Ingress Controller
+### Installing NGINX Ingress Controller { #install-nginx-ingress-controller }
 NGINX Ingress Controller is one of the most frequently used ingress controllers. For more details, see [NGINX Ingress Controller](https://kubernetes.github.io/ingress-nginx/) and [NGINX Ingress Controller for Kubernetes](https://www.nginx.com/products/nginx-ingress-controller/). For installation of NGINX Ingress Controller, see [Installation Guide](https://kubernetes.github.io/ingress-nginx/deploy/).
 
 <a id="uri-based-service-routing"></a>
-### Diverging Service on URI
+### Diverging Service on URI { #uri-based-service-routing }
 Ingress controller can diverge services based on URI. The following figure shows the structure of a simple example of service divergence based on URI.
 
 ![ingress-01.png](http://static.toastoven.net/prod_infrastructure/container/kubernetes/ingress-01.png)
 
+<a id="uri-based-service-routing-create-services-and-pods"></a>
 #### Create Services and Pods
 Manifest is created to create services and pods like below: Associate the `tea` pod to `tea-svc`, and the `coffee` pod to `coffee-svc`.
 
@@ -3428,6 +3500,7 @@ pod/tea-5c457db9-fdkxl        1/1     Running   0          27m
 pod/tea-5c457db9-z6hl5        1/1     Running   0          27m
 ```
 
+<a id="uri-based-service-routing-create-ingress"></a>
 #### Create Ingress
 According to the request path, ingress manifest is created for service connection. A request with `/tea` as endpoint is connected to the `tea-svc` service, while `/coffee` is connected to the `coffee-svc` service.
 
@@ -3469,6 +3542,7 @@ NAME               CLASS   HOSTS   ADDRESS          PORTS   AGE
 cafe-ingress-uri   nginx   *       123.123.123.44   80      23s
 ```
 
+<a id="uri-based-service-routing-send-http-requests"></a>
 #### Send HTTP Requests
 Send HTTP request to the IP address set for **ADDRESS** of ingress for an external host, to check if the ingress has been properly set.
 
@@ -3527,6 +3601,7 @@ $ curl 123.123.123.44/unknown
 </html>
 ```
 
+<a id="uri-based-service-routing-delete-resources"></a>
 #### Delete Resources
 Resources for testing can be deleted with used manifest.
 
@@ -3542,14 +3617,16 @@ service "tea-svc" deleted
 ```
 
 <a id="host-based-service-routing"></a>
-### Service Divergence on Host
+### Service Divergence on Host { #host-based-service-routing }
 Ingress controller can diverge services based on the host name. The following figure shows the structure of a simple example of service divergence based on the host name.
 
 ![ingress-02.png](http://static.toastoven.net/prod_infrastructure/container/kubernetes/ingress-02.png)
 
+<a id="host-based-service-routing-create-services-and-pods"></a>
 #### Create Services and Pods
 Create services and pods by using the same manifest as [URI-based Service Divergence](/Container/NKS/en/user-guide/#uri).
 
+<a id="host-based-service-routing-create-ingress"></a>
 #### Create Ingress
 Write the ingress manifest connecting services based on the host name. Incoming request via the `tea.cafe.example.com` host is connected to the `tea-svc` service, while request via the `coffee.cafe.example.com` host is connected to the `coffee-svc` service.
 
@@ -3595,6 +3672,7 @@ NAME                CLASS   HOSTS                                          ADDRE
 cafe-ingress-host   nginx   tea.cafe.example.com,coffee.cafe.example.com   123.123.123.44   80      36s
 ```
 
+<a id="host-based-service-routing-send-http-requests"></a>
 #### Send HTTP Requests
 HTTP request is sent from external host to IP configured at the ADDRESS of the ingress controller. Nevertheless, such request must be sent by using host name, since service divergence is based on the host name by configuration.
 
@@ -3638,9 +3716,10 @@ $ curl 123.123.123.44/unknown
 ```
 
 <a id="ingress-nginx-internal-communication"></a>
-### Internal communication structure and cautions for the ingress-nginx controller
+### Internal communication structure and cautions for the ingress-nginx controller { #ingress-nginx-internal-communication }
 When exposing a service externally through the ingress-nginx controller, the path the request takes to reach the workload varies depending on the location of the requesting client (inside or outside the cluster).
 
+<a id="ingress-nginx-internal-communication-cluster-external-client"></a>
 #### Cluster External Client
 Requests from clients outside the cluster are forwarded to the Ingress Controller via the load balancer. The load balancer acts as an external endpoint for the Ingress Controller Service, and the Ingress Controller routes requests to the destination backend pod based on the Ingress rules.
 
@@ -3648,6 +3727,7 @@ Requests from clients outside the cluster are forwarded to the Ingress Controlle
 Cluster External Client → Load Balancer → ingress-nginx Service → ingress-nginx Controller Pod → Backend Pod
 ```
 
+<a id="ingress-nginx-internal-communication-cluster-internal-client"></a>
 #### Cluster Internal Client
 When a Pod within the cluster makes a request to the Ingress address, the traffic bypasses the load balancer. The request is forwarded directly to the internal route via the ClusterIP of the Ingress Controller Service, and is routed according to the CNI as follows:
 
@@ -3659,6 +3739,7 @@ In both cases, traffic is routed only within the internal network and does not g
 내부 Pod → ingress-nginx Service (ClusterIP) → ingress-nginx Controller Pod → Backend Pod
 ```
 
+<a id="ingress-nginx-internal-communication-cautions"></a>
 #### Cautions
 
 - Internal requests are not subject to load balancer policies. The load balancer's TLS settings, security policies, firewall rules, etc. do not affect internal traffic.
@@ -3667,7 +3748,7 @@ In both cases, traffic is routed only within the internal network and does not g
 
 
 <a id="k8s-dashboard"></a>
-## Kubernetes Dashboard
+## Kubernetes Dashboard { #k8s-dashboard }
 NHN Kubernetes Service (NKS) provides the default web UI dashboard. For more details on Kubernetes Dashboard, see [Web UI (Dashboard)](https://kubernetes.io/docs/tasks/access-application-cluster/web-ui-dashboard/).
 
 > [Caution]
@@ -3676,7 +3757,7 @@ NHN Kubernetes Service (NKS) provides the default web UI dashboard. For more det
 > * You can view Kubernetes resources from the NHN Cloud console.
 
 <a id="expose-dashboard"></a>
-### Opening Dashboard Services
+### Opening Dashboard Services { #expose-dashboard }
 User Kubernetes has the `kubernetes-dashboard` service object which has been already created to publicly open dashboard.
 
 ```
@@ -3704,6 +3785,7 @@ Events:            <none>
 
 However, the `kubernetes-dashboard` object belongs to ClusterIP type and is not open out of the cluster. To open up dashboard externally, the service object type must be changed into LoadBalancer, or ingress controller and ingress object must be created.
 
+<a id="expose-dashboard-change-into-loadbalancer"></a>
 #### Change into LoadBalancer
 
 Once the type of service object is changed into `LoadBalancer`, NHN Cloud Load Balancer is created out of the cluster, which is associated with load balancer and service object. By querying service object associated with the load balancer, IP of the load balancer is displayed in the **EXTERNAL-IP** field. See [LoadBalancer Service](/Container/NKS/en/user-guide/#loadbalancer) for the description of service objects of the `LoadBalancer` type. The following figure shows the structure of making dashboard public using the `LoadBalancer` type service.
@@ -3735,6 +3817,7 @@ If you access `https://{EXTERNAL-IP}` in a web browser, the Kubernetes dashboard
 > [Note]
 Since Kubernetes dashboard is based on a private certificate that is automatically created, the page may be displayed as unsafe, depending on the web browser or security setting.
 
+<a id="expose-dashboard-open-services-with-ingress"></a>
 #### Open Services with Ingress
 
 Ingress refers to the network object providing routing to access many services within a cluster. The setting of an ingress object runs by ingress controller. The `kubernetes-dashboard` service object can go public through ingress. See [Ingress Controller](/Container/NKS/en/user-guide/#ingress-controller) regarding description on ingress and ingress controller. The following figure shows the structure of making dashboard public through ingress.
@@ -3787,7 +3870,7 @@ k8s-dashboard-ingress   nginx   *       123.123.123.44   80, 443   34s
 If you access `https://{ADDRESS}` in a web browser, the Kubernetes dashboard page is loaded. See [Dashboard Access Token](/Container/NKS/en/user-guide/#dashboard-access-token) for the token required for login.
 
 <a id="dashboard-access-token"></a>
-### Dashboard Access Token
+### Dashboard Access Token { #dashboard-access-token }
 A token is required to log in to the Kubernetes dashboard. You can get the token with the following command:
 
 ```
@@ -3800,7 +3883,7 @@ eyJhbGc...-QmXA
 Enter the printed token in the token input window on the browser, and you can log in as a user that has been granted the cluster admin privileges.
 
 <a id="persistent-volume"></a>
-## Persistent Volume
+## Persistent Volume { #persistent-volume }
 Persistent Volume or PV is a Kubernetes resource representing physical storage volume. One PV is attached to one NHN Cloud Block Storage. For more details, see [Persistent Volume](https://kubernetes.io/docs/concepts/storage/persistent-volumes/).
 
 Persistent Volume Claims, or PVC is required to attach PV to pods. PVC defines necessary volume requirements, including volume and read/write modes.
@@ -3808,7 +3891,7 @@ Persistent Volume Claims, or PVC is required to attach PV to pods. PVC defines n
 With PV and PVC, user can define the attributes of a volume of choice, while the system seperates the use of resources from management by assigning volume resources for each user requirement.
 
 <a id="pv-lifecycle"></a>
-### Life Cycle of PV/PVC
+### Life Cycle of PV/PVC { #pv-lifecycle }
 PV and PVC support the four-phase life cycle.
 
 * Provisioning
@@ -3830,15 +3913,17 @@ Volume is reclaimed after it is used up, in three methods: Delete, Retain, or Re
 | Recycle | PV is deleted and its attached volumes are made to be reused without being deleted. This method has been deprecated. |
 
 <a id="storageclass"></a>
-### Storage Class (StorageClass)
+### Storage Class (StorageClass) { #storageclass }
 A storage class must be defined before provisioning. Storage classes provide a way to classify storages by certain characteristics. You can set the information such as media type and availability zone by including information about the storage provider (provisioner). 
 
+<a id="storageclass-storage-provider-provisioner"></a>
 #### Storage Provider (provisioner)
 Set the provider information of storage. Depending on the Kubernetes version, the supported storage provider information is as follows:
 
 * v1.19.13 or earlier: The provisioner field must be set to `kubernetes.io/cinder`.
 * v1.20.12 or later: You can use the provisioner field by setting it to `cinder.csi.openstack.org`.
 
+<a id="storageclass-parameters-parameter"></a>
 #### Parameters (parameter)
 The storage class allows you to set the following parameters:
 
@@ -3850,18 +3935,21 @@ The storage class allows you to set the following parameters:
     * Pyeongchon region: **kr2-pub-a** or **kr2-pub-b**
     * Gwangju region: **kr3-pub-a** or **kr3-pub-b**    
 
+<a id="storageclass-volume-binding-mode-volumebindingmode"></a>
 #### Volume Binding Mode (VolumeBindingMode)
 A volume binding mode controls the time when volume binding and dynamic provisioning start. This setting is configurable only if the storage provider is cinder.csi.openstack.org. 
 
 * **Immediate**: Volume binding and dynamic provisioning start as soon as a persistent volume claim is created. When the persistent volume claim is created, there is no prior knowledge of the pods to which the volume will be attached. Therefore, if the availability zone of the volume and the availability zone of the node on which the pod will be scheduled are different, the pod will not work properly. 
 * **WaitForFirstConsumer**: Volume binding and dynamic provisioning are not performed when a persistent volume claim is created. When this persistent volume claim is attached to a pod for the first time, volume binding and dynamic provisioning are performed based on the availability zone information of the node on which the pod is scheduled. Therefore, there is no case where the pod does not work properly because the availability zone of the volume and the availability zone of the instance are different, such as in Immediate mode.
 
+<a id="storageclass-allow-volume-expansion-allowvolumeexpansion"></a>
 #### Allow Volume Expansion (allowVolumeExpansion)
 Set whether to allow expansion of the created volume (if not input, false is set).
 
 * **True** : Volume expansion is allowed.
 * **False** : Volume expansion is not allowed.
 
+<a id="storageclass-example-1"></a>
 #### Example 1
 The storage class manifest below can be used for Kubernetes clusters using v1.19.13 or earlier. You can use parameters to specify the availability zone and volume type.
 
@@ -3888,6 +3976,7 @@ NAME     PROVISIONER            RECLAIMPOLICY   VOLUMEBINDINGMODE   ALLOWVOLUMEE
 sc-ssd   kubernetes.io/cinder   Delete          Immediate           false                  3s
 ```
 
+<a id="storageclass-example-2"></a>
 #### Example 2
 The storage class manifest below can be used for Kubernetes clusters using v1.20.12 or later. Set the volume binding mode to WaitForFirstConsumer to initiate volume binding and dynamic provisioning when a persistent volume claim is attached to a pod.
 
@@ -3913,7 +4002,7 @@ csi-storageclass   cinder.csi.openstack.org   Delete          WaitForFirstConsum
 ```
 
 <a id="static-provisioning"></a>
-### Static Provisioning
+### Static Provisioning { #static-provisioning }
 
 Static provisioning requires the user to prepare a block storage manually. On the **Storage > Block Storage** service page of the NHN Cloud web console, click the **Create Block Storage** button to create a block storage to attach to the PV. See [Create Block Storage](/Storage/Block%20Storage/en/console-guide/#create-block-storage) in the Block Storage guide.
 
@@ -3999,7 +4088,7 @@ pv-static-001   10Gi       RWO            Delete           Bound    default/pvc-
 ```
 
 <a id="dynamic-provisioning"></a>
-### Dynamic Provisioning
+### Dynamic Provisioning { #dynamic-provisioning }
 
 With Dynamic Provisioning, block storage is automatically created in reference of attributes defined at storage class. To use Dynamic Provisioning, do not set Volume Binding Mode of storage class or set it to **Immediate**.
 
@@ -4052,7 +4141,7 @@ persistentvolumeclaim/pvc-dynamic   Bound    pvc-1056949c-bc67-45cc-abaa-1d1bd9e
 A block storage created by dynamic provisioning cannot be deleted from the web console. It is not automatically deleted along with a cluster being deleted. Therefore, before a cluster is deleted, all PVCs must be deleted first; otherwise, you may be charged for PVC usage. The reclaimPolicy of PV created by dynamic provisioning is set to `Delete` by default, so deleting only the PVC will also delete the PV and block storage.
 
 <a id="pod-pvc-mount"></a>
-### Mounting PVC to Pods
+### Mounting PVC to Pods { #pod-pvc-mount }
 
 To mount PVC to a pod, mount information must be defined at the pod manifest. Enter the PVC name to use in `spec.volumes.persistenVolumeClaim.claimName`; enter paths to mount in `spec.containers.volumeMounts.mountPath`.
 
@@ -4102,10 +4191,11 @@ Filesystem      Size  Used Avail Use% Mounted on
 You can also check block storage attachment information in the **Storage > Block Storage** service page of the NHN Cloud web console.
 
 <a id="volume-expansion"></a>
-### Volume Expansion
+### Volume Expansion { #volume-expansion }
 You can adjust an existing volume by editing the PersistentVolumeClaim (PVC) object. You can change the volume size by editing the **spec.resources.requests.storage** item of the PVC object. Volume shrinking is not supported. To use the volume expansion feature, the **allowVolumeExpansion** property of StorageClass must be **True**.
 
 
+<a id="volume-expansion-from-v11913-and-older"></a>
 #### Volume Expansion from v1.19.13 and older
 **kubernetes.io/cinder**, the storage provider from v1.19.13 and older does not provide the volume expansion feature for the volume in use. To use the feature for the volume in use, you must use **cinder.csi.openstack.org**, the storage provider from v1.20.12 and later. The cluster upgrade feature allows you to upgrade the version to v1.20.12 or later in order to use the storage provider **cinder.csi.openstack.org**.
 
@@ -4152,14 +4242,15 @@ status:
   phase: Bound
 ```
 
+<a id="volume-expansion-from-v12012-and-older"></a>
 #### Volume Expansion from v1.20.12 and older
 The storage provider **cinder.csi.openstack.org** from v1.20.12 and later supports the expansion of the volume in use by default. You can change the volume size by modifying the **spec.resources.requests.storage** item of the PVC object to a desired value.
 
 <a id="service-integration"></a>
-## Integrate with NHN Cloud Service
+## Integrate with NHN Cloud Service { #service-integration }
 
 <a id="ncr-integration"></a>
-### Integrate with NHN Cloud Container Registry (NCR)
+### Integrate with NHN Cloud Container Registry (NCR) { #ncr-integration }
 You can use images saved at NHN Cloud Container Registry. To use images registered in the registry, first create a secret to login to user registry.
 
 To use NHN Cloud (Old) Container Registry, you need to create a secret as follows:
@@ -4209,12 +4300,13 @@ spec:
 Regarding how to use NHN Cloud Container Registry, see [NHN Cloud Container Registry (NCR) User Guide](/Container/NCR/en/user-guide).
 
 <a id="nas-integration"></a>
-### Integrate with NHN Cloud NAS
+### Integrate with NHN Cloud NAS { #nas-integration }
 You can utilize NAS volume provided by NHN Cloud as PV. In order to use NAS services, you must use a cluster of version v1.20 or later. For more information on using NHN Cloud NAS, please refer to the [NAS Console User Guide](/Storage/NAS/en/console-guide).
 
 > [Note]
 The NHN Cloud NAS service is currently (2024.08) only available in some regions. For more information on supported regions for NHN Cloud NAS service, see [NAS Service Overview](/Storage/NAS/en/overview).
 
+<a id="nas-integration-run-the-rpcbind-service-on-all-worker-nodes"></a>
 #### Run the rpcbind service on All Worker Nodes
 To use NAS volume, you must run the rpcbind service on all worker nodes. After connecting to all worker nodes, run the rpcbind service with the command below.
 
@@ -4232,6 +4324,7 @@ For clusters that are using enforced security rules, you must add security rules
 | egress | TCP | 111 | IPv4 | NAS IP address | portmapper port in rpc, direction: csi-nfs-node(worker node) → NAS |
 | egress | TCP | 635 | IPv4 | NAS IP address |  rpc's mountd port, direction: csi-nfs-node(worker node) → NAS |
 
+<a id="nas-integration-install-csi-driver-nfs"></a>
 #### Install csi-driver-nfs
 To use the NHN Cloud NAS service, you must deploy [nfs-csi-plugin](/Container/NKS/en/user-guide/#addon-mgmt-addon-nfs-csi-plugin) to the cluster using the add-on feature of NHN Kubernetes Service (NKS).
 
@@ -4242,6 +4335,7 @@ If you configure multiple PVs using the nfs-csi-driver, the nfs-csi-driver regis
 <br>
 ![nfs-csi-driver-02.png](http://static.toastoven.net/prod_infrastructure/container/kubernetes/nfs-csi-driver-02.png)
 
+<a id="nas-integration-how-to-use-existing-nhn-cloud-nas-volume-when-provisioning"></a>
 #### How to Use existing NHN Cloud NAS Volume When Provisioning
 You can use existing NAS volume as a PV by entering the NAS information when creating the PV manifest or by entering the NAS information in the StorageClass manifest.
 
@@ -4444,6 +4538,7 @@ Filesystem                                                                 Size 
 ...
 ```
 
+<a id="nas-integration-how-to-create-new-nhn-cloud-nas-volume-when-provisioning"></a>
 #### How to create new NHN Cloud NAS volume when provisioning
 You can use the automatically created NAS volume as a PV by entering the NAS information when creating the StorageClass and PVC manifest.
 
@@ -4615,7 +4710,7 @@ tmpfs                                                                          1
 > In the process of mounting the PV to the pod, not only the subdirectory is mounted, but the entire nfs storage is mounted, so it is not possible to force the application to use the volume by the provisioned size.
 
 <a id="encrypted-block-storage-integration"></a>
-### NHN Cloud Encrypted Block Storage Integration
+### NHN Cloud Encrypted Block Storage Integration { #encrypted-block-storage-integration }
 You can utilize encrypted block storage provided by NHN Cloud as PV. For more information about NHN Cloud encrypted block storage, see [Encrypted Block Storage](/Storage/Block%20Storage/en/console-guide/#_2).
 
 > [Note]
@@ -4626,6 +4721,7 @@ Clusters created before November 28, 2023 can enable encrypted block storage int
 > [Caution]
 If you are using a cluster with a version prior to v1.24.3 without upgrading it and just replacing the cinder-csi-plugin container image, it can cause malfunctions.
 
+<a id="encrypted-block-storage-integration-updating-cinder-csi-plugin-image-for-encrypted-block-storage-integration"></a>
 #### Updating cinder-csi-plugin image for encrypted block storage integration
 You can run the command below to see the tags of the cinder-csi-plugin images currently deployed in your cluster.
 
@@ -4663,6 +4759,7 @@ $ kubectl -n kube-system patch daemonset csi-cinder-nodeplugin -p "{\"spec\": {\
 > The cinder-csi-plugin container image is maintained in NHN Cloud NCR. Since the cluster configured in a closed network environment is not connected to the Internet, it is necessary to configure the environment to use a private URI in order to receive images normally. For information on how to use Private URI, refer to the [NHN Cloud Container Registry (NCR)](/Container/NCR/en/user-guide/#private-uri).
 
 
+<a id="encrypted-block-storage-integration-static-provisioning"></a>
 #### Static Provisioning
 To create a PV, you need the ID of the encrypted block storage. On the Storage > Block Storage service page, select the block storage you want to use from the block storage list. You can find the ID under the block storage name section in the Information tab at the bottom.
 
@@ -4696,6 +4793,7 @@ spec:
 
 The process of creating a PVC manifest and mounting it to a Pod is the same as static provisioning for general block storage. For more information, see [Static Provisioning](/Container/NKS/en/user-guide/#static-provisioning).
 
+<a id="encrypted-block-storage-integration-dynamic-provisioning"></a>
 #### Dynamic Provisioning
 You can use automatically generated encrypted block storage as a PV by entering the information required to create encrypted block storage when creating the storage class manifest.
 
@@ -4729,16 +4827,18 @@ The process of creating a PVC manifest and mounting it to a Pod is the same as d
 
 
 <a id="etcd-encryption-with-skm"></a>
-### Secure Key Manager Service Integration for Secret Data Encryption and Decryption
+### Secure Key Manager Service Integration for Secret Data Encryption and Decryption { #etcd-encryption-with-skm }
 
 NKS cluster encrypts secret resources before storing them in the data store (etcd). NKS offers two distinct methods for encrypting this sensitive data.
 
+<a id="etcd-encryption-with-skm-standard"></a>
 #### Standard
 
 * Automatically generate symmetric keys during cluster creation and stores them in the control plane
 * Encrypt etcd data with the key
 * Key management is handled internally within the cluster
 
+<a id="etcd-encryption-with-skm-skm-integration"></a>
 #### SKM Integration
 
 * Configure Secure Key Manager (SKM) as the storage encryption provider

--- a/en/version-guide.md
+++ b/en/version-guide.md
@@ -1,21 +1,27 @@
-## Container > NHN Kubernetes Service(NKS) > Version Guide
+<!-- pre-align:aligned sig=c2b4f6b0a381 -->
+
+<a id="container-nhn-kubernetes-servicenks-version-guide"></a>
+## Container > NHN Kubernetes Service(NKS) > Version Guide { #container-nhn-kubernetes-servicenks-version-guide }
 
 <a id="cluster-version-management"></a>
-## Manage Cluster Version
+## Manage Cluster Version { #cluster-version-management }
 
 An NKS cluster manages Kubernetes and platform versions for each cluster control plane and worker node group. The differences between the two versions are as follows:
 
-### Kubernetes Version
+<a id="kubernetes-version"></a>
+### Kubernetes Version { #kubernetes-version }
 - A version defined by upstream Kubernetes.
 - It determines the version of the main Kubernetes components that make up the NKS cluster.
 - Main components: `kube-apiserver`, `kube-controller-manager`, `kube-scheduler`, `kubelet`, `kube-proxy`
 
-### Platform Version
+<a id="cluster-version-management-platform-version"></a>
+### Platform Version { #cluster-version-management-platform-version }
 - A version defined at the NKS service level.
 - Multiple components that make up a cluster are defined and managed as a single version.
 - Key components: Control plane components such as `containerd` and `etcd`, key worker node components, various system components, and system management tools.
 
-### Upgrade Targets by Version Status
+<a id="upgrade-targets-by-version-status"></a>
+### Upgrade Targets by Version Status { #upgrade-targets-by-version-status }
 
 | Kubernetes Version Up-to-Date | Platform Version Up-to-Date | Upgrade Target |
 |----------------------------|----------------------|----------------|
@@ -27,14 +33,16 @@ An NKS cluster manages Kubernetes and platform versions for each cluster control
 > Control plane version information can be found on the **View Cluster** screen, and worker node group version information can be found on each **View Worker Node Group** screen.
 
 <a id="support-policy"></a>
-## Support Policy for Kubernetes Version
+## Support Policy for Kubernetes Version { #support-policy }
 
-### Available Cluster Versions
+<a id="available-cluster-versions"></a>
+### Available Cluster Versions { #available-cluster-versions }
 - You can create a new cluster using the three most recent Kubernetes versions released by NKS.
 - When a new version is released, the oldest version from the existing list of available versions will be automatically removed.
 - Kubernetes patch versions may be updated according to internal policies.
 
-### Service Support Policy
+<a id="service-support-policy"></a>
+### Service Support Policy { #service-support-policy }
 To ensure stable service operation, we apply a service support policy for each Kubernetes version.
 
 - NKS service support is determined based on the **Kubernetes version**.
@@ -46,6 +54,7 @@ To ensure stable service operation, we apply a service support policy for each K
 | **Service Support** | Less than about 14 months after the Kubernetes version release | Guaranteed | Possible |
 | **Service Not Supported** | More than about 14 months after the Kubernetes version release | Not Guaranteed | However, upgrade support is provided for 10 months after the end of service support |
 
+<a id="service-support-policy-example-lifecycle-of-version-v133-released-in-november-2025"></a>
 #### Example: Lifecycle of version v1.33 released in November 2025
 
 | Category | Period | Key Features |
@@ -60,21 +69,23 @@ To ensure stable service operation, we apply a service support policy for each K
 
 
 <a id="k8s-version-support-time-table"></a>
-## Schedule for Kubernetes Version-Specific Support 
+## Schedule for Kubernetes Version-Specific Support { #k8s-version-support-time-table }
 
 > [Notice] The Kubernetes version support policy will change starting in November 2025.
 > - The existing schedule and policy will apply up to v1.32.
 > - The new policy will apply starting from v1.33.
 > - The dates in the table are based on UTC+00:00.
 
-### New Policy Applied Version (v1.33 or later)
+<a id="new-policy-applied-version-v133-or-later"></a>
+### New Policy Applied Version (v1.33 or later) { #new-policy-applied-version-v133-or-later }
 
 | Version | Release | End of Service Support (Upgrade Support) | End of Service Support (EOS) |
 |------|--------|---------------------------------|---------------------|
 | v1.33 | November, 2025 | January 31, 2027 | November 30, 2027 |
 | v1.34 | May, 2026 | July 31, 2027 | May 31, 2028 |
 
-### Old Policy Applied Version (v1.32 or earlier)
+<a id="old-policy-applied-version-v132-or-earlier"></a>
+### Old Policy Applied Version (v1.32 or earlier) { #old-policy-applied-version-v132-or-earlier }
 
 | Version | Release | End of Service Support (Upgrade Support) | End of Service Support (EOS) |
 |------|--------|---------------------------------|---------------------|
@@ -85,10 +96,10 @@ To ensure stable service operation, we apply a service support policy for each K
 | v1.32.3 | May 2025 | February 28, 2027 (Planned) | February 28, 2027 (Planned) |
 
 <a id="platform-version"></a>
-## Platform Version
+## Platform Version { #platform-version }
 
 <a id="platform-version-info"></a>
-### Platform Version-Specific Information
+### Platform Version-Specific Information { #platform-version-info }
 
 | Version | Release Date | Kubernetes Compatible Version | Description |
 |------|------------|--------------------|-----|
@@ -99,7 +110,7 @@ To ensure stable service operation, we apply a service support policy for each K
 | 1.202605.0 | 2026.05 | v1.30–v1.34 | Feature Updates<br>- Added support for worker node CGroup v1 → v2 migration<br>- Enabled `ImageVolume` feature gate for Kubernetes v1.34 clusters<br>- Added support for konnectivity for communication between kube-apiserver and pods<br>- Added support for etcd upgrade |
 
 <a id="platform-component-versions"></a>
-### Key component versions by platform version
+### Key component versions by platform version { #platform-component-versions }
 
 | Platform Version | etcd | containerd |
 | :--- | :--- | :--- |
@@ -110,7 +121,7 @@ To ensure stable service operation, we apply a service support policy for each K
 | **1.202605.0** | v3.5.29 | k8s v1.33 or earlier: 1.7.27 </br> k8s v1.34 or later: 2.2.1 |
 
 <a id="platform-version-cgroup-v2-support"></a>
-### Platform version for using CGroup v2 OS images
+### Platform version for using CGroup v2 OS images { #platform-version-cgroup-v2-support }
 * Clusters with a platform version earlier than 1.202602.0 cannot use OS images configured with CGroup v2.
 * The configured CGroup version differs based on the release date of the OS image.
   * Images released before 2026/03/10: CGroup v1

--- a/ja/backup-guide.md
+++ b/ja/backup-guide.md
@@ -1,6 +1,10 @@
-## Container > NHN Kubernetes Service(NKS) > バックアップガイド
+<!-- pre-align:aligned sig=dd3a912dfca5 -->
 
-## 概要
+<a id="container-nhn-kubernetes-service-nks-backup-guide"></a>
+## Container > NHN Kubernetes Service(NKS) > バックアップガイド { #container-nhn-kubernetes-service-nks-backup-guide }
+
+<a id="overview"></a>
+## 概要 { #overview }
 
 NHN Kubernetes Service(NKS)クラスタのバックアップが必要な場合、Veleroプラグインを使用してObject Storageにバックアップできます。
 この文書はObject StorageとVeleroを活用してクラスタをバックアップおよび復元する方法について記述します。
@@ -11,12 +15,15 @@ NHN Kubernetes Service(NKS)クラスタのバックアップが必要な場合�
 
 Veleroの詳細については[Velero Docs](https://velero.io/docs/v1.9/)を参照してください。
 
-## Veleroを利用したクラスタのバックアップと復元
+<a id="cluster-backup-and-restoration-with-velero"></a>
+## Veleroを利用したクラスタのバックアップと復元 { #cluster-backup-and-restoration-with-velero }
 
-### 事前準備
+<a id="prerequisites"></a>
+### 事前準備 { #prerequisites }
 
 Object Storage APIを使用するにはテナントID(tenant ID)およびAPIエンドポイント(endpoint)の確認、APIパスワードの設定、Temporary URL Keyの作成を行う必要があります。
 
+<a id="prerequisites-check-the-tenant-id-and-api-endpoint"></a>
 #### テナントIDおよびAPIエンドポイントの確認
 
 テナントIDとAPIのエンドポイントはObject Storageサービスページの**API Endpoint設定**ボタンをクリックして確認できます。
@@ -26,6 +33,7 @@ Object Storage APIを使用するにはテナントID(tenant ID)およびAPIエ�
 | Identity | https://api-identity-infrastructure.nhncloudservice.com/v2.0 | 認証トークン発行 |
 | Tenant ID | 数字 + 英字で構成された32文字の文字列 | 認証トークン発行 |
 
+<a id="prerequisites-set-an-api-password"></a>
 #### APIパスワード設定
 
 APIパスワードはObject Storageサービスページの**API Endpoint設定**ボタンをクリックして設定できます。
@@ -36,6 +44,7 @@ APIパスワードはObject Storageサービスページの**API Endpoint設定*
 
 Object Storage APIの詳細については[Object Storage APIガイド](/Storage/Object%20Storage/ja/api-guide/)を参照してください。
 
+<a id="prerequisites-create-temporary-url-key"></a>
 #### Temporary URL Keyの作成
 
 Veleroクライアントで`velero log`コマンドを使用するにはObject StorageにTemporary URL Keyを作成する必要があります。
@@ -53,24 +62,28 @@ Veleroクライアントで`velero log`コマンドを使用するにはObject S
 $ curl -X POST {Object Store} -H "X-Auth-Token: {tokenId}" -H "X-Account-Meta-Temp-Url-Key: {key}"
 ```
 
-### Veleroクライアントのインストール
+<a id="install-the-velero-client"></a>
+### Veleroクライアントのインストール { #install-the-velero-client }
 
 Veleroクライアントはクラスタのバックアップおよび復元コマンドを入力するプログラムです。
 Velero GithubリポジトリからVeleroクライアントをダウンロードして、クラスタのバックアップおよび復元に活用できます。ダウンロードしたVeleroクライアントコマンドを実行する前にバックアップおよび復元クラスタのkubeconfigファイルをWebコンソールからダウンロードし、**KUBECONFIG環境変数を設定してバックアップおよび復元対象クラスタを正確に指定**する必要があります。
 kubeconfig設定の詳細については[kubectlインストール](/Container/NKS/ja/user-guide/#kubectl)を参照してください。
 
+<a id="install-the-velero-client-download-the-velero-client"></a>
 #### Veleroクライアントのダウンロード
 
 ```
 $ wget https://github.com/vmware-tanzu/velero/releases/download/v1.17.0/velero-v1.17.0-linux-amd64.tar.gz
 ```
 
+<a id="install-the-velero-client-decompress-the-file"></a>
 #### 解凍
 
 ```
 $ tar xzf velero-v1.17.0-linux-amd64.tar.gz
 ```
 
+<a id="install-the-velero-client-change-the-location-or-set-the-path"></a>
 #### 位置変更またはパス指定
 
 どのパスからでもVeleroクライアントを実行できるように環境変数に指定されたパスに移すか、Veleroがあるパスを環境変数に追加します。
@@ -87,16 +100,19 @@ $ sudo mv velero-v1.17.0-linux-amd64/velero /usr/local/bin
 $ export PATH=$PATH:$(pwd)
 ```
 
-### Veleroサーバーのインストール
+<a id="install-the-velero-server"></a>
+### Veleroサーバーのインストール { #install-the-velero-server }
 
 VeleroサーバーはHelmを利用してインストールします。
 
+<a id="install-the-velero-server-download-helm"></a>
 #### Helmダウンロード
 
 ```
 $ curl -fsSL -o get_helm.sh https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3
 ```
 
+<a id="install-the-velero-server-change-a-permission"></a>
 #### 権限変更
 
 ダウンロードしたファイルは基本的に実行権限がありません。実行権限を追加してください。
@@ -105,12 +121,14 @@ $ curl -fsSL -o get_helm.sh https://raw.githubusercontent.com/helm/helm/main/scr
 $ chmod 700 get_helm.sh
 ```
 
+<a id="install-the-velero-server-install-helm"></a>
 #### Helmインストール
 
 ```
 $ ./get_helm.sh
 ```
 
+<a id="install-the-velero-server-add-the-helm-repository"></a>
 #### Helm Repository追加
 
 VeleroサーバーをインストールするにはHelm Repositoryを追加する必要があります。
@@ -119,6 +137,7 @@ VeleroサーバーをインストールするにはHelm Repositoryを追加す�
 $ helm repo add vmware-tanzu https://vmware-tanzu.github.io/helm-charts
 ```
 
+<a id="install-the-velero-server-2"></a>
 #### Veleroサーバーのインストール
 
 Veleroサーバーは`バックアップクラスタ`と`復元クラスタ`にそれぞれインストールする必要があります。同じObject Storageを使用するには`2つのクラスタに同じhelmコマンド`を使用してインストールすることを推奨します。
@@ -174,10 +193,12 @@ $ helm install velero vmware-tanzu/velero \
 | Region | 韓国(パンギョ)リージョン：`KR1`<br>韓国(坪村)リージョン：`KR2`<br>韓国(クァンジュ)リージョン: `KR3` |
 | OBS endpoint | Object Storage API Endpoint |
 
+<a id="install-the-velero-server-delete-the-velero-server"></a>
 #### Veleroサーバー削除
 Veleroサーバーは`velero uninstall`コマンドで削除できます。
 
-### クラスタのバックアップ
+<a id="back-up-a-cluster"></a>
+### クラスタのバックアップ { #back-up-a-cluster }
 
 クラスタのバックアップは`velero backup create`コマンドで設定できます。
 
@@ -203,7 +224,8 @@ my-backup    Completed   0        0          2025-10-13 11:01:53 +0900 KST   29d
 
 * バックアップされた情報はObject Storageサービスページで確認できます。
 
-### クラスタの復元
+<a id="restore-a-cluster"></a>
+### クラスタの復元 { #restore-a-cluster }
 
 クラスタバックアップ/復元は`velero restore create`コマンドで設定できます。
 
@@ -219,8 +241,10 @@ $ velero restore create --from-backup {name}
 > [注意]
 > `バックアップクラスタ`と`復元クラスタ`のバージョンが異なる場合、復元時に問題が発生する可能性があります。
 
-### 例
+<a id="examples"></a>
+### 例 { #examples }
 
+<a id="examples-example-of-cluster-backup-and-restoration"></a>
 #### クラスタバックアップ/復元例
 
 * バックアップクラスタでvelero backup createコマンドを使用してバックアップします。
@@ -249,6 +273,7 @@ $ velero restore create --from-backup my-backup
 $ kubectl get pod --all-namespaces
 ```
 
+<a id="examples-example-of-setting-periodic-backups"></a>
 #### 定期的バックアップの設定例
 
 `velero schedule create`コマンドで定期的なバックアップを設定できます。詳細については[schedule-a-backup](https://velero.io/docs/v1.17/backup-reference/#schedule-a-backup)を参照してください。
@@ -268,6 +293,7 @@ my-schedule-20251013055022   Completed   0        0          2025-10-13 14:50:22
 my-schedule-20251013054022   Completed   0        0          2025-10-13 14:40:22 +0900 KST   29d       default            <none>
 ```
 
+<a id="examples-example-of-clearing-periodic-backups"></a>
 #### 定期的バックアップ設定の解除例
 `velero schedule delete`コマンドで定期的なバックアップを解除できます。
 

--- a/ja/gateway-api-guide.md
+++ b/ja/gateway-api-guide.md
@@ -1,6 +1,10 @@
-## Container > NHN Kubernetes Service(NKS) > アプリケーションガイド > Gateway API
+<!-- pre-align:aligned sig=091ebaa2b119 -->
 
-### 概要
+<a id="container-nhn-kubernetes-service-nks-application-guide-gateway-api"></a>
+## Container > NHN Kubernetes Service(NKS) > アプリケーションガイド > Gateway API { #container-nhn-kubernetes-service-nks-application-guide-gateway-api }
+
+<a id="overview"></a>
+### 概要 { #overview }
 
 Gateway APIは、Kubernetesでトラフィックルーティングを管理するための次世代標準APIです。従来のIngress APIの限界を克服し、より表現力豊かで拡張可能な方法で、クラスター外部から内部サービスへのHTTP、HTTPS、TCPなど多様なトラフィックをルーティングできます。Gateway APIと関連リソースの詳細は、[Gateway API](https://gateway-api.sigs.k8s.io/)ドキュメントを参照してください。
 
@@ -14,6 +18,7 @@ Gateway APIは多様な実装体をサポートしており、使用環境に応
 
 > [参考] 実装体ごとにサポートするGateway APIのバージョンが異なる場合があるため、詳細は各実装体の公式ドキュメントを参照してください。
 
+<a id="overview-key-gateway-api-resources"></a>
 #### Gateway APIの主要リソース
 
 Gateway APIは役割に応じてリソースを分離し、運営者とアプリケーション開発者が各自の権限範囲内で設定できるように設計されています。
@@ -31,11 +36,13 @@ Gateway APIは役割に応じてリソースを分離し、運営者とアプリ
 
 > [参考] NGFではNginxProxyリソースを通じてNGINX data planeの動作(サービス設定、レプリカ数など)を追加で構成できます。
 
-### NGINX Gateway Fabricのインストール
+<a id="install-nginx-gateway-fabric"></a>
+### NGINX Gateway Fabricのインストール { #install-nginx-gateway-fabric }
 
 NGINX Gateway Fabricのインストールに関する詳細は、[NGINX Gateway Fabricインストールガイド](https://docs.nginx.com/nginx-gateway-fabric/install)ドキュメントを参照してください。
 
-### HTTPルーティングの例
+<a id="http-routing-example"></a>
+### HTTPルーティングの例 { #http-routing-example }
 
 以下は、URIパスに基づいて複数のサービスへトラフィックを分岐する例です。下の図は、`/coffee`と`/tea`パスに応じてそれぞれ異なるサービスへリクエストをルーティングする構造を示しています。
 
@@ -45,6 +52,7 @@ NGINX Gateway Fabricのインストールに関する詳細は、[NGINX Gateway 
                                          └── /tea    → tea-svc    → tea Pod
 ```
 
+<a id="http-routing-example-deploy-services-and-pods"></a>
 #### サービスおよびPodのデプロイ
 
 次のようにサービスとPodを作成するためのマニフェストを作成します。`coffee-svc`サービスには`coffee` Podを、`tea-svc`サービスには`tea` Podを接続します。
@@ -124,6 +132,7 @@ spec:
 kubectl apply -f cafe.yaml
 ```
 
+<a id="http-routing-example-verify-gatewayclass"></a>
 #### GatewayClassの確認
 
 NGINX Gateway Fabricは、Helmでのインストール時に`nginx`という名前のGatewayClassが作成されます。インストール方式によってはGatewayClassが自動作成されない場合があるため、必要に応じて独自に作成する必要があります。
@@ -141,6 +150,7 @@ nginx   gateway.nginx.org/nginx-gateway-controller    True       10s
 
 `ACCEPTED`項目が`True`の場合、GatewayClassが正常に作成されています。
 
+<a id="http-routing-example-create-gateway"></a>
 #### Gatewayの作成
 
 クラスター外部からトラフィックを受信するゲートウェイを作成します。以下のマニフェストは、80番ポートでHTTPトラフィックを受信するゲートウェイを定義します。
@@ -180,6 +190,7 @@ nginx   nginx   123.123.123.44   True         1m
 
 `PROGRAMMED`項目が`True`であり、`ADDRESS`にIPアドレスが割り当てられていることを確認します。
 
+<a id="http-routing-example-create-httproute"></a>
 #### HTTPRouteの作成
 
 パスベースのルーティングルールを定義するHTTPRouteを作成します。以下のマニフェストを作成して適用します。
@@ -216,6 +227,7 @@ spec:
 kubectl apply -f cafe-route.yaml
 ```
 
+<a id="http-routing-example-verify-operation"></a>
 #### 動作確認
 
 外部ホストからゲートウェイのIPアドレスへHTTPリクエストを送信し、ルーティングが正しく設定されているか確認します。
@@ -232,7 +244,8 @@ curl http://${GATEWAY_IP}/tea
 
 `/coffee`パスへのリクエスト時は`coffee-svc`サービスに転送され、`coffee` Podがレスポンスを返します。レスポンスの`Server name`項目を見ると、`coffee` Podがラウンドロビン方式で交互にレスポンスを返していることが確認できます。
 
-### ホストベースのルーティングの例
+<a id="host-based-routing-example"></a>
+### ホストベースのルーティングの例 { #host-based-routing-example }
 
 以下は、リクエストのホスト名(Hostヘッダ)に基づいて異なるサービスへトラフィックを分岐する例です。下の図は、`coffee.example.com`と`tea.example.com`のホスト名に応じてそれぞれ異なるサービスへリクエストをルーティングする構造を示しています。
 
@@ -243,6 +256,7 @@ curl http://${GATEWAY_IP}/tea
 
 サービスおよびPodは、前の例の`cafe.yaml`をそのまま使用します。
 
+<a id="host-based-routing-example-create-httproute"></a>
 #### HTTPRouteの作成
 
 ホスト名ごとにHTTPRouteをそれぞれ作成します。`spec.hostnames`フィールドにルーティングするホスト名を指定します。
@@ -284,6 +298,7 @@ spec:
 kubectl apply -f cafe-route-host.yaml
 ```
 
+<a id="host-based-routing-example-verify-operation"></a>
 #### 動作確認
 
 外部ホストから`--resolve`オプションを使用してホスト名をゲートウェイIPにマッピングし、リクエストを送信します。
@@ -304,7 +319,8 @@ curl --resolve tea.example.com:80:${GATEWAY_IP} \
 
 > [参考] 実際の運用環境では、DNSに各ホスト名がゲートウェイの外部IPとして登録されている必要があります。テスト時は上記のように`--resolve`オプションを使用してホスト名をゲートウェイIPに直接マッピングするか、`/etc/hosts`ファイルにレコードを追加して確認できます。
 
-### ネームスペース間のルーティングの例
+<a id="cross-namespace-routing-example"></a>
+### ネームスペース間のルーティングの例 { #cross-namespace-routing-example }
 
 Gateway APIは、複数のネームスペースにまたがるトラフィックルーティングをサポートします。この例では、`nginx-gateway`ネームスペースにGatewayを、`default`ネームスペースにHTTPRouteを、`app`ネームスペースにServiceをデプロイします。
 
@@ -313,6 +329,7 @@ Gateway APIにおいて、ネームスペース間の参照は次の2つの設�
 * **`allowedRoutes.namespaces`**: GatewayとHTTPRouteのネームスペースが異なる場合に必要です。HTTPRouteが他のネームスペースのGatewayを`parentRef`として参照できるように許可します。
 * **`ReferenceGrant`**: HTTPRouteとバックエンドServiceのネームスペースが異なる場合に必要です。HTTPRouteが他のネームスペースのServiceを`backendRef`として参照できるように許可します。
 
+<a id="cross-namespace-routing-example-deploy-services-and-pods"></a>
 #### サービスおよびPodのデプロイ
 
 例で使用する`app`ネームスペースを作成します。
@@ -327,6 +344,7 @@ kubectl create namespace app
 kubectl apply -f cafe.yaml -n app
 ```
 
+<a id="cross-namespace-routing-example-create-gateway"></a>
 #### Gatewayの作成
 
 `nginx-gateway`ネームスペースにGatewayを作成します。`default`ネームスペースのHTTPRouteがこのGatewayを参照できるように、`allowedRoutes.namespaces.from: All`と設定します。以下のマニフェストを作成して適用します。
@@ -355,6 +373,7 @@ spec:
 kubectl apply -f gateway-cross-ns.yaml
 ```
 
+<a id="cross-namespace-routing-example-create-referencegrant"></a>
 #### ReferenceGrantの作成
 
 `default`ネームスペースのHTTPRouteが`app`ネームスペースのServiceを参照できるように、`ReferenceGrant`を作成します。以下のマニフェストを作成して適用します。
@@ -384,6 +403,7 @@ kubectl apply -f reference-grant.yaml
 
 > [参考] ReferenceGrantリソースは、Gateway API v1.5からv1 APIとして提供されています。使用中のGateway APIバージョンまたは実装体によっては、v1beta1 APIを使用できる場合があります。
 
+<a id="cross-namespace-routing-example-create-httproute"></a>
 #### HTTPRouteの作成
 
 `default`ネームスペースにHTTPRouteを作成します。`parentRef`にGatewayのネームスペース(`nginx-gateway`)を、`backendRef`にServiceのネームスペース(`app`)を明記します。以下のマニフェストを作成して適用します。
@@ -424,6 +444,7 @@ spec:
 kubectl apply -f cafe-route-cross-ns.yaml
 ```
 
+<a id="cross-namespace-routing-example-verify-operation"></a>
 #### 動作確認
 
 以下のコマンドで、ルーティングが正しく設定されているか確認します。
@@ -438,7 +459,8 @@ curl http://${GATEWAY_IP}/coffee
 curl http://${GATEWAY_IP}/tea
 ```
 
-### IngressからGateway APIへのマイグレーション
+<a id="migrate-from-ingress-to-gateway-api"></a>
+### IngressからGateway APIへのマイグレーション { #migrate-from-ingress-to-gateway-api }
 
 `ingress2gateway`はKubernetes SIG-Networkが管理するツールで、既存のIngressリソースをGateway APIリソース(Gateway、HTTPRouteなど)に変換するために使用できます。ただし、全てのIngress設定が完全に変換されるわけではなく、一部の機能は手動での補正が必要になる場合があります。詳細は、[ingress2gateway](https://github.com/kubernetes-sigs/ingress2gateway)ドキュメントを参照してください。
 
@@ -446,10 +468,12 @@ curl http://${GATEWAY_IP}/tea
 
 > [参考] 全てのIngressアノテーションがGateway APIに変換されるわけではありません。変換後にサポートされないアノテーションがある場合は警告メッセージが出力されます。詳細は、[サポートプロバイダー一覧](https://github.com/kubernetes-sigs/ingress2gateway?tab=readme-ov-file#supported-providers)を参照してください。
 
+<a id="migrate-from-ingress-to-gateway-api-install-ingress2gateway"></a>
 #### ingress2gatewayのインストール
 
 ingress2gatewayのインストールに関する詳細は、[ingress2gatewayインストールガイド](https://github.com/kubernetes-sigs/ingress2gateway?tab=readme-ov-file#installation)ドキュメントを参照してください。
 
+<a id="migrate-from-ingress-to-gateway-api-convert-ingress-resources"></a>
 #### Ingressリソースの変換
 
 現在クラスターにデプロイされているIngressリソースをGateway APIリソースに変換します。`--providers`オプションで使用中のIngressコントローラーを指定し、`-A`オプションで全てのネームスペースのリソースを変換します。変換結果をファイルとして保存するには、以下のコマンドを使用します。
@@ -470,6 +494,7 @@ kubectl get ingress -A -o yaml > /path/to/ingress.yaml
 ingress2gateway print --providers=ingress-nginx --input-file /path/to/ingress.yaml > gateway-resources.yaml
 ```
 
+<a id="migrate-from-ingress-to-gateway-api-conversion-example"></a>
 #### 変換例
 
 以下は変換前のIngressリソースと変換後のGateway APIリソースの例です。
@@ -553,6 +578,7 @@ status:
 
 > [参考] 変換されたリソースの`gatewayClassName`は既存のIngressクラス名(`nginx`)をそのまま使用します。先ほどインストール時に指定したGatewayClass名と一致するか確認してください。
 
+<a id="migrate-from-ingress-to-gateway-api-apply-conversion-results"></a>
 #### 変換結果の適用
 
 変換されたリソースを検討した後、クラスターに適用します。

--- a/ja/istio-guide.md
+++ b/ja/istio-guide.md
@@ -1,14 +1,20 @@
-## Container > NHN Kubernetes Service(NKS) > 外部サービス連動ガイド > Istio
+<!-- pre-align:aligned sig=f2738c580f82 -->
 
-### 概要
+<a id="container-nhn-kubernetes-service-nks-application-guide-istio"></a>
+## Container > NHN Kubernetes Service(NKS) > 外部サービス連動ガイド > Istio { #container-nhn-kubernetes-service-nks-application-guide-istio }
+
+<a id="overview"></a>
+### 概要 { #overview }
 この文書はユーザーがNKS(NHN Kubernetes Service(NKS)クラスタにIstioを構成してテストできる例について説明したガイド文書です。NKSでは、インターネットに接続されていないクラスタでもIstioを構成できるように、ガイドとNCRレジストリを通じたIstioイメージを提供しています。ユーザーはこのガイド文書を通じてNKSが提供するイメージを使用してIstioを構成したり、Istio公式ガイド文書を参考にして直接Istioを構成できます。
 
-### Istio
+<a id="istio"></a>
+### Istio { #istio }
 サービスメッシュ(Service Mesh)は、分散システムでサービス間の通信を制御し、効率的に管理できるようにすることに特化したマイクロサービスのためのインフラ層です。
 Istioはよく使われるオープンソースのサービスメッシュの一つです。 この例では、クラスタにdemoプロファイルのIstioサービスを配布した後、動作することを示します。Istioの詳細は[Istio](https://istio.io/latest/about/service-mesh/)を参照してください。
 
 
-### Istio 配布のための事前準備
+<a id="prerequisites-for-istio-deployment"></a>
+### Istio 配布のための事前準備 { #prerequisites-for-istio-deployment }
 配布するIstioのバージョンとクラスタに合う正しいレジストリ情報を確認した後、変数に指定します。設定した変数は以降の配布過程で使用されます。
 
 ```
@@ -16,6 +22,7 @@ $ VERSION="{ダウンロードするistioのバージョン}"
 $ REGISTRY="{リージョン別レジストリ}"
 ```
 
+<a id="prerequisites-for-istio-deployment-supported-kubernetes-versions-by-istio-version"></a>
 #### IstioのバージョンごとにサポートされるKubernetesのバージョン
 
 | バージョン | サポートされるKubernetesバージョン |
@@ -27,6 +34,7 @@ $ REGISTRY="{リージョン別レジストリ}"
 > NKSは上記の表に記載されたIstioのバージョンに対してのみインストールを提供します。NKSが提供しないバージョンを使用するには、ユーザーが直接Istioを構成する必要があります。 サポートされるIstioバージョンに関する情報は[istioサポートポリシー](https://istio.io/latest/docs/releases/supported-releases/)を参考してください。
 
 
+<a id="prerequisites-for-istio-deployment-registry-information-by-region-and-internet-environment"></a>
 #### リージョン及びインターネット環境別レジストリ情報
 | リージョン | インターネット接続 | レジストリ |
 | --- | --- | --- |
@@ -41,6 +49,7 @@ $ REGISTRY="{リージョン別レジストリ}"
 > インターネットに接続されていないクラスタがNCRレジストリを使用するためには、Private URIを使用するための環境設定が必要です。Private URIの使用方法の詳細は[NHN Cloud Container Registry(NCR)ユーザーガイド](/Container/NCR/ja/user-guide/#private-uri)を参照してください。
 
 
+<a id="prerequisites-for-istio-deployment-install-the-oras-command-line-tool"></a>
 #### ORASコマンドラインツールのインストール
 アーティファクトをpullするためにORAS(OCI Registry As Storage)コマンドラインツールをダウンロードします。ORASはOCIレジストリでOCIアーティファクトをpushおよびpullする方法を提供するツールです。
 下記のコマンドを実行してORASコマンドラインツールをインストールします。ORASコマンドラインツールの詳しい使い方は[ORAS docs](https://oras.land/docs/)を参照してください。
@@ -56,8 +65,10 @@ $ export PATH="/usr/local/bin:$PATH"
 ```
 
 
-### Istioのインストール
+<a id="install-istio"></a>
+### Istioのインストール { #install-istio }
 
+<a id="install-istio-download-and-install-istioctl-using-the-oras-command-line-tool"></a>
 #### 1. ORASコマンドラインツールを使ってistioctlをダウンロードしてインストールします。
 istioctlはIstioが提供するサービスメッシュディストリビューションをデバッグして診断することができる構成コマンドラインユーティリティで、Istioディストリビューション構成オプションの設定など多様な機能を提供します。istioctlの詳しい説明は[istioctl](https://istio.io/latest/docs/reference/commands/istioctl/)を参照してください。
 
@@ -69,6 +80,7 @@ $ cd istio-${VERSION}
 $ export PATH=$PWD/bin:$PATH
 ```
 
+<a id="install-istio-deploy-istio-components-using-istioctl"></a>
 #### 2. istioctlを使用してIstioコンポーネントを配布します。
 プロファイルは、Istioコントロールプレーンとデータプレーンのサイドカーのユーザー定義配布機能を提供します。設定されたプロファイルによって、配布時に有効化されるコンポーネントが異なります。ユーザーはクラスタの環境構成に応じて基本提供されるプロファイルを使用するか、特定の要求に合わせて構成をユーザー定義できます。 Istioプロファイルの詳しい説明は[Istioインストール構成プロファイル](https://istio.io/latest/docs/setup/additional-setup/config-profiles/)を参照してください。この例では、基本的に提供されるdemoプロファイルを使用して配布します。
 
@@ -158,9 +170,11 @@ replicaset.apps/istio-ingressgateway-b8844867c   1         1         1       86s
 replicaset.apps/istiod-8c7fbbdc8                 1         1         1       90s
 ```
 
-### アプリケーション配布
+<a id="deploy-application"></a>
+### アプリケーション配布 { #deploy-application }
 Istioが正常にインストールされ、動作することを確認するためアプリケーションを配布します。この例では、Istioが基本的に提供するBookinfoサンプルアプリケーションを使います。サンプルアプリケーションはproductpage, details, reviews, ratingsの4つのマイクロサービスで構成されています。Bookinfoサンプルアプリケーションの詳細は[Istio Bookinfo Application](https://istio.io/latest/docs/examples/bookinfo/)を参照してください。
 
+<a id="deploy-application-label-namespace"></a>
 #### 1. 名前空間にラベルを指定する
 Istioサイドカープロキシを使用するためには、Podが作成される名前空間にラベルを指定する必要があります。ラベルはIstioコンポーネントを配布する名前空間を識別するために使用されます。ラベルが設定された名前空間にPodが配布されると、Istioサイドカープロキシが自動的にPodに配布されます。
 
@@ -170,6 +184,7 @@ $ kubectl label namespace default istio-injection=enabled
 namespace/default labeled
 ```
 
+<a id="deploy-application-components"></a>
 #### 2. アプリケーションコンポーネント配布する
 アプリケーションコンポーネントを配布し、正常に配布されたか確認します。
 
@@ -217,9 +232,11 @@ $ kubectl exec "$(kubectl get pod -l app=ratings -o jsonpath='{.items[0].metadat
 <title>Simple Bookstore App</title>
 ```
 
-### サービス表示
+<a id="expose-service"></a>
+### サービス表示 { #expose-service }
 上のプロセスまで実行した時、サービスはクラスタ内のホストだけアクセスできる`ClusterIP`の形で設定されています。 Kubernetesではサービスを公開するために`NodePort`、`LoadBalancer`など様々なタイプの`Service`オブジェクトを提供していますが、Istioではより幅広い範囲のネットワークトラフィックを処理するためのgatewayオブジェクトを提供しています。下記の例ではIstioが基本的に提供するサンプルbookinfo gatewayを使用してサービスを公開する過程を示しています。Istio gatewayの詳しい説明は[Istio Gateway](https://istio.io/latest/docs/concepts/traffic-management/#gateways)を参照してください。
 
+<a id="expose-service-configure-ingress-gateway"></a>
 #### イングレスゲートウェイを構成する
 サービスを公開するためのIstioイングレスゲートウェイを追加で構成します。
 
@@ -236,6 +253,7 @@ $ istioctl analyze
 ✔ No validation issues found when analyzing namespace: default.
 ```
 
+<a id="expose-service-access-service"></a>
 #### サービスにアクセスする
 公開されたサービスにアクセスするため、ゲートウェイURL情報を確認します。ゲートウェイURLは基本的に`イングレスホスト:イングレスIP`の構成になっています。クラスタがインターネット上またはクローズドネットワーク環境に構成されたかによって、ゲートウェイURL情報を確認する方法が異なります。インターネット上に構成されたクラスタはロードバランサーの `EXTERNAL-IP` 情報に基づいてゲートウェイ URL が構成され、クローズドネットワーク環境に構成されたクラスタはノードポートに基づいてゲートウェイ URL が構成されます。
 
@@ -271,7 +289,8 @@ $ curl http://114.110.160.79:80/productpage
 ```
 
 
-### Istio削除
+<a id="delete-istio"></a>
+### Istio削除 { #delete-istio }
 下記のコマンドを実行して例題で使ったbookinfoアプリケーション関連コンポーネントを削除します。
 ```
 $ kubectl delete -f samples/bookinfo/networking/bookinfo-gateway.yaml

--- a/ja/overview.md
+++ b/ja/overview.md
@@ -1,7 +1,11 @@
-## Container > NHN Kubernetes Service(NKS) > 概要
+<!-- pre-align:aligned sig=380a0a4ca9e2 -->
+
+<a id="container-nhn-kubernetes-service-nks-overview"></a>
+## Container > NHN Kubernetes Service(NKS) > 概要 { #container-nhn-kubernetes-service-nks-overview }
 ここではKubernetesとは何か、そしてNHN Cloudで提供するNHN Kubernetes Service(NKS)について説明します。
 
-## Kubernetes
+<a id="kubernetes"></a>
+## Kubernetes { #kubernetes }
 Kubernetesは、コンテナ化されたワークロードとサービスを管理できるオープンソースのプラットフォームです。Kubernetesは次のような機能を提供します。
 
 * サービスディスカバリーとロードバランシング
@@ -15,20 +19,25 @@ Kubernetesは、コンテナ化されたワークロードとサービスを管�
 
 * [Kubernetesとは？](https://kubernetes.io/docs/concepts/overview/)
 
-## Kubernetesクラスター
+<a id="kubernetes-cluster"></a>
+## Kubernetesクラスター { #kubernetes-cluster }
 Kubernetesクラスターは、相互に接続されて1つのユニットのように動作するコンピュータクラスターです。Kubernetesが提供する機能はクラスター単位で動作し、クラスター単位で設定できます。
 
-### 構成
+<a id="configuration"></a>
+### 構成 { #configuration }
 Kubernetesクラスターはコントロールプレーンとノードで構成されます。
 
+<a id="configuration-control-plane"></a>
 #### コントロールプレーン
 コントロールプレーンはクラスターの管理を担当します。アプリケーションをスケジューリングしたり、スケーリング、アップデートなど、クラスター内の全ての活動を管理します。一般的にコントロールプレーンのコンポーネントは別のマシン(仮想または物理マシン)で起動します。高可用性を保障するために、1つのクラスターに複数のコントロールプレーンコンポーネントを構成することもできます。
 
+<a id="configuration-node"></a>
 #### ノード
 ノードは、ユーザーのアプリケーションが起動するワーカーマシンです。1つのクラスターには複数のノードが存在できます。ノードはコントロールプレーンと接続すると動作します。コントロールプレーンのアプリケーション起動、停止などのコマンドに応じてそのまま実行します。
 
 
-## NHN Kubernetes Service(NKS)
+<a id="nhn-kubernetes-service-nks"></a>
+## NHN Kubernetes Service(NKS) { #nhn-kubernetes-service-nks }
 NHN Kubernetes Service(NKS)は、クラウドでKubernetesを正しく安全に起動できるようにKubernetesクラスターを作成し、管理できるサービスです。ユーザーはWebコンソールを利用してNHN Cloudに最適なKubernetesクラスターを作成し、管理できます。安全かつ効率的に運営を行えるように、コントロールプレーンはNHN Cloudで管理し、ユーザーはノードとサービス、 Pod(ポッド)などを管理します。
 
 NHN Kubernetes Service(NKS)の主な機能は次のとおりです。

--- a/ja/public-api.md
+++ b/ja/public-api.md
@@ -1,4 +1,5 @@
-## Container > NHN Kubernetes Service(NKS) > API v2ガイド
+<a id="container-nhn-kubernetes-service-nks-api-v2-guide"></a>
+## Container > NHN Kubernetes Service(NKS) > API v2ガイド { #container-nhn-kubernetes-service-nks-api-v2-guide }
 
 Kubernetesクラスタを構成するためのAPIを記述します。
 NKSは、API呼び出し時の認証/認可のためにIaaSトークンを使用します。IaaSトークンは、NHN CloudのOpenStackベースのインフラサービス(IaaS)で使用する認証トークンです。IaaSトークンの発行及び使用に関する詳細は、[IaaSトークン](/nhncloud/ja/public-api/iaas-token)を参照してください。
@@ -12,11 +13,13 @@ NKSは、API呼び出し時の認証/認可のためにIaaSトークンを使用
 
 APIレスポンスにガイドに明示されていないフィールドが表示されることがあります。これらのフィールドはNHN Cloud内部用途で使用され、予告なしに変更されることがあるため使用しません。
 
-## APIに使用されるリソース情報の確認
+<a id="check-the-information-of-resources-used-in-api"></a>
+## APIに使用されるリソース情報の確認 { #check-the-information-of-resources-used-in-api }
 
 NHN Kubernetes Service(NKS)APIは、クラスタおよびノードグループを構成するために複数のリソースを使用します。各リソースの情報確認方法は次のとおりです。
 
-### インターネットゲートウェイに接続されたVPCネットワークUUID
+<a id="uuid-of-the-vpc-network-attached-to-the-internet-gateway"></a>
+### インターネットゲートウェイに接続されたVPCネットワークUUID { #uuid-of-the-vpc-network-attached-to-the-internet-gateway }
 
 インターネットゲートウェイに接続されたVPCネットワークは、VPCネットワークリスト照会APIに**router:external=True**クエリパラメータを利用して照会できます。
 
@@ -27,44 +30,54 @@ GET /v2.0/networks?router:external=True
 ネットワークリスト照会APIの詳細については、[ネットワークリスト表示](/Network/VPC/ja/public-api/#_2)を参照してください。
 
 
-### インターネットゲートウェイに接続されたサブネットUUIDリスト
+<a id="list-of-uuids-of-subnets-attached-to-the-internet-gateway"></a>
+### インターネットゲートウェイに接続されたサブネットUUIDリスト { #list-of-uuids-of-subnets-attached-to-the-internet-gateway }
 
 インターネットゲートウェイに接続されたVPCネットワークに接続されたサブネットUUIDを入力します。複数のサブネットが検索された場合はコロン(`:`)でつなげて入力します。サブネットリスト照会APIの詳細については、[サブネットリスト表示](/Network/VPC/ja/public-api/#vpc_7)を参照してください。
 
 
-### VPCネットワークUUID
+<a id="vpc-network-uuid"></a>
+### VPCネットワークUUID { #vpc-network-uuid }
 
 ノードと接続する内部VPCネットワークUUIDを入力します。ネットワークリスト照会APIの詳細については[ネットワークリスト表示](/Network/VPC/ja/public-api/#vpc_1)を参照してください。
 
-### VPCサブネットUUID
+<a id="vpc-subnet-uuid"></a>
+### VPCサブネットUUID { #vpc-subnet-uuid }
 
 ノードと接続する内部VPCネットワークに接続されたサブネットUUIDを入力します。サブネットリスト照会APIの詳細については[サブネットリスト表示](/Network/VPC/ja/public-api/#vpc_7)を参照してください。
 
-### アベイラビリティゾーンUUID
+<a id="availability-zone-uuid"></a>
+### アベイラビリティゾーンUUID { #availability-zone-uuid }
 
 ノードを作成するアベイラビリティゾーンUUIDを入力します。アベイラビリティゾーンリスト照会APIの詳細については[可用性リスト表示](/Compute/Instance/ja/public-api/#_9)を参照してください。
 
-### キーペアUUID
+<a id="key-pair-uuid"></a>
+### キーペアUUID { #key-pair-uuid }
 
 ノード接続時に使用するキーペアを入力します。キーペアリスト照会APIの詳細については[キーペアリスト表示](/Compute/Instance/ja/public-api/#_13)を参照してください。
 
-### ベースイメージUUID
+<a id="base-image-uuid"></a>
+### ベースイメージUUID { #base-image-uuid }
 
 ノードの作成に使用するベースイメージのUUIDを入力します。NKSノードの作成に使用されるベースイメージだけをフィルタリングするため、API呼び出し時にクエリ文字列パラメータに`nhncloud_allow_nks_cpu_flavor=true&visibility=public`を入力します。ベースイメージリスト照会APIの詳細については、[イメージリスト照会](/Compute/Image/ja/public-api/#_2)を参照してください。
 
-### ブロックストレージの種類
+<a id="block-storage-type"></a>
+### ブロックストレージの種類 { #block-storage-type }
 
 ノードに使用するブロックストレージUUIDを入力します。ブロックストレージタイプリスト照会APIの詳細については[ボリュームタイプリスト表示](/Storage/Block%20Storage/ja/public-api/#_2)を参照してください。
 
-### インスタンスタイプUUID
+<a id="flavor-uuid"></a>
+### インスタンスタイプUUID { #flavor-uuid }
 
 作成するノードのインスタンスタイプUUIDを入力します。インスタンスタイプリスト照会APIの詳細については[インスタンスタイプリスト表示](/Compute/Instance/ja/public-api/#_2)を参照してください。
 
 
 
-## クラスタ
+<a id="cluster"></a>
+## クラスタ { #cluster }
 
-### クラスタリスト表示
+<a id="list-clusters"></a>
+### クラスタリスト表示 { #list-clusters }
 
 クラスタリストを照会します。
 
@@ -76,6 +89,7 @@ OpenStack-API-Version: container-infra latest
 X-Auth-Token: {tokenId}
 ```
 
+<a id="list-clusters-request"></a>
 #### リクエスト
 
 このAPIはリクエスト本文を要求しません。
@@ -84,6 +98,7 @@ X-Auth-Token: {tokenId}
 |---|---|---|---|---|
 | tokenId | Header | String | O | トークンID |
 
+<a id="list-clusters-response"></a>
 #### レスポンス
 
 | 名前 | 種類 | 形式 | 説明 |
@@ -188,7 +203,8 @@ X-Auth-Token: {tokenId}
 
 ---
 
-### クラスタ表示
+<a id="get-a-cluster"></a>
+### クラスタ表示 { #get-a-cluster }
 
 個別クラスタ情報を照会します。
 
@@ -200,6 +216,7 @@ OpenStack-API-Version: container-infra latest
 X-Auth-Token: {tokenId}
 ```
 
+<a id="get-a-cluster-request"></a>
 #### リクエスト
 
 このAPIはリクエスト本文を要求しません。
@@ -209,6 +226,7 @@ X-Auth-Token: {tokenId}
 | tokenId | Header | String | O | トークンID |
 | CLUSTER_ID_OR_NAME| URL | UUID or String | O | クラスタUUIDまたはクラスタ名 |
 
+<a id="get-a-cluster-response"></a>
 #### レスポンス
 
 | 名前 | 種類 | 形式 | 説明 |
@@ -334,7 +352,8 @@ X-Auth-Token: {tokenId}
 
 ---
 
-### 作業履歴リストの表示
+<a id="view-task-history-list"></a>
+### 作業履歴リストの表示 { #view-task-history-list }
 
 クラスタの作業履歴リストを照会します。
 
@@ -346,6 +365,7 @@ OpenStack-API-Version: container-infra latest
 X-Auth-Token: {tokenId}
 ```
 
+<a id="view-task-history-list-request"></a>
 #### リクエスト
 
 このAPIはリクエスト本文を要求しません。
@@ -356,6 +376,7 @@ X-Auth-Token: {tokenId}
 | CLUSTER_UUID | URL | UUID | O | クラスタUUID |
 
 
+<a id="view-task-history-list-response"></a>
 #### レスポンス
 
 | 名前 | 種類 | 形式 | 説明 |
@@ -407,7 +428,8 @@ X-Auth-Token: {tokenId}
 
 ---
 
-### 作業履歴の表示
+<a id="list-task-history"></a>
+### 作業履歴の表示 { #list-task-history }
 
 クラスタの作業履歴を照会します。
 
@@ -419,6 +441,7 @@ OpenStack-API-Version: container-infra latest
 X-Auth-Token: {tokenId}
 ```
 
+<a id="list-task-history-request"></a>
 #### リクエスト
 
 このAPIはリクエスト本文を要求しません。
@@ -430,6 +453,7 @@ X-Auth-Token: {tokenId}
 | EVENT_UUID | URL | UUID | O | 作業UUID |
 
 
+<a id="list-task-history-response"></a>
 #### レスポンス
 
 | 名前 | 種類 | 形式 | 説明 |
@@ -476,7 +500,8 @@ X-Auth-Token: {tokenId}
 
 ---
 
-### クラスタ作成
+<a id="create-a-cluster"></a>
+### クラスタ作成 { #create-a-cluster }
 
 クラスタを作成します。
 
@@ -488,6 +513,7 @@ OpenStack-API-Version: container-infra latest
 X-Auth-Token: {tokenId}
 ```
 
+<a id="create-a-cluster-request"></a>
 #### リクエスト
 
 | 名前 | 種類 | 形式 | 必須 | 説明 |
@@ -627,6 +653,7 @@ X-Auth-Token: {tokenId}
 </p>
 </details>
 
+<a id="create-a-cluster-response"></a>
 #### レスポンス
 
 | 名前 | 種類 | 形式 | 説明 |
@@ -647,7 +674,8 @@ X-Auth-Token: {tokenId}
 
 ---
 
-### クラスタ削除
+<a id="delete-a-cluster"></a>
+### クラスタ削除 { #delete-a-cluster }
 
 クラスタを削除します。
 
@@ -659,6 +687,7 @@ OpenStack-API-Version: container-infra latest
 X-Auth-Token: {tokenId}
 ```
 
+<a id="delete-a-cluster-request"></a>
 #### リクエスト
 
 このAPIはリクエスト本文を要求しません。
@@ -669,13 +698,15 @@ X-Auth-Token: {tokenId}
 | CLUSTER_ID_OR_NAME | URL | UUID or String | O | クラスタUUIDまたはクラスタ名 | 
 
 
+<a id="delete-a-cluster-response"></a>
 #### レスポンス
 
 このAPIはレスポンス本文を返しません。
 
 ---
 
-### リサイズ
+<a id="resize"></a>
+### リサイズ { #resize }
 
 クラスタのノード数を調整します。
 
@@ -687,6 +718,7 @@ OpenStack-API-Version: container-infra latest
 X-Auth-Token: {tokenId}
 ```
 
+<a id="resize-request"></a>
 #### リクエスト
 
 | 名前 | 種類 | 形式 | 必須 | 説明 |
@@ -733,6 +765,7 @@ X-Auth-Token: {tokenId}
 
 
 
+<a id="resize-response"></a>
 #### レスポンス
 
 | 名前 | 種類 | 形式 | 説明 |
@@ -754,7 +787,8 @@ X-Auth-Token: {tokenId}
 
 ---
 
-### クラスタkubeconfig照会
+<a id="get-kubeconfig-of-a-cluster"></a>
+### クラスタkubeconfig照会 { #get-kubeconfig-of-a-cluster }
 
 クラスタ設定ファイル(kubeconfig)を照会します。
 
@@ -766,6 +800,7 @@ OpenStack-API-Version: container-infra latest
 X-Auth-Token: {tokenId}
 ```
 
+<a id="get-kubeconfig-of-a-cluster-request"></a>
 #### リクエスト
 
 このAPIはリクエスト本文を要求しません。
@@ -776,6 +811,7 @@ X-Auth-Token: {tokenId}
 | CLUSTER_ID_OR_NAME | URL | UUID or String | O | クラスタUUIDまたはクラスタ名 | 
 
 
+<a id="get-kubeconfig-of-a-cluster-response"></a>
 #### レスポンス
 
 | 名前 | 種類 | 形式 | 説明 |
@@ -796,7 +832,8 @@ X-Auth-Token: {tokenId}
 </details>
 
 
-### クラスタAPIエンドポイントIPアクセス制御適用
+<a id="enforce-ip-access-control-to-cluster-api-endpoints"></a>
+### クラスタAPIエンドポイントIPアクセス制御適用 { #enforce-ip-access-control-to-cluster-api-endpoints }
 クラスタAPIエンドポイントにIPアクセス制御を適用または解除できます。
 IPアクセス制御機能の詳細については、 [IPアクセス制御](/Network/Load%20Balancer/ja/overview/#ip)文書を参照してください。
 クラスタAPIエンドポイントへのIPアクセス制御ルールに関する詳細については、 [ユーザーガイド](/Container/NKS/ja/user-guide/#api_endpoint_ipacl)を参照してください。
@@ -809,6 +846,7 @@ OpenStack-API-Version: container-infra latest
 X-Auth-Token: {tokenId}
 ```
 
+<a id="enforce-ip-access-control-to-cluster-api-endpoints-request"></a>
 #### リクエスト
 
 | 名前 | 種類 | 形式 | 必須 | 説明 |
@@ -845,6 +883,7 @@ X-Auth-Token: {tokenId}
 </details>
 
 
+<a id="enforce-ip-access-control-to-cluster-api-endpoints-response"></a>
 #### レスポンス
 
 | 名前 | 種類 | 形式 | 説明 |
@@ -864,7 +903,8 @@ X-Auth-Token: {tokenId}
 </details>
 
 
-### クラスタAPIエンドポイントのIPアクセス制御照会
+<a id="get-cluster-api-endpoint-ip-access-control"></a>
+### クラスタAPIエンドポイントのIPアクセス制御照会 { #get-cluster-api-endpoint-ip-access-control }
 クラスタAPIエンドポイントに適用されたIPアクセス制御情報を確認できます。
 
 ```
@@ -875,6 +915,7 @@ OpenStack-API-Version: container-infra latest
 X-Auth-Token: {tokenId}
 ```
 
+<a id="get-cluster-api-endpoint-ip-access-control-request"></a>
 #### リクエスト
 このAPIはリクエスト本文を要求しません。
 
@@ -884,6 +925,7 @@ X-Auth-Token: {tokenId}
 | CLUSTER_ID_OR_NAME | URL | UUID or String | O | クラスタUUIDまたはクラスタ名 | 
 
 
+<a id="get-cluster-api-endpoint-ip-access-control-response"></a>
 #### レスポンス
 
 | 名前 | 種類 | 形式 | 説明 |
@@ -932,7 +974,8 @@ X-Auth-Token: {tokenId}
 </details>
 
 ---
-### クラスタ証明書の更新
+<a id="renew-cluster-certificate"></a>
+### クラスタ証明書の更新 { #renew-cluster-certificate }
 
 クラスタの証明書を更新します。
 ```
@@ -943,6 +986,7 @@ OpenStack-API-Version: container-infra latest
 X-Auth-Token: {tokenId}
 ```
 
+<a id="renew-cluster-certificate-name"></a>
 #### リクエスト
 | 名前 | 種類 | 形式 | 必須 | 説明 |
 |---|---|---|---|---|
@@ -962,6 +1006,7 @@ X-Auth-Token: {tokenId}
 </p>
 </details>
 
+<a id="renew-cluster-certificate-response"></a>
 #### レスポンス
 
 | 名前 | 種類 | 形式 | 説明 |
@@ -983,7 +1028,8 @@ X-Auth-Token: {tokenId}
 
 ---
 
-### サービスゲートウェイを変更する
+<a id="change-service-gateway"></a>
+### サービスゲートウェイを変更する { #change-service-gateway }
 
 クラスタ作成時、サービスゲートウェイを設定した場合、他のサービスゲートウェイに変更できます。
 ```
@@ -994,6 +1040,7 @@ OpenStack-API-Version: container-infra latest
 X-Auth-Token: {tokenId}
 ```
 
+<a id="change-service-gateway-request"></a>
 #### リクエスト
 
 | 名前 | 種類 | 形式 | 必須 | 説明 |
@@ -1016,6 +1063,7 @@ X-Auth-Token: {tokenId}
 </p>
 </details>
 
+<a id="change-service-gateway-response"></a>
 #### レスポンス
 
 | 名前 | 種類 | 形式 | 説明 |
@@ -1037,7 +1085,8 @@ X-Auth-Token: {tokenId}
 
 ---
 
-### コントロールプレーンKubernetesコンポーネントログ保存
+<a id="store-logs-of-kubernetes-control-plane-components"></a>
+### コントロールプレーンKubernetesコンポーネントログ保存 { #store-logs-of-kubernetes-control-plane-components }
 NHN Kubernetes Service(NKS)のコントロールプレーンで実行中の主要KubernetesコンポーネントのログをLog & Crash SearchまたはObject Storageに保存します。
 
 ```
@@ -1048,6 +1097,7 @@ OpenStack-API-Version: container-infra latest
 X-Auth-Token: {tokenId}
 ```
 
+<a id="store-logs-of-kubernetes-control-plane-components-name"></a>
 #### リクエスト
 
 | 名前 | 種類 | 形式 | 必須 | 説明 |
@@ -1121,6 +1171,7 @@ X-Auth-Token: {tokenId}
 </p>
 </details>
 
+<a id="store-logs-of-kubernetes-control-plane-components-type"></a>
 #### レスポンス
 
 | 名前 | 種類 | 形式 | 説明 |
@@ -1140,9 +1191,11 @@ X-Auth-Token: {tokenId}
 </details>
 
 
-## ノードグループ
+<a id="node-group"></a>
+## ノードグループ { #node-group }
 
-### ノードグループリスト表示
+<a id="list-node-groups"></a>
+### ノードグループリスト表示 { #list-node-groups }
 
 ノードグループリストを照会します。
 
@@ -1154,6 +1207,7 @@ OpenStack-API-Version: container-infra latest
 X-Auth-Token: {tokenId}
 ```
 
+<a id="list-node-groups-request"></a>
 #### リクエスト
 
 このAPIはリクエスト本文を要求しません。
@@ -1164,6 +1218,7 @@ X-Auth-Token: {tokenId}
 | CLUSTER_ID_OR_NAME | URL | UUID or String | O | クラスタUUIDまたはクラスタ名 | 
 
 
+<a id="list-node-groups-response"></a>
 #### レスポンス
 
 | 名前 | 種類 | 形式 | 説明 |
@@ -1208,7 +1263,8 @@ X-Auth-Token: {tokenId}
 
 ---
 
-### ノードグループ表示
+<a id="get-a-node-group"></a>
+### ノードグループ表示 { #get-a-node-group }
 
 個別ノードグループ情報を照会します。
 
@@ -1220,6 +1276,7 @@ OpenStack-API-Version: container-infra latest
 X-Auth-Token: {tokenId}
 ```
 
+<a id="get-a-node-group-request"></a>
 #### リクエスト
 
 このAPIはリクエスト本文を要求しません。
@@ -1230,6 +1287,7 @@ X-Auth-Token: {tokenId}
 | CLUSTER_ID_OR_NAME | URL | UUID or String | O | クラスタUUIDまたはクラスタ名 | 
 | NODEGROUP_ID_OR_NAME | URL | UUID or String | O | ノードグループUUIDまたはノードグループ名 | 
 
+<a id="get-a-node-group-response"></a>
 #### レスポンス
 
 | 名前 | 種類 | 形式 | 説明 |
@@ -1356,7 +1414,8 @@ X-Auth-Token: {tokenId}
 
 ---
 
-### ノードグループ作成
+<a id="create-a-node-group"></a>
+### ノードグループ作成 { #create-a-node-group }
 
 ノードグループを作成します。
 
@@ -1368,6 +1427,7 @@ OpenStack-API-Version: container-infra latest
 X-Auth-Token: {tokenId}
 ```
 
+<a id="create-a-node-group-request"></a>
 #### リクエスト
 
 | 名前 | 種類 | 形式 | 必須 | 説明 |
@@ -1434,6 +1494,7 @@ X-Auth-Token: {tokenId}
 </p>
 </details>
 
+<a id="create-a-node-group-response"></a>
 #### レスポンス
 
 | 名前 | 種類 | 形式 | 説明 |
@@ -1514,7 +1575,8 @@ X-Auth-Token: {tokenId}
 
 ---
 
-### ノードグループ削除
+<a id="delete-a-node-group"></a>
+### ノードグループ削除 { #delete-a-node-group }
 
 指定したノードグループを削除します。
 ```
@@ -1525,6 +1587,7 @@ OpenStack-API-Version: container-infra latest
 X-Auth-Token: {tokenId}
 ```
 
+<a id="delete-a-node-group-request"></a>
 #### リクエスト
 
 このAPIはリクエスト本文を要求しません。
@@ -1535,6 +1598,7 @@ X-Auth-Token: {tokenId}
 | CLUSTER_ID_OR_NAME | URL | UUID or String | O | クラスタUUIDまたはクラスタ名 | 
 | NODEGROUP_ID_OR_NAME | URL | UUID or String | O | ノードグループUUIDまたはノードグループ名 | 
 
+<a id="delete-a-node-group-response"></a>
 #### レスポンス
 
 このAPIはレスポンス本文を返しません。
@@ -1542,7 +1606,8 @@ X-Auth-Token: {tokenId}
 ---
 
 
-### ノードを停止する
+<a id="stop-a-node-group"></a>
+### ノードを停止する { #stop-a-node-group }
 
 指定したノードリストを停止させます。
 
@@ -1554,6 +1619,7 @@ OpenStack-API-Version: container-infra latest
 X-Auth-Token: {tokenId}
 ```
 
+<a id="stop-a-node-group-request"></a>
 #### リクエスト
 
 | 名前 | 種類 | 形式 | 必須 | 説明 |
@@ -1576,6 +1642,7 @@ X-Auth-Token: {tokenId}
 </details>
 
 
+<a id="stop-a-node-group-response"></a>
 #### レスポンス
 
 | 名前 | 種類 | 形式 | 説明 |
@@ -1596,7 +1663,8 @@ X-Auth-Token: {tokenId}
 
 ---
 
-### ノードを起動する
+<a id="start-a-node"></a>
+### ノードを起動する { #start-a-node }
 
 指定したノードリストを起動させます。
 
@@ -1608,6 +1676,7 @@ OpenStack-API-Version: container-infra latest
 X-Auth-Token: {tokenId}
 ```
 
+<a id="start-a-node-request"></a>
 #### リクエスト
 
 | 名前 | 種類 | 形式 | 必須 | 説明 |
@@ -1629,6 +1698,7 @@ X-Auth-Token: {tokenId}
 </p>
 </details>
 
+<a id="start-a-node-response"></a>
 #### レスポンス
 
 | 名前 | 種類 | 形式 | 説明 |
@@ -1649,7 +1719,8 @@ X-Auth-Token: {tokenId}
 
 ---
 
-### ノードグループのクラスターオートスケーラー設定表示
+<a id="view-cluster-autoscaler-configuration-of-a-node-group"></a>
+### ノードグループのクラスターオートスケーラー設定表示 { #view-cluster-autoscaler-configuration-of-a-node-group }
 
 ノードグループのクラスターオートスケーラー設定を照会します。
 
@@ -1661,6 +1732,7 @@ OpenStack-API-Version: container-infra latest
 X-Auth-Token: {tokenId}
 ```
 
+<a id="view-cluster-autoscaler-configuration-of-a-node-group-request"></a>
 #### リクエスト
 
 このAPIはリクエスト本文を要求しません。
@@ -1672,6 +1744,7 @@ X-Auth-Token: {tokenId}
 | NODEGROUP_ID_OR_NAME | URL | UUID or String | O | ノードグループUUIDまたはノードグループ名 | 
 
 
+<a id="view-cluster-autoscaler-configuration-of-a-node-group-response"></a>
 #### レスポンス
 
 | 名前 | 種類 | 形式 | 説明 |
@@ -1707,7 +1780,8 @@ X-Auth-Token: {tokenId}
 
 ---
 
-### ノードグループのクラスターオートスケーラー設定の変更
+<a id="change-cluster-autoscaler-configuration-of-a-node-group"></a>
+### ノードグループのクラスターオートスケーラー設定の変更 { #change-cluster-autoscaler-configuration-of-a-node-group }
 
 ノードグループのクラスターオートスケーラー設定を変更します。
 
@@ -1719,6 +1793,7 @@ OpenStack-API-Version: container-infra latest
 X-Auth-Token: {tokenId}
 ```
 
+<a id="change-cluster-autoscaler-configuration-of-a-node-group-request"></a>
 #### リクエスト
 
 | 名前 | 種類 | 形式 | 必須 | 説明 |
@@ -1754,6 +1829,17 @@ X-Auth-Token: {tokenId}
 </p>
 </details>
 
+<a id="change-cluster-autoscaler-configuration-of-a-node-group-response"></a>
+#### レスポンス
+
+<!-- TODO: translate body -->
+
+<a id="change-metric-based-autoscaler-configuration-of-a-node-group"></a>
+### ノードグループの指標ベースオートスケーラー設定の変更 { #change-metric-based-autoscaler-configuration-of-a-node-group }
+
+<!-- TODO: translate body -->
+
+<a id="change-metric-based-autoscaler-configuration-of-a-node-group-request"></a>
 #### リクエスト
 
 | 名前 | 種類 | 形式 | 必須 | 説明 |
@@ -1855,6 +1941,7 @@ X-Auth-Token: {tokenId}
 </details>
 
 
+<a id="change-metric-based-autoscaler-configuration-of-a-node-group-response"></a>
 #### レスポンス
 
 | 名前 | 種類 | 形式 | 説明 |
@@ -1875,7 +1962,8 @@ X-Auth-Token: {tokenId}
 
 ---
 
-### クラスタのアップグレード
+<a id="upgrade-a-cluster"></a>
+### クラスタのアップグレード { #upgrade-a-cluster }
 
 ノードグループをアップグレードします。
 
@@ -1887,6 +1975,7 @@ OpenStack-API-Version: container-infra latest
 X-Auth-Token: {tokenId}
 ```
 
+<a id="upgrade-a-cluster-request"></a>
 #### リクエスト
 
 | 名前 | 種類 | 形式 | 必須 | 説明 |
@@ -1920,6 +2009,7 @@ X-Auth-Token: {tokenId}
 </details>
 
 
+<a id="upgrade-a-cluster-response"></a>
 #### レスポンス
 
 | 名前 | 種類 | 形式 | 説明 |
@@ -1940,7 +2030,8 @@ X-Auth-Token: {tokenId}
 
 ---
 
-### ユーザースクリプトを変更する
+<a id="change-user-script"></a>
+### ユーザースクリプトを変更する { #change-user-script }
 
 ノードグループのユーザースクリプトを変更します。
 
@@ -1952,6 +2043,7 @@ OpenStack-API-Version: container-infra latest
 X-Auth-Token: {tokenId}
 ```
 
+<a id="change-user-script-request"></a>
 #### リクエスト
 
 | 名前 | 種類 | 形式 | 必須 | 説明 |
@@ -1975,6 +2067,7 @@ X-Auth-Token: {tokenId}
 </details>
 
 
+<a id="change-user-script-response"></a>
 #### レスポンス
 
 | 名前 | 種類 | 形式 | 説明 |
@@ -1995,7 +2088,8 @@ X-Auth-Token: {tokenId}
 
 ---
 
-### インスタンスタイプを変更する
+<a id="change-instance-flavor"></a>
+### インスタンスタイプを変更する { #change-instance-flavor }
 
 ノードグループのインスタンスタイプを変更します。
 
@@ -2007,6 +2101,7 @@ OpenStack-API-Version: container-infra latest
 X-Auth-Token: {tokenId}
 ```
 
+<a id="change-instance-flavor-request"></a>
 #### リクエスト
 
 | 名前 | 種類 | 形式 | 必須 | 説明 |
@@ -2036,6 +2131,7 @@ X-Auth-Token: {tokenId}
 </details>
 
 
+<a id="change-instance-flavor-response"></a>
 #### レスポンス
 
 | 名前 | 種類 | 形式 | 説明 |
@@ -2056,7 +2152,8 @@ X-Auth-Token: {tokenId}
 
 ---
 
-### ノードグループのフローティングIP自動割り当て設定の変更
+<a id="change-floating-ip-auto-assignment-configuration-of-a-node-group"></a>
+### ノードグループのフローティングIP自動割り当て設定の変更 { #change-floating-ip-auto-assignment-configuration-of-a-node-group }
 
 ノードグループのフローティングIP自動割り当て設定を変更します。
 
@@ -2068,6 +2165,7 @@ OpenStack-API-Version: container-infra latest
 X-Auth-Token: {tokenId}
 ```
 
+<a id="change-floating-ip-auto-assignment-configuration-of-a-node-group-request"></a>
 #### リクエスト
 
 
@@ -2101,6 +2199,7 @@ X-Auth-Token: {tokenId}
 </details>
 
 
+<a id="change-floating-ip-auto-assignment-configuration-of-a-node-group-response"></a>
 #### レスポンス
 
 | 名前 | 種類 | 形式 | 説明 |
@@ -2121,7 +2220,8 @@ X-Auth-Token: {tokenId}
 
 ---
 
-### ノードグループのKubernetesラベル設定変更
+<a id="change-kubernetes-label-configuration-of-a-node-group"></a>
+### ノードグループのKubernetesラベル設定変更 { #change-kubernetes-label-configuration-of-a-node-group }
 
 ノードグループのKubernetesラベル設定を変更します。
 
@@ -2133,6 +2233,7 @@ OpenStack-API-Version: container-infra latest
 X-Auth-Token: {tokenId}
 ```
 
+<a id="change-kubernetes-label-configuration-of-a-node-group-request"></a>
 #### リクエスト
 
 | 名前 | 種類 | 形式 | 必須 | 説明 |
@@ -2161,6 +2262,7 @@ X-Auth-Token: {tokenId}
 </details>
 
 
+<a id="change-kubernetes-label-configuration-of-a-node-group-response"></a>
 #### レスポンス
 
 | 名前 | 種類 | 形式 | 説明 |
@@ -2181,9 +2283,11 @@ X-Auth-Token: {tokenId}
 
 ---
 
-## アドオン管理機能
+<a id="add-on-management"></a>
+## アドオン管理機能 { #add-on-management }
 
-### NHN Cloudが提供するアドオンタイプ表示
+<a id="view-the-types-of-add-ons-offered-by-nhn-cloud"></a>
+### NHN Cloudが提供するアドオンタイプ表示 { #view-the-types-of-add-ons-offered-by-nhn-cloud }
 NHN Cloudが提供するアドオンタイプを確認できます。
 
 ```
@@ -2194,6 +2298,7 @@ OpenStack-API-Version: container-infra latest
 X-Auth-Token: {tokenId}
 ```
 
+<a id="view-the-types-of-add-ons-offered-by-nhn-cloud-request"></a>
 #### リクエスト
 
 | 名前 | 種類 | 形式 | 必須 | 説明 |
@@ -2201,6 +2306,7 @@ X-Auth-Token: {tokenId}
 | tokenId | Header | String | O | トークンID |
 | ADDON_TYPE_UUID_OR_NAME | URL | UUID or String | O | アドオンタイプのUUIDまたは名前 |
 
+<a id="view-the-types-of-add-ons-offered-by-nhn-cloud-response"></a>
 #### レスポンス
 
 | 名前 | 種類 | 形式 | 説明 |
@@ -2225,7 +2331,8 @@ X-Auth-Token: {tokenId}
 
 ---
 
-### NHN Cloudが提供するアドオンタイプリスト表示
+<a id="view-a-list-of-add-ons-types-offered-by-nhn-cloud"></a>
+### NHN Cloudが提供するアドオンタイプリスト表示 { #view-a-list-of-add-ons-types-offered-by-nhn-cloud }
 NHN Cloudが提供するアドオンタイプのリストを確認できます。
 
 ```
@@ -2236,11 +2343,13 @@ OpenStack-API-Version: container-infra latest
 X-Auth-Token: {tokenId}
 ```
 
+<a id="view-a-list-of-add-ons-types-offered-by-nhn-cloud-request"></a>
 #### リクエスト
 | 名前 | 種類 | 形式 | 必須 | 説明 |
 |---|---|---|---|---|
 | tokenId | Header | String | O | トークンID |
 
+<a id="view-a-list-of-add-ons-types-offered-by-nhn-cloud-response"></a>
 #### レスポンス
 
 | 名前 | 種類 | 形式 | 説明 |
@@ -2264,7 +2373,8 @@ X-Auth-Token: {tokenId}
 
 ---
 
-### NHN Cloudが提供するアドオン表示
+<a id="view-add-ons-offered-by-nhn-cloud"></a>
+### NHN Cloudが提供するアドオン表示 { #view-add-ons-offered-by-nhn-cloud }
 NHN Cloudが提供するアドオンを確認できます。
 
 ```
@@ -2275,6 +2385,7 @@ OpenStack-API-Version: container-infra latest
 X-Auth-Token: {tokenId}
 ```
 
+<a id="view-add-ons-offered-by-nhn-cloud-request"></a>
 #### リクエスト
 
 | 名前 | 種類 | 形式 | 必須 | 説明 |
@@ -2283,6 +2394,7 @@ X-Auth-Token: {tokenId}
 | tokenId | Header | String | O | トークンID |
 
 
+<a id="view-add-ons-offered-by-nhn-cloud-response"></a>
 #### レスポンス
 
 | 名前 | 種類 | 形式 | 説明 |
@@ -2334,7 +2446,8 @@ X-Auth-Token: {tokenId}
 
 ---
 
-### NHN Cloudが提供するアドオンリスト表示
+<a id="view-a-list-of-add-ons-offered-by-nhn-cloud"></a>
+### NHN Cloudが提供するアドオンリスト表示 { #view-a-list-of-add-ons-offered-by-nhn-cloud }
 NHN Cloudが提供するアドオンリストを確認できます。
 
 ```
@@ -2345,6 +2458,7 @@ OpenStack-API-Version: container-infra latest
 X-Auth-Token: {tokenId}
 ```
 
+<a id="view-a-list-of-add-ons-offered-by-nhn-cloud-request"></a>
 #### リクエスト
 
 | 名前 | 種類 | 形式 | 必須 | 説明 |
@@ -2354,6 +2468,7 @@ X-Auth-Token: {tokenId}
 | image | Query | UUID | X | ベースイメージのUUID。指定時、該当イメージにインストール可能なアドオンのみを返却します。 |
 | platform_version | Query | String | X | プラットフォームバージョン(例：`1.202605.0`)。指定時、該当プラットフォームバージョンで使用可能なアドオンのみを返却します。 |
 
+<a id="view-a-list-of-add-ons-offered-by-nhn-cloud-response"></a>
 #### レスポンス
 
 | 名前 | 種類 | 形式 | 説明 |
@@ -2380,7 +2495,8 @@ X-Auth-Token: {tokenId}
 
 ---
 
-### クラスターにインストールされたアドオン表示
+<a id="view-add-ons-installed-on-a-cluster"></a>
+### クラスターにインストールされたアドオン表示 { #view-add-ons-installed-on-a-cluster }
 クラスターにインストールされたアドオンを確認できます。
 
 ```
@@ -2391,6 +2507,7 @@ OpenStack-API-Version: container-infra latest
 X-Auth-Token: {tokenId}
 ```
 
+<a id="view-add-ons-installed-on-a-cluster-request"></a>
 #### リクエスト
 
 | 名前 | 種類 | 形式 | 必須 | 説明 |
@@ -2400,6 +2517,7 @@ X-Auth-Token: {tokenId}
 | ADDON_UUID_OR_NAME | URL | UUID or String | O | アドオンUUIDまたはアドオン名 |
 
 
+<a id="view-add-ons-installed-on-a-cluster-response"></a>
 #### レスポンス
 
 | 名前 | 種類 | 形式 | 説明 |
@@ -2446,7 +2564,8 @@ X-Auth-Token: {tokenId}
 
 ---
 
-### クラスターにインストールされたアドオンリスト表示
+<a id="view-a-list-of-add-ons-installed-on-a-cluster"></a>
+### クラスターにインストールされたアドオンリスト表示 { #view-a-list-of-add-ons-installed-on-a-cluster }
 クラスターにインストールされたアドオンリストを確認できます。
 
 ```
@@ -2457,6 +2576,7 @@ OpenStack-API-Version: container-infra latest
 X-Auth-Token: {tokenId}
 ```
 
+<a id="view-a-list-of-add-ons-installed-on-a-cluster-request"></a>
 #### リクエスト
 
 | 名前 | 種類 | 形式 | 必須 | 説明 |
@@ -2464,6 +2584,7 @@ X-Auth-Token: {tokenId}
 | tokenId | Header | String | O | トークンID |
 | CLUSTER_ID_OR_NAME | URL | UUID or String | O | クラスターUUIDまたはクラスター名 |
 
+<a id="view-a-list-of-add-ons-installed-on-a-cluster-response"></a>
 #### レスポンス
 
 | 名前 | 種類 | 形式 | 説明 |
@@ -2487,7 +2608,8 @@ X-Auth-Token: {tokenId}
 
 ---
 
-### クラスターにアドオンをインストール
+<a id="install-add-ons-on-a-cluster"></a>
+### クラスターにアドオンをインストール { #install-add-ons-on-a-cluster }
 クラスターにアドオンをインストールします。
 
 ```
@@ -2498,6 +2620,7 @@ OpenStack-API-Version: container-infra latest
 X-Auth-Token: {tokenId}
 ```
 
+<a id="install-add-ons-on-a-cluster-request"></a>
 #### リクエスト
 
 | 名前 | 種類 | 形式 | 必須 | 説明 |
@@ -2520,6 +2643,7 @@ X-Auth-Token: {tokenId}
 </details>
 
 
+<a id="install-add-ons-on-a-cluster-response"></a>
 #### レスポンス
 
 | 名前 | 種類 | 形式 | 説明 |
@@ -2540,7 +2664,8 @@ X-Auth-Token: {tokenId}
 
 ---
 
-### クラスターにアドオンを更新
+<a id="update-add-ons-to-a-cluster"></a>
+### クラスターにアドオンを更新 { #update-add-ons-to-a-cluster }
 クラスターにインストールされたアドオンを更新します。
 
 ```
@@ -2551,6 +2676,7 @@ OpenStack-API-Version: container-infra latest
 X-Auth-Token: {tokenId}
 ```
 
+<a id="update-add-ons-to-a-cluster-request"></a>
 #### リクエスト
 
 | 名前 | 種類 | 形式 | 必須 | 説明 |
@@ -2573,6 +2699,7 @@ X-Auth-Token: {tokenId}
 </details>
 
 
+<a id="update-add-ons-to-a-cluster-response"></a>
 #### レスポンス
 
 | 名前 | 種類 | 形式 | 説明 |
@@ -2593,7 +2720,8 @@ X-Auth-Token: {tokenId}
 
 ---
 
-### クラスターにインストールされたアドオンの削除
+<a id="remove-add-ons-from-a-cluster"></a>
+### クラスターにインストールされたアドオンの削除 { #remove-add-ons-from-a-cluster }
 クラスターにインストールされたアドオンを削除します。
 
 ```
@@ -2604,6 +2732,7 @@ OpenStack-API-Version: container-infra latest
 X-Auth-Token: {tokenId}
 ```
 
+<a id="remove-add-ons-from-a-cluster-request"></a>
 #### リクエスト
 
 | 名前 | 種類 | 形式 | 必須 | 説明 |
@@ -2612,6 +2741,7 @@ X-Auth-Token: {tokenId}
 | CLUSTER_ID_OR_NAME | URL | UUID or String | O | クラスターUUIDまたはクラスター名 |
 | ADDON_UUID_OR_NAME | URL | UUID or String | O | アドオンUUIDまたはアドオン名 |
 
+<a id="remove-add-ons-from-a-cluster-response"></a>
 #### レスポンス
 
 | 名前 | 種類 | 形式 | 説明 |
@@ -2632,9 +2762,11 @@ X-Auth-Token: {tokenId}
 
 
 
-## その他機能
+<a id="other-features"></a>
+## その他機能 { #other-features }
 
-### サポートされるKubernetesバージョン及び作業の種類を表示
+<a id="view-supported-kubernetes-versions-and-task-types"></a>
+### サポートされるKubernetesバージョン及び作業の種類を表示 { #view-supported-kubernetes-versions-and-task-types }
 
 NHN Kubernetes Service(NKS)でサポートするKubernetesバージョン及び作業タイプを照会します。
 
@@ -2646,6 +2778,7 @@ OpenStack-API-Version: container-infra latest
 X-Auth-Token: {tokenId}
 ```
 
+<a id="view-supported-kubernetes-versions-and-task-types-request"></a>
 #### リクエスト
 
 このAPIはリクエスト本文を要求しません。
@@ -2655,6 +2788,7 @@ X-Auth-Token: {tokenId}
 | tokenId | Header | String | O | トークンID |
 
 
+<a id="view-supported-kubernetes-versions-and-task-types-response"></a>
 #### レスポンス
 
 | 名前 | 種類 | 形式 | 説明 |

--- a/ja/release-notes.md
+++ b/ja/release-notes.md
@@ -1,13 +1,19 @@
-## Container > Kubernetes > リリースノート
+<!-- pre-align:aligned sig=a9faa149ecf3 -->
 
-### 2026. 05. 27.
+<a id="container-nhn-kubernetes-service-nks-release-notes"></a>
+## Container > Kubernetes > リリースノート { #container-nhn-kubernetes-service-nks-release-notes }
 
+<a id="may-27-2026"></a>
+### 2026. 05. 27. { #may-27-2026 }
+
+<a id="may-27-2026-added-features"></a>
 #### 機能追加
 * Kubernetes v1.34.3をサポートします。
     * k8s v1.34以上のバージョンにおいて、ワーカーノードイメージのCGroupバージョンによる制約事項が存在します。詳細は、[KubernetesバージョンとCGroupバージョンによる制約事項](/Container/NKS/ko/version-guide/#constraints-on-cgroup)を参照してください。
     * k8s v1.34以上のバージョンにおいて、カスタムcontainerdレジストリ設定機能が動作しません。詳細は、[カスタムcontainerdレジストリ設定機能](/Container/NKS/ko/version-guide/#containerd-registry-config)を参照してください。
 * Cilium CNIをサポートします。
 
+<a id="may-27-2026-platform-version-updates"></a>
 #### プラットフォームバージョンのアップデート
 * 1.202605.0が追加されました。
     * Kubernetes互換バージョン：v1.30～v1.34
@@ -16,6 +22,7 @@
         * kube-apiserverとpod間の通信のためのkonnectivityサポート
         * k8s v1.34クラスターの`ImageVolume` feature gate有効化
 
+<a id="may-27-2026-add-on-updates"></a>
 #### アドオンのアップデート
 * 次のアドオンが追加されました。
     * nfs_csi_plugin v1.0.2-nks1
@@ -24,8 +31,20 @@
     * calico v3.28.2-nks3
     * calico v3.30.2-nks3
     
-### 2026. 03. 10.
+<a id="march-17-2026"></a>
+### 2026. 03. 17. { #march-17-2026 }
 
+<!-- TODO: translate body -->
+
+<a id="march-17-2026-platform-version-updates"></a>
+#### プラットフォームバージョンのアップデート
+
+<!-- TODO: translate body -->
+
+<a id="march-10-2026"></a>
+### 2026. 03. 10. { #march-10-2026 }
+
+<a id="march-10-2026-platform-version-updates"></a>
 #### プラットフォームバージョンアップデート
 * 1.202602.0が追加されました。
     * Kubernetes互換バージョン：v1.29–v1.33
@@ -37,6 +56,7 @@
     * 機能改善
         * ノード及びノードグループ削除時のロードバランサートラフィック消失改善
 
+<a id="march-10-2026-add-on-updates"></a>
 #### アドオンアップデート
 * 次のアドオンが追加されました。
     * calico v3.30.2-nks2
@@ -46,6 +66,7 @@
     * snapshot_controller v4.1.1-nks2
     * nfs_csi_plugin v1.0.1-nks2
 
+<a id="march-10-2026-added-features"></a>
 #### 機能追加
 * CGroupがv2に設定されたOSイメージに対応します。
     * 2026年3月以降に配布されるOSイメージは、CGroupがv2に設定されています。
@@ -53,12 +74,15 @@
 * Kubernetesテイント設定機能が追加されました。
 * Secure Key Managerサービスを利用して、クラスターの機密データを暗号化/復号できます。
 
-### 2025. 12. 23.
+<a id="december-23-2025"></a>
+### 2025. 12. 23. { #december-23-2025 }
 
+<a id="december-23-2025-platform-version-updates"></a>
 #### プラットフォームバージョンのアップデート
 * 1.202511.1が追加されました。
     * ヘルスチェック確認ポートの設定エラーを修正しました。
 
+<a id="december-23-2025-add-on-updates"></a>
 #### アドオンのアップデート
 * Cinder CSI Plugin v1.27.101-nks2、v1.27.102-nks2が追加されました。
     * 内部コンテナのバージョンが次のように変更されました。
@@ -68,12 +92,15 @@
         * csi-resizer: v1.0.1 → v1.3.0
         * csi-node-driver-registrar: v2.0.1 → v2.3.0
         
-### 2025. 11. 25.
+<a id="november-25-2025"></a>
+### 2025. 11. 25. { #november-25-2025 }
 
+<a id="november-25-2025-changed-service-support-policy"></a>
 #### サービスサポートポリシーの変更
 * NKSのKubernetesバージョンサポートポリシーが変更されます。
     * 詳細は[バージョンガイド](/Container/NKS/ko/version-guide)を参照してください。
 
+<a id="november-25-2025-updated-add-on"></a>
 #### アドオンアップデート
 * 次のアドオンが追加されました。
     * Calico CNI v3.30.2-nks1
@@ -82,6 +109,7 @@
     * Snapshot Controller v4.1.1-nks1
     * NFS CSI Plugin v1.0.1-nks1
 
+<a id="november-25-2025-added-features"></a>
 #### 機能追加
 * Kubernetes v1.33.4をサポートします。
 * コントロールプレーンとワーカーノードグループのプラットフォームバージョンの照会及びアップグレード機能が追加されました。
@@ -89,15 +117,19 @@
 * ロードバランサー詳細オプション設定に、ヘルスチェックホストヘッダ設定機能が追加されました。
 
 
-### 2025. 07. 15.
+<a id="july-15-2025"></a>
+### 2025. 07. 15. { #july-15-2025 }
 
+<a id="july-15-2025-image-update"></a>
 #### イメージアップデート
 * クラスター及びノードグループ作成時に以下のイメージは今後サポートされません。
     * 対象イメージ
         * Ubuntu Server 20.04.3 LTS - Container
 
-### 2025. 05. 27.
+<a id="may-27-2025"></a>
+### 2025. 05. 27. { #may-27-2025 }
 
+<a id="may-27-2025-added-features"></a>
 #### 機能追加
 * Kubernetes v1.32.3をサポートします。
 * コントロールプレーンkubernetesコンポーネントログ保存機能を追加しました。
@@ -108,14 +140,17 @@
 * Addon管理機能を使用できます。
     * 詳細は[使用ガイド](/Container/NKS/ja/user-guide/#addon_mgmt)を参照してください。
 
+<a id="may-27-2025-feature-updates"></a>
 #### 機能改善/変更
 * クラスターCNI変更機能は今後サポートされません。
 * 物理タイプのロードバランサーは今後サポートされません。
 * Blue/Green Upgrade時、システムPodアップグレード段階が削除されました。
     * Calico, CoreDNSなどのシステムPodはアドオン管理機能を通じてアップデートできます。
 
-### 2025. 03. 04.
+<a id="march-4-2025"></a>
+### 2025. 03. 04. { #march-4-2025 }
 
+<a id="march-4-2025-added-features"></a>
 #### 機能追加
 * Kubernetes v1.31.4をサポートします。
 * OIDC(openID connect)設定機能を使用できます。
@@ -123,17 +158,22 @@
     * クラスターキーペアを設定したクラスターはサービスユーザーの権限で動作します。
     * サービスユーザーの権限で動作するクラスターは、オーナーを変更/管理する必要がありません。
 
+<a id="march-4-2025-feature-updates"></a>
 #### 機能改善/変更
 * クラスターオーナー変更機能のサポートを終了します。
 
-### 2024. 11. 26.
+<a id="november-26-2024"></a>
+### 2024. 11. 26. { #november-26-2024 }
 
+<a id="november-26-2024-added-features"></a>
 #### 機能追加
 * Kubernetesコンポーネント設定機能を使用できます。
 
+<a id="november-26-2024-feature-updates"></a>
 #### 機能改善
 * Podサブネットサイズに応じて、ノードあたりの作成可能な最大Pod数が自動的に設定されるように変更されました。
 
+<a id="november-26-2024-image-update"></a>
 #### イメージアップデート
 イメージにインストールされたGPUドライバーのバージョンが変更されました。
 
@@ -159,18 +199,23 @@
 | Ubuntu Server 20.04.6 LTS (2024.11.19) | 20GB | 30GB |
 | Ubuntu Server 22.04.6 LTS (2024.11.19) | 20GB | 30GB |
 
+<a id="november-26-2024-deprecated-image-support"></a>
 #### イメージサポートの中断
 * CentOSイメージを使用して新規クラスター及びノードグループを作成できません。
 
-### 2024. 10. 29.
+<a id="october-29-2024"></a>
+### 2024. 10. 29. { #october-29-2024 }
 
+<a id="october-29-2024-feature-updates"></a>
 #### 機能改善
 
 * CNIアップデート
     * Kubernetes v1.27.3以上クラスターのCalico CNIバージョンがv3.28.0からv3.28.2に変更されました。
 
-### 2024. 08. 27.
+<a id="august-27-2024"></a>
+### 2024. 08. 27. { #august-27-2024 }
 
+<a id="august-27-2024-added-features"></a>
 #### 機能追加
 * ノードグループに追加セキュリティグループを指定する機能が追加されました。
 * ノードグループに追加ブロックストレージを指定する機能が追加されました。
@@ -178,18 +223,23 @@
 * ロードバランサーの静的ルートを適用するかどうかを設定できます。
 * NKSレジストリを有効化できます。
 
+<a id="august-27-2024-deprecated-image-support"></a>
 #### イメージサポート中断
 * Debianイメージを使用して新規クラスター及びノードグループを作成できません。
 
-### 2024. 07. 23.
+<a id="july-23-2024"></a>
+### 2024. 07. 23. { #july-23-2024 }
 
+<a id="july-23-2024-added-features"></a>
 #### 機能追加
 
 * ロードバランサー詳細オプション設定でL7ルールと条件を適用できます。
 * クラスタ作成時、Calico-VXLANとCalico-eBPF CNIを選択できます。
 
-### 2024. 05. 28.
+<a id="may-28-2024"></a>
+### 2024. 05. 28. { #may-28-2024 }
 
+<a id="may-28-2024-added-features"></a>
 #### 機能追加
 
 * Kubernetes v1.29.3をサポートします。
@@ -199,15 +249,19 @@
 * Resource Watcherサービスを通じて、クラスタで発生するイベントに関する通知を受け取ることができます。
     * 詳細は[Resource Watcher](/Governance%20&%20Audit/Resource%20Watcher/ko/overview)を参照してください。
 
-### 2024. 03. 26.
+<a id="march-26-2024"></a>
+### 2024. 03. 26. { #march-26-2024 }
 
+<a id="march-26-2024-feature-updates"></a>
 #### 機能改善
 * クラスタ作成時に入力するサービスゲートウェイの有効範囲が変更されました。
     * 変更前：クラスタのサブネットと同じサブネットに作成されたサービスゲートウェイ
     * 変更後:クラスタのVPCに含まれるサブネットに作成されたサービスゲートウェイ
 
-### 2024. 02. 27.
+<a id="february-27-2024"></a>
+### 2024. 02. 27. { #february-27-2024 }
 
+<a id="february-27-2024-added-features"></a>
 #### 機能追加
 
 * 強化されたセキュリティルールをクラスタに適用できます。
@@ -215,14 +269,17 @@
 * Kubernetes v1.28.3をサポートします。
 * クラスタとノードグループ照会画面で作業履歴を確認できます。
 
-### 2023. 11. 28.
+<a id="november-28-2023"></a>
+### 2023. 11. 28. { #november-28-2023 }
 
+<a id="november-28-2023-added-features"></a>
 #### 機能追加
 * kubeletユーザー定義引数設定機能が追加されました。
 * ロードバランサー詳細オプション設定でメンバーサブネット設定機能が追加されました。
 * ロードバランサー詳細オプション設定でkeep-aliveタイムアウト値設定機能が追加されました。
 * 暗号化されたブロックストレージを使用してPVを作成する機能が追加されました。
 
+<a id="november-28-2023-image-update"></a>
 #### イメージアップデート
 * クラスタ及びノードグループ作成時に使用可能な新規イメージが追加されました。
     * 対象イメージ
@@ -240,8 +297,10 @@
         * Rocky Linux 8.8 - Container (2023.11.21)
         * Ubuntu Server 20.04.6 LTS - Container (2023.11.21)
 
-### 2023. 08. 29.
+<a id="august-29-2023"></a>
+### 2023. 08. 29. { #august-29-2023 }
 
+<a id="august-29-2023-added-features"></a>
 #### 機能追加
 
 * Kubernetes v1.27.3をサポートします。
@@ -250,6 +309,7 @@
 * クラスタとノードグループリスト照会画面で、より詳細な状態情報を提供します。
 * プロビジョニング時に新しいNASストレージを作成する機能が追加されました。
 
+<a id="august-29-2023-feature-updates"></a>
 #### 機能改善
 * クラスタおよびノードグループ作成時に使用するイメージの配布版バージョンが変更されました。
     * 変更前
@@ -257,6 +317,7 @@
     * 変更後
         * Rocky Linux 8.8 - Container (2023.08.22)
 
+<a id="august-29-2023-image-update"></a>
 #### イメージアップデート 
 * 変更事項
     * nvidia-device-pluginのバージョンが470.182.03から470.199.02に変更されました。
@@ -268,8 +329,10 @@
     * Ubuntu Server 20.04.6 LTS - Container (2023.08.22)
 
 
-### 2023. 07. 19.
+<a id="july-19-2023"></a>
+### 2023. 07. 19. { #july-19-2023 }
 
+<a id="july-19-2023-image-update"></a>
 #### イメージアップデート
 * ノードグループ作成時、一部のイメージでiptablesカーネルモジュールが正常に初期化されない問題を修正しました。
     * 問題イメージ：Rocky Linux 8.7 - Container (2023.05.25)
@@ -279,8 +342,10 @@
     * 解決イメージ：CentOS 7.9 - Container (2023.07.25)
 
 
-### 2023. 05. 30.
+<a id="may-30-2023"></a>
+### 2023. 05. 30. { #may-30-2023 }
 
+<a id="may-30-2023-added-features"></a>
 #### 機能追加
 
 * Kubernetes v1.26.3をサポートします。
@@ -288,6 +353,7 @@
     * 詳細な内容は[ユーザーガイド](/Container/NKS/ja/user-guide/#custom-image)を参照してください。
 * クラスタサービスネットワーク、 Podネットワーク、 Podサブネットサイズの変更機能が追加されました。
 
+<a id="may-30-2023-feature-updates"></a>
 #### 機能改善
 
 * クラスタおよびノードグループ作成時に使用するイメージの配布版バージョンが変更されました。
@@ -310,8 +376,10 @@
         * Rocky Linux 8.7 - Container (2023.05.25)
         * Ubuntu Server 20.04.6 LTS - Container (2023.05.25)
 
-### 2023. 03. 28.
+<a id="march-28-2023"></a>
+### 2023. 03. 28. { #march-28-2023 }
 
+<a id="march-28-2023-added-features"></a>
 #### 機能追加
 
 * クラスタCNI変更機能が追加されました。
@@ -319,6 +387,7 @@
 * ノードグループのインスタンスタイプを変更できます。
 * コンソールでKubernetesリソース照会機能を使用できます。
 
+<a id="march-28-2023-feature-updates"></a>
 #### 機能変更
 
 * NKS APIアドレスドメインが変更されました。
@@ -329,6 +398,7 @@
         * 既存：https://kr2-api-kubernetes.infrastructure.cloud.toast.com
         * 変更：https://kr2-api-kubernetes-infrastructure.nhncloudservice.com
 
+<a id="march-28-2023-march-28-2023-feature-updates"></a>
 #### 機能改善
 
 * イメージアップデート
@@ -336,8 +406,10 @@
     * Debian 11.6 Bullseye - Container (2023.02.21)
     * Rocky Linux 8.6 - Container (2023.02.21)
 
-### 2023. 01. 31.
+<a id="january-31-2023"></a>
+### 2023. 01. 31. { #january-31-2023 }
 
+<a id="january-31-2023-added-features"></a>
 #### 機能追加
 
 * クラスタOWNER変更機能が追加されました。
@@ -348,15 +420,19 @@
 * 物理ロードバランサーを作成できます。
 
 
-### 2022. 12. 27.
+<a id="december-27-2022"></a>
+### 2022. 12. 27. { #december-27-2022 }
 
+<a id="december-27-2022-added-features"></a>
 #### 機能追加
 
 * イメージ追加
     * Rocky Linux 8.6 - Container (2022.12)
 
-### 2022. 11. 29.
+<a id="november-29-2022"></a>
+### 2022. 11. 29. { #november-29-2022 }
 
+<a id="november-29-2022-feature-updates"></a>
 #### 機能改善
 
 * イメージアップデート
@@ -367,6 +443,7 @@
         * Ubuntu Server 18.04.6 LTS - Container (2022.11.22)
         * CentOS 7.9 - Container (2022.11.22)
 
+<a id="november-29-2022-added-features"></a>
 #### 機能追加
 
 * ノードの起動/停止機能を使用できます。
@@ -375,42 +452,58 @@
 * イメージ追加
     * Debian 11.5 Bullseye - Container (2022.11.22)
 
-### 2022. 09. 27.
+<a id="september-27-2022"></a>
+### 2022. 09. 27. { #september-27-2022 }
 
+<a id="september-27-2022-added-features"></a>
 #### 機能追加
 
 * Kubernetes v1.24.3をサポートします。
 * クラスタ作成時、Kubernetes v1.20.12のサポートは終了します。ただし、使用中のクラスタには影響がありません。
 
-### 2022. 07. 26.
+<a id="july-26-2022"></a>
+### 2022. 07. 26. { #july-26-2022 }
 * ノードグループ作成後にもユーザースクリプトを変更できます。
 * ユーザースクリプト変更APIが追加されました。
 * ワーカーノードグループのアップグレード時に最大ノード数と最大サービス不可ノード数を指定できます。
 
-### 2022. 05. 24.
+<a id="july-26-2022-added-features"></a>
+#### 機能追加
 
+<!-- TODO: translate body -->
+
+<a id="may-24-2022"></a>
+### 2022. 05. 24. { #may-24-2022 }
+
+<a id="may-24-2022-feature-updates"></a>
 #### 機能改善
 * 内部構造を改善し、サービスの性能と安定性が向上しました。
 
-### 2022. 03. 29.
+<a id="march-29-2022"></a>
+### 2022. 03. 29. { #march-29-2022 }
 
+<a id="march-29-2022-added-features"></a>
 #### 機能追加
 
 * Kubernetes v1.23.3をサポートします。
 * クラスタ作成時、Kubernetes v1.19.13はサポートしません。ただし、使用中のクラスタには影響がありません。
 * ロードバランサーのリスナープロトコルをTERMINATED_HTTPSに設定すると、SSLバージョンをTLSv1.3に設定できます。
 
+<a id="march-29-2022-feature-updates"></a>
 #### 機能変更
 
 * 機能名が変更されました。
     * 変更前：予約スクリプト
     * 変更後：ユーザースクリプト
 
-### 2022. 01. 25.
+<a id="january-25-2022"></a>
+### 2022. 01. 25. { #january-25-2022 }
 
+<a id="january-25-2022-feature-updates"></a>
 #### 機能改善
 * Kubernetesサービスの名前がNHN Kubernetes Service(NKS)に変更されました。
 
+<a id="january-25-2022-added-features"></a>
 #### 機能追加
 
 * 以下のKubernetesバージョンをサポートします。
@@ -428,8 +521,10 @@
     * イメージ追加
         * Ubuntu Server 18.04.6 LTS - Container (2022.01)
 
-### 2021. 12. 28.
+<a id="december-28-2021"></a>
+### 2021. 12. 28. { #december-28-2021 }
 
+<a id="december-28-2021-feature-updates"></a>
 #### 機能改善
 
 * GPUワーカーノードで使用するNVIDIAドライバーがアップデートされました。
@@ -439,14 +534,18 @@
 * イメージアップデート
     * CentOS 7.8 - Container (2021.12.21)
 
-### 2021. 11. 23.
+<a id="november-23-2021"></a>
+### 2021. 11. 23. { #november-23-2021 }
 
+<a id="november-23-2021-added-features"></a>
 #### 機能追加
 * KubernetesサービスのためのPublic APIが公開されました。
     * Public APIの詳しい内容は[APIガイド](/Container/NKS/ja/public-api)を参照してください。
 
-### 2021. 10. 26.
+<a id="october-26-2021"></a>
+### 2021. 10. 26. { #october-26-2021 }
 
+<a id="october-26-2021-added-features"></a>
 #### 機能追加
 
 * Kubernetes v1.19.13をサポートします。
@@ -454,8 +553,10 @@
 * オートスケーラーの「増設後、削減遅延時間」設定の最小値が10分に変更されました。
 * 新しいクラスタではワーカーノードグループが2個以上の場合、基本ワーカーノードグループを削除できます。
 
-### 2021. 07. 27.
+<a id="july-27-2021"></a>
+### 2021. 07. 27. { #july-27-2021 }
 
+<a id="july-27-2021-added-features"></a>
 #### 機能追加
 
 * ノードグループ作成時にユーザースクリプト機能を使用できます。
@@ -464,64 +565,87 @@
         * CentOS 7.8 - Container (2021.07.27)
     * コンテナログ管理については[問題解決ガイド](/Container/NKS/ja/troubleshooting-guide)を参照してください。
 
-### 2021. 06. 29.
+<a id="june-29-2021"></a>
+### 2021. 06. 29. { #june-29-2021 }
 
+<a id="june-29-2021-added-features"></a>
 #### 機能追加
 
 * Kubernetes v1.18.19をサポートします。
 * クラスターバージョンをアップグレードできます。
 
-### 2021. 03. 23.
+<a id="march-23-2021"></a>
+### 2021. 03. 23. { #march-23-2021 }
 
+<a id="march-23-2021-added-features"></a>
 #### 機能追加
 
 * ユーザークラスターで発生したイベントをNHN CloudTrailで確認できます。
 
+<a id="march-23-2021-bug-fixes"></a>
 #### バグ修正
 * グラフィックが最適化されたインスタンスタイプ(g2)でノードグループを作成した時、正常に初期化されない問題が修正されました。
 
-### 2021. 02. 23.
+<a id="february-23-2021"></a>
+### 2021. 02. 23. { #february-23-2021 }
 
+<a id="february-23-2021-feature-updates"></a>
 #### 機能改善
 * Kubernetes承認コントローラー(admission controller)にPodSecurityPolicyプラグインが追加されました。
 * クラスターおよびノードグループ作成時に使用するイメージの配布版バージョンが変更されました。
     * イメージアップデート
         * CentOS 7.8 - Container (2021.02.23)
 
-### 2021. 01. 26.
+<a id="january-26-2021"></a>
+### 2021. 01. 26. { #january-26-2021 }
+<a id="january-26-2021-bug-fixes"></a>
 #### バグ修正
 * インターネットゲートウェイが接続されていない環境でオートスケーラー機能が動作しない問題が修正されました。
     * イメージアップデート
         * CentOS 7.5 - Container (2021.01.26)
 
-### 2020. 12. 29.
+<a id="december-29-2020"></a>
+### 2020. 12. 29. { #december-29-2020 }
+<a id="december-29-2020-feature-updates"></a>
 #### 機能改善
 * Kubernetes CSR(Certificate Signing Request)機能を使用できます。
 
-### 2020. 11. 24.
+<a id="november-24-2020"></a>
+### 2020. 11. 24. { #november-24-2020 }
+<a id="november-24-2020-added-features"></a>
 #### 機能追加
 * オートスケーラー機能を使用できます。
 
+<a id="november-24-2020-feature-updates"></a>
 #### 機能改善
 * クラスターを削除する時、残っているロードバランサーとFloating IPを削除します。
 
-### 2020. 10. 27.
+<a id="october-27-2020"></a>
+### 2020. 10. 27. { #october-27-2020 }
+<a id="october-27-2020-more-feature"></a>
 #### 機能追加
 * KubernetesクラスターでGPU基盤のノードグループを使用できます。 
     * イメージアップデート
         * CentOS 7.5 - Container (2020.10.27)
 
-### 2020. 09. 22.
+<a id="09-22"></a>
+### 2020. 09. 22. { #09-22 }
+<a id="09-22-feature-updates"></a>
 #### 機能改善
 * 動作中のノードグループにノードを追加または削除できます。 
 
+<a id="09-22-release-of-new-service"></a>
 #### 新規サービスリリース
 * 韓国(坪村)リージョンでもKubernetesサービスを使用できます。
 
-### 2020. 08. 25.
+<a id="august-25-2020"></a>
+### 2020. 08. 25. { #august-25-2020 }
+<a id="august-25-2020-feature-updates"></a>
 #### 機能改善
 * コンソールでKubernetesクラスターを作成する時、任意の領域(zone)を選択できます。
 
-### 2020. 06. 23.
+<a id="june-23-2020"></a>
+### 2020. 06. 23. { #june-23-2020 }
+<a id="june-23-2020-release-of-new-service"></a>
 #### 新規サービスリリース
 * コンソールからKubernetesクラスターを作成し、管理できます。

--- a/ja/troubleshooting-guide.md
+++ b/ja/troubleshooting-guide.md
@@ -1,9 +1,14 @@
-## Container > NHN Kubernetes Service(NKS) > トラブルシューティング
+<!-- pre-align:aligned sig=d435f80f360f -->
+
+<a id="container-nhn-kubernetes-service-nks-troubleshooting-guide"></a>
+## Container > NHN Kubernetes Service(NKS) > トラブルシューティング { #container-nhn-kubernetes-service-nks-troubleshooting-guide }
 
 NHN Kubernetes Service(NKS)を使用する際に発生する可能性のあるさまざまな問題の解決方法を説明します。
 
-### > ワーカーノードのコンテナログファイルサイズが大きくなり、ディスクスペースが減ります。
+<a id="disk-space-is-reduced-as-the-size-of-the-worker-nodes-container-log-file-increases"></a>
+### > ワーカーノードのコンテナログファイルサイズが大きくなり、ディスクスペースが減ります。 { #disk-space-is-reduced-as-the-size-of-the-worker-nodes-container-log-file-increases }
 
+<a id="disk-space-is-reduced-as-the-size-of-the-worker-nodes-container-log-file-increases-set-log-rotation"></a>
 #### ログローテーションを設定する
 コンテナログファイル管理(最大ファイルサイズ、ログファイル数設定など)のためにワーカーノードに以下のような設定を追加します。
 
@@ -29,6 +34,7 @@ EOF
 > [参考] `CentOS 7.8 - Container (2021.07.27)`以降のインスタンスイメージには上記のようなログローテーション設定が基本的に提供されます。
 <br>
 
+<a id="disk-space-is-reduced-as-the-size-of-the-worker-nodes-container-log-file-increases-synchronize-log-rotation-setting"></a>
 #### ログローテーション設定を同期する
 
 クラスタ運用過程で次のような場合は一部ワーカーノードのログローテーション設定が変わる状況が発生することもあります。
@@ -126,7 +132,8 @@ $
 > [参考]上記の内容は同期を行うための1つの方法にすぎません。ユーザーの環境に、より適切な方法があれば、その方法で同期処理を行ってください。
 
 
-#### > Podの状態がImagePullBackOffと表示されます。
+<a id="the-status-of-the-pod-appears-as-imagepullbackoff"></a>
+### > Podの状態がImagePullBackOffと表示されます。 { #the-status-of-the-pod-appears-as-imagepullbackoff }
 
 2020年11月20日からdockerhubはコンテナイメージpullリクエスト回数に次のような制限を設けるポリシーを実施しました。制限の詳細については、[Understanding Docker Hub Rate Limiting](https://www.docker.com/increase-rate-limits)と[Pricing & Subscriptions](https://www.docker.com/pricing)を参照してください。
 
@@ -144,7 +151,8 @@ NKSのワーカーノードでdockerhubからコンテナイメージをダウ�
 * dockerhubにログインしていない状況で独立したパブリックIPによる制約を受けたい場合は、ワーカーノードにFloating IPを割り当てます。
 
 
-### > クローズドネットワーク環境でfailed to pull image `k8s.gcr.io/pause:3.2`が発生します。
+<a id="failed-to-pull-image-k8sgcriopause32-in-a-closed-network-environment"></a>
+### > クローズドネットワーク環境でfailed to pull image `k8s.gcr.io/pause:3.2`が発生します。 { #failed-to-pull-image-k8sgcriopause32-in-a-closed-network-environment }
 クローズドネットワーク環境のクラスターがパブリックレジストリからイメージを取得できないため発生する問題であり、2024年8月以前に作成されたクラスターで発生する可能性があります。k8s.gcr.io/pause:3.2`イメージのように、デフォルトで配布されているイメージは、ワーカーノード作成時にNHN Cloud内部レジストリからプルされます。しかし、最初にイメージをプルされた後、イメージが削除された場合、問題が発生する可能性があります。クラスター作成時、基本的に配布されるイメージのリストは次のとおりです。
 * kubernetesui/dashboard
 * k8s.gcr.io/pause
@@ -182,11 +190,13 @@ imageGCHighThresholdPercent=85 :ディスク使用率が85%を超える場合、
 imageGCLowThresholdPercent=80 :ディスク使用率が80%以下の場合、イメージGarbage Collectionを実行しません。
 ```
 
+<a id="failed-to-pull-image-k8sgcriopause32-in-a-closed-network-environment-workaround"></a>
 #### 解決策
 NKSレジストリを有効にすると、クローズドネットワーク環境でコンテナイメージをパブリックレジストリから取得せず、NHN Cloud内部レジストリから取得するようにクラスター設定を変更できます。NKSレジストリは、クラスター照会画面で有効化できます。
 
 
-### > `quay.io`からFlannel CNI関連イメージのpullが失敗します。
+<a id="image-pull-for-flannel-cni-related-images-from-quayio-fails"></a>
+### > `quay.io`からFlannel CNI関連イメージのpullが失敗します。 { #image-pull-for-flannel-cni-related-images-from-quayio-fails }
 
 Flannel関連コンテナイメージのリポジトリドメインは`quay.io`をベースに設定されています。`quay.io`で該当イメージに対するpullサービスが終了したため、該当イメージをpullできなくなりました。
 
@@ -200,7 +210,8 @@ Flannel関連コンテナイメージのリポジトリドメインは`quay.io`�
     * 変更前: `quay.io/coreos/flannel*`
     * 変更後: `ghcr.io/flannel-io/flannel*`
     
-### > k8s v1.24 以上のバージョンで `pulling from host docker.pkg.github.com failed` エラーが発生し、イメージpullが失敗します。
+<a id="in-k8s-v124-and-later-the-pull-from-host-dockerpkggithubcom-failed-error-occurs-and-the-image-pull-fails"></a>
+### > k8s v1.24 以上のバージョンで `pulling from host docker.pkg.github.com failed` エラーが発生し、イメージpullが失敗します。 { #in-k8s-v124-and-later-the-pull-from-host-dockerpkggithubcom-failed-error-occurs-and-the-image-pull-fails }
 
 githubのパッケージレジストリがDockerレジストリからContainerレジストリに変更されたため発生した問題です。 v1.24以前のバージョンのクラスタはコンテナランタイムとしてDockerを使用して `docker.pkg.github.com` レジストリからイメージpullが可能でしたが、v1.24以降のバージョンのNKSクラスタはコンテナランタイムとしてcotainerdを使用するため、`docker.pkg.github.com` レジストリからイメージpullができません。パッケージレジストリの移行に関する詳細は[Migration to Container registry from the Docker registry](https://docs.github.com/en/packages/working-with-a-github-packages-registry/migrating-to-the-container-registry-from-the-docker-registry) を参照してください。
 
@@ -208,10 +219,12 @@ githubのパッケージレジストリがDockerレジストリからContainer�
 解決方法は次のとおりです。
 Podマニフェストに定義されたimage URLのbaseを`docker.pkg.github.com`から`gchr.io`に変更します。
 
-### > `cannot allocate memory`エラーが発生し、Podの状態が`FailedCreatePodContainer`と表示されます。
+<a id="cannot-allocate-memory-error-occurs-and-the-pods-status-appears-as-failedcreatepodcontainer"></a>
+### > `cannot allocate memory`エラーが発生し、Podの状態が`FailedCreatePodContainer`と表示されます。 { #cannot-allocate-memory-error-occurs-and-the-pods-status-appears-as-failedcreatepodcontainer }
 
 Linuxカーネルの機能の中でmemory cgroupに対するkernel object accounting機能のバグで発生する現象です。主にLinuxカーネル3.x, 4.xバージョンで発生し、dying memory cgroup problem問題として知られています。ユーザーがイメージレベルでmemory cgroupに対するkernel object accounting機能を無効にしてこの問題を回避できます。
 
+<a id="cannot-allocate-memory-error-occurs-and-the-pods-status-appears-as-failedcreatepodcontainer-apply-the-workaround-to-existing-clusters"></a>
 #### 作成済みのクラスタに解決策を適用
 ワーカーノードに接続して起動オプションを変更した後、再起動します。
 
@@ -235,6 +248,7 @@ $ reboot
 
 この問題は常に発生するわけではなく、ユーザーのアプリケーション特性によって発生する可能性があります。もし問題発生が懸念される場合、NKSのカスタムイメージ機能を利用して、最初から上記のような解決策が適用されたワーカーノードイメージを使用できます。
 
+<a id="cannot-allocate-memory-error-occurs-and-the-pods-status-appears-as-failedcreatepodcontainer-apply-the-workaround-to-newly-created-clusters-using-the-nks-custom-image-feature"></a>
 #### NKSのカスタムイメージ機能を使って新しく作成したクラスタに解決策を適用
 NKSではユーザーのカスタムイメージをベースにしたワーカーノードグループを作成する機能を提供しています。NKSカスタムイメージ機能を使用してmemory cgroupに対するkernel object accounting機能が無効化されたイメージを作成し、クラスタ作成時に活用することができます。カスタムイメージの使用機能の詳細については、[カスタムイメージをワーカーイメージとして活用](/Container/NKS/ja/user-guide/#custom-image)を参照してください。
 
@@ -248,7 +262,8 @@ sudo grub2-mkconfig -o /boot/grub2/grub.cfg
 ```
 
 
-### > rpc.statd is not running but is required for remote lockingエラーが発生し、PodでNASボリュームマウントが失敗します。
+<a id="rpcstatd-is-not-running-but-is-required-for-remote-locking-error-occurs-and-the-pod-fails-to-mount-the-nas-volume"></a>
+### > rpc.statd is not running but is required for remote lockingエラーが発生し、PodでNASボリュームマウントが失敗します。 { #rpcstatd-is-not-running-but-is-required-for-remote-locking-error-occurs-and-the-pod-fails-to-mount-the-nas-volume }
 
 ワーカーノードのrpc.statdプロセスがゾンビプロセスになったり、管理者のコマンドによって停止して発生する問題です。ボリュームをマウントするためには、ワーカーノードでrpcbindとrpc.statdプロセスが正常に実行されている必要があります。解決策は次のとおりです。
 ```
@@ -256,7 +271,8 @@ systemctl restart rpc-statd
 systemctl restart rpcbind
 ```
 
-### > PV容量を増設しても、Podのファイルシステムに増設された容量が反映されません。
+<a id="the-pods-file-system-does-not-reflect-the-increased-capacity-after-the-pv-capacity-is-increased"></a>
+### > PV容量を増設しても、Podのファイルシステムに増設された容量が反映されません。 { #the-pods-file-system-does-not-reflect-the-increased-capacity-after-the-pv-capacity-is-increased }
 2024年8月以前に作成された1.20以上のバージョンのクラスターで発生する可能性がある問題です。下記のスクリプトを実行してクラスターに配布されたcinder-csi-driverをアップデートして問題を解決できます。スクリプトの実行後、新しく作成されたPVまたは容量が増設されたPVにのみ設定の更新が反映されます。
 
 kubeconfig_file_path変数にクラスターのkubeconfigファイルが位置する絶対パス値を定義した後、スクリプトを実行します。
@@ -292,12 +308,14 @@ kubectl -n kube-system rollout restart daemonet cinder-csi-nodeplugin
 kubectl -n kube-system rollout restart statefulset cinder-csi-controllerplugin
 ```
 
-### > timed out waiting for conditionエラーが発生し、Podのボリュームマウントが失敗します。
+<a id="error-of-timed-out-waiting-for-condition-occurs-and-the-volume-mount-to-the-pod-fails"></a>
+### > timed out waiting for conditionエラーが発生し、Podのボリュームマウントが失敗します。 { #error-of-timed-out-waiting-for-condition-occurs-and-the-volume-mount-to-the-pod-fails }
 これは、大きなサイズのボリュームをPodにマウントする場合に発生する可能性のある問題です。基本的に、Kubernetesはボリュームをマウントする際、各ボリュームの内容に対する所有権と権限を変更し、PodのSecurityContextに指定されたfsGroupと一致するようにします。ボリュームが大きい場合、所有権と権限を確認して変更するのに時間がかかり、タイムアウトが発生する可能性があります。
 
 タイムアウトの発生を防ぐために、securityContextのfsGroupChangePolicyフィールドを使用して、Kubernetesがボリュームの所有権と権限を確認して管理する方法を変更できます。詳細は[Configure volume permission and ownership change policy for pods](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#configure-volume-permission-and-ownership-change-policy-for-pods)を参照してください。
 
-### > Calico-eBPF CNIを使用するクラスターのPodにhostnetwork: true, dnsPolicy: ClusterFirstWithHostNetオプションを設定すると、UDP通信の問題が発生します。
+<a id="setting-the-hostnetwork-true-dnspolicy-clusterfirstwithhostnet-option-on-a-pod-in-a-cluster-with-calico-ebpf-cni-causes-udp-communication-issues"></a>
+### > Calico-eBPF CNIを使用するクラスターのPodにhostnetwork: true, dnsPolicy: ClusterFirstWithHostNetオプションを設定すると、UDP通信の問題が発生します。 { #setting-the-hostnetwork-true-dnspolicy-clusterfirstwithhostnet-option-on-a-pod-in-a-cluster-with-calico-ebpf-cni-causes-udp-communication-issues }
 Calico v3.28.0でUDP通信中、BPF NATテーブルがネットワークパケットを正しく処理できないために発生する問題です。 eBPFを使用する場合、TCPは`CTLB(connect-time load balancing)`方式で通信し、UDPはBPFが管理する`NATテーブル`を通じて通信します。この問題はUDP通信もCTLB方式に変更すれば解決できます。
 
 `CTLB(connect-time load balancing)`は、ネットワークロードバランシング技術の1つで、クライアントがサーバーに初めて接続する際、最初のパケットでバックエンドサーバーを選択し、その後の全てのトラフィックは選択されたバックエンドサーバーに直接転送されます。これにより、セッションの永続性が保証され、毎回ロードバランシングを実行するオーバーヘッドを減らすことができます。
@@ -316,23 +334,28 @@ Podのテンプレートが修正されると、ローリングアップデー�
     value: "Disabled"
 ```
 
+<a id="setting-the-hostnetwork-true-dnspolicy-clusterfirstwithhostnet-option-on-a-pod-in-a-cluster-with-calico-ebpf-cni-causes-udp-communication-issues-cautions-for-setting-up-udp-communication-after-applying-the-workaround"></a>
 #### 解決策適用後、UDP通信を設定する際の注意事項
 UDPは非接続型プロトコルで、サーバー/クライアント通信時、別途セッションを設定したり、接続を維持することなくデータを送信します。しかし、Golang `net.DialUDP()`関数などのUDPの`connect()`関数を使用するとUDPソケットを特定アドレスと接続して指定されたアドレスにのみデータを送受信できます。
 CalicoのeBPFを使用すると、UDPのCTLB(connect-time load balancing)が有効化になっているクラスターにUD `connect()`関数を使用するPodを配布した場合、サーバーの役割を行うPodが再配布されると、通信問題が発生する可能性があります。これは、UDPソケットが最初に接続されたサーバーアドレスにのみデータ転送を試みるためです。サーバーPodが再配布されると、IPアドレスやネットワークパスが変更される可能性がありますが、UDP connect()ソケットは以前のサーバーアドレスにのみデータを送信するため、通信に失敗する可能性があります。
 この問題はUDP connect()の動作方法とCTLB環境で発生する既知の問題なので、Calico eBPFとUDP CTLBを使用するクラスターでUDPのconnect()関数を使用する場合、このような通信問題が発生する可能性があることを認識して注意する必要があります。
 
-### > Calico-eBPFクラスターでistioが誤動作します。
+<a id="istio-is-not-working-properly-in-a-calico-ebpf-cluster"></a>
+### > Calico-eBPFクラスターでistioが誤動作します。 { #istio-is-not-working-properly-in-a-calico-ebpf-cluster }
 eBPFが有効になると、`CTLB(connect-time load balancing)`方式で接続時にロードバランシングを行い、クライアントがサービスに接続しようとする最初のパケットでバックエンドPodを選択し、その後の全てのパケットは該当バックエンドに直接転送されます。一方、Istioはサービスメッシュを構成するためにサイドカープロキシを配備し、プロキシはアプリケーショントラフィックを傍受して制御とモニタリングの役割を果たします。
 CTLBが有効になっている場合、パケットはBPF MAPから目的地Podに直接転送され、この過程でパケットが改ざんされます。そのため、Istioのプロキシを経由せず、パケットは目的地Podに直接転送されます。このようなeBPFネットワーク構造により、Istioの機能が正常に動作しない場合があります。istioを使ったクラスター管理が必要な場合は、Calico-VXLANクラスターの使用を考慮する必要があります。
 
 
-### > Calico-eBPF CNIを使用するクラスターでノード削減後、増設時にネットワーク障害が発生します。
+<a id="in-a-cluster-using-calico-ebpf-cni-network-failures-occur-when-scaling-up-after-node-reduction"></a>
+### > Calico-eBPF CNIを使用するクラスターでノード削減後、増設時にネットワーク障害が発生します。 { #in-a-cluster-using-calico-ebpf-cni-network-failures-occur-when-scaling-up-after-node-reduction }
 Calico v3.28.0のcalico/kube-controllersで発見されたバグにより発生する問題です。ノード削減の際、calico/kube-cube-controllers Podが配布されたノードが削除されると、そのノードは他のノードにスケジューリングされて実行されます。calico/kube-controllersが再実行されている間、ノード情報が同期されません。この状態で削除したノードと同じ名前のノードが追加されると、ネットワーク障害が発生する可能性があります。
 
 この問題はCalico v3.28.2で修正されました。Calico v3.28.2を使うためには、Kubernetesのバージョンをアップグレードするか、クラスターを再作成する必要があります。
 
-### > クラスターアップグレードに失敗します。
+<a id="failed-to-upgrade-clusters"></a>
+### > クラスターアップグレードに失敗します。 { #failed-to-upgrade-clusters }
 
+<a id="failed-to-upgrade-clusters-when-creating-an-nks-check-whether-finalizers-are-set-on-the-resources-that-are-deployed-by-default"></a>
 #### NKS作成時に基本的に配布されるリソースにfinalizersが設定されているかどうかを確認する必要があります。
 NKS作成時に配布されたリソースにfinalizersが設定されている場合、リソースが削除されず、アップグレードに失敗します。全てのワーカーノードグループのアップグレードが完了すると、NKS初期配布リソースが再配布されます。この過程でNKS初期配布リソースにfinalizersが設定されている場合、リソース再配布に失敗してアップグレードが中断されます。この問題を解決するためには、アップグレード前にNKS初期配布リソースにfinalizers設定を削除する必要があります。
 
@@ -346,17 +369,20 @@ kubectl patch clusterrole calico-kube-controllers --type=json -p='[{"op": "remov
 ```
 
 
-### > NKSレジストリが非活性状態のv1.29.3以下バージョンのクラスタで、ノード増設またはノードグループ追加時にcalico-node Podのデプロイに失敗し、ノード初期化作業に失敗します。
+<a id="when-scaling-out-nodes-or-adding-node-groups-in-a-cluster-running-v1293-or-earlier-with-an-inactive-nks-registry-the-calico-node-pod-deployment-fails-causing-the-node-initialization-task-to-fail"></a>
+### > NKSレジストリが非活性状態のv1.29.3以下バージョンのクラスタで、ノード増設またはノードグループ追加時にcalico-node Podのデプロイに失敗し、ノード初期化作業に失敗します。 { #when-scaling-out-nodes-or-adding-node-groups-in-a-cluster-running-v1293-or-earlier-with-an-inactive-nks-registry-the-calico-node-pod-deployment-fails-causing-the-node-initialization-task-to-fail }
 誤ったイメージリポジトリ設定により、ノード増設またはノードグループ追加時にcalico関連Pod(calico-node, calico-kube-controllers, calico-typha)がデプロイされずに発生する問題です。
 
 この問題は主に2024年5月以前に作成されたクラスタで発生する可能性があります。当時作成されたクラスタはNKS専用イメージレジストリが基本的に非活性状態であり、Calicoコンテナイメージのリポジトリパスが正しくないため、イメージのダウンロードが不可能なことが原因です。
 
+<a id="when-scaling-out-nodes-or-adding-node-groups-in-a-cluster-running-v1293-or-earlier-with-an-inactive-nks-registry-the-calico-node-pod-deployment-fails-causing-the-node-initialization-task-to-fail-how-to-check-if-the-symptom-occurs"></a>
 #### 症状発生時の確認方法
 `kubectl get all -n kube-system`コマンドで確認時、増設作業に失敗したノードにデプロイされている以下のPodの状態が**ImagePullBackOff**または**ErrImagePull**で維持されます。
 - calico-node
 - calico-kube-controllers
 - calico-typha
 
+<a id="when-scaling-out-nodes-or-adding-node-groups-in-a-cluster-running-v1293-or-earlier-with-an-inactive-nks-registry-the-calico-node-pod-deployment-fails-causing-the-node-initialization-task-to-fail-solution"></a>
 #### 解決策
 calico関連imageリポジトリurlをpublicリポジトリに変更することで問題を解決できます。ただし、インターネットに接続可能なクラスタにのみ適用可能です。作業進行中、一時的にクラスタPodのネットワーキングが切断される可能性があるため、作業進行時に注意が必要です。作業段階は次のとおりです。
 

--- a/ja/user-guide.md
+++ b/ja/user-guide.md
@@ -1,7 +1,13 @@
-## Container > NHN Kubernetes Service(NKS) > 使用ガイド
+<a id="container-nhn-kubernetes-service-nks-user-guide"></a>
+## Container > NHN Kubernetes Service(NKS) > 使用ガイド { #container-nhn-kubernetes-service-nks-user-guide }
+
+<a id="cluster-headings"></a>
+## クラスター { #cluster-headings }
+
+<!-- TODO: translate body -->
 
 <a id="cluster-create"></a>
-### クラスター作成
+### クラスター作成 { #cluster-create }
 NHN Kubernetes Service(NKS)を使用するには、まずクラスターを作成する必要があります。
 
 > [注意]クラスタを使用するための権限設定<br>
@@ -74,7 +80,7 @@ NHN Kubernetes Service(NKS)を使用するには、まずクラスターを作�
 >  - 計算 : 254(ノードごとにPodに割り当て可能な最大IP数) * 253(最大作成可能なノード数) =最大64,262個のIPを使用可能
 
 <a id="cluster-show"></a>
-### クラスター照会
+### クラスター照会 { #cluster-show }
 作成したクラスタは**Container > NHN Kubernetes Service(NKS)**サービスページで確認できます。クラスタリストには各クラスタの簡単な情報が表示されます。
 
 | 項目 | 説明 |
@@ -130,11 +136,11 @@ k8s Node状態のアイコン別の意味は次のとおりです。
 | 設定ファイル | クラスターにアクセスして操作するために必要な設定ファイルのダウンロードボタン |
 
 <a id="cluster-delete"></a>
-### クラスター削除
+### クラスター削除 { #cluster-delete }
 削除するクラスターを選択し、**クラスター削除**を押すと削除が行われます。削除には約5分かかります。クラスターの状態によっては、さらに時間がかかる場合もあります。
 
 <a id="change-keypair"></a>
-### クラスターキーペア変更
+### クラスターキーペア変更 { #change-keypair }
 
 クラスターに属する全てのワーカーノードのキーペアを変更します。設定するキーペアはログインしたユーザーのキーペアを選択します。キーペアを変更すると、以下の内容が適用されます。
 
@@ -149,11 +155,11 @@ k8s Node状態のアイコン別の意味は次のとおりです。
 > * クラスターオーナー変更機能は提供していません。クラスターがサービスユーザーの権限で動作できるようにするにはキーペア変更機能を利用してください。
 
 <a id="nodegroup-headings"></a>
-## ノードグループ
+## ノードグループ { #nodegroup-headings }
 ノードグループはKubernetesを構成するワーカーノードインスタンスのグループです。
 
 <a id="nodegroup-show"></a>
-### ノードグループ照会
+### ノードグループ照会 { #nodegroup-show }
 クラスタリストからクラスタ名を押すと、ノードグループリストを確認できます。ノードグループを選択すると、下部にノードグループ情報が表示されます。
 
 | 項目 | 説明 |
@@ -206,7 +212,7 @@ k8s Node状態のアイコン別の意味は次のとおりです。
 **ノードリスト**タブでは、ノードグループを構成するインスタンスのリストを確認できます。
 
 <a id="nodegroup-create"></a>
-### ノードグループ作成
+### ノードグループ作成 { #nodegroup-create }
 クラスターを作成すると、基本ノードグループが作成されますが、必要に応じて追加ノードグループを作成できます。基本ノードグループのインスタンスより高い仕様のコンテナ起動環境が必要な場合や、スケールアウト(scale out、拡張)のためにさらに多くのワーカーノードインスタンスが必要な場合は、追加ノードグループを作成して使用できます。ノードグループリストページで**ノードグループ作成**ボタンを押すと、ノードグループ作成ページが表示されます。ノードグループの作成に必要な項目は次のとおりです。
 
 | 項目 | 説明 |
@@ -226,7 +232,7 @@ k8s Node状態のアイコン別の意味は次のとおりです。
 >該当クラスタを作成したユーザーのみノードグループを作成できます。
 
 <a id="nodegroup-delete"></a>
-### ノードグループ削除
+### ノードグループ削除 { #nodegroup-delete }
 ノードグループリストから削除するノードグループを選択し、**ノードグループ削除**ボタンを押すと、削除が行われます。ノードグループの削除には約5分かかります。ノードグループの状態によっては、さらに時間がかかる場合もあります。
 
 ノードグループに含まれる全てのノードは、次の順序で削除されます。
@@ -236,14 +242,14 @@ k8s Node状態のアイコン別の意味は次のとおりです。
 * 該当ノードがインスタンスレベルで削除されます。
 
 <a id="nodegroup-scale-out"></a>
-### ノードグループにノード追加
+### ノードグループにノード追加 { #nodegroup-scale-out }
 動作中のノードグループにノードを追加できます。ノードグループ情報照会ページのノードリストタブを押すと、現在のノードリストが表示されます。ノード追加ボタン押し、ノード数を入力するとノードが追加されます。
 
 >[注意]
 >オートスケーラーが有効になっているノードグループは、手動でノードを追加できません。
 
 <a id="nodegroup-scale-in"></a>
-### ノードグループからノード削除
+### ノードグループからノード削除 { #nodegroup-scale-in }
 動作中のノードグループからノードを削除できます。ノードグループ情報照会ページのノードリストタブを押すと、現在のノードリストが表示されます。ノードリストの中から削除するノードを選択し、ノード削除ボタンを押すと、確認ダイアログボックスが表示されます。削除するノード名をもう一度確認して確認ボタンを押すとノードが削除されます。
 
 >[注意]
@@ -257,9 +263,10 @@ k8s Node状態のアイコン別の意味は次のとおりです。
 >オートスケーラーが有効になっているノードグループは、手動でノードを削除できません。
 
 <a id="node-start-stop"></a>
-### ノードの停止と起動
+### ノードの停止と起動 { #node-start-stop }
 ノードグループに属すノードのうち一部を停止させ、停止したノードを再度起動できます。ノードグループ情報照会ページのノードリストタブをクリックすると現在のノードリストが現れます。停止するノードを選択し、ノード停止ボタンをクリックするとノードが停止します。停止したノードを選択し、ノード起動ボタンをクリックするとノードが再び起動します。
 
+<a id="node-start-stop-action-process"></a>
 #### 動作プロセス
 
 起動状態のノードを停止すると次の順序で動作します。
@@ -275,6 +282,7 @@ k8s Node状態のアイコン別の意味は次のとおりです。
 * 当該ノードがKubernetesノードリソースに再び追加されます。
 
 
+<a id="node-start-stop-constraints"></a>
 #### 制約事項
 
 ノードの停止と起動機能は、次の制約事項があります。
@@ -286,6 +294,7 @@ k8s Node状態のアイコン別の意味は次のとおりです。
 * 停止したノードが存在するノードグループはアップグレードできません。
 
 
+<a id="node-start-stop-display-status"></a>
 #### 状態表示
 
 ノードの状態に基づいてノードリストタブの状態アイコンが表示されます。アイコンの各色の状態は次のとおりです。
@@ -295,7 +304,7 @@ k8s Node状態のアイコン別の意味は次のとおりです。
 * 赤色：異常状態のノード
 
 <a id="use-gpu-nodegroup"></a>
-### GPUノードグループ使用 
+### GPUノードグループ使用 { #use-gpu-nodegroup }
 KubernetesでGPU基盤ワークロードの実行が必要な場合、 GPUインスタンスで構成されたノードグループを作成できます。
 クラスターまたはノードグループ作成プロセスでインスタンスタイプを選択する時、 `g2`タイプを選択するとGPUノードグループを作成できます。
 
@@ -305,6 +314,7 @@ KubernetesでGPU基盤ワークロードの実行が必要な場合、 GPUイン
 
 作成されたGPUノードの基本的な設定のヘルスチェックおよび簡単な動作テストは次のような方法を利用できます。
 
+<a id="use-gpu-nodegroup-node-level-status-check"></a>
 #### ノード水準のヘルスチェック
 GPUノードに接続した後、`nvidia-smi`コマンドを実行します。
 次のような内容が出力されればGPU driverが正常に動作しているということです。
@@ -330,6 +340,7 @@ Mon Jul 27 14:38:07 2020
 +-----------------------------------------------------------------------------+ 
 ```
 
+<a id="use-gpu-nodegroup-kubernetes-level-status-check"></a>
 #### Kubernetes水準のヘルスチェック
 `kubectl`コマンドを使用してクラスター水準で使用可能なGPUリソース情報を確認します。
 以下は各ノードで使用可能なGPUコアの個数を出力するコマンドおよび実行結果です。
@@ -340,6 +351,7 @@ NAME                                       GPU Allocatable   GPU Capacity
 my-cluster-default-w-vdqxpwisjjsk-node-1   1                 1
 ```
 
+<a id="use-gpu-nodegroup-sample-workload-execution-for-gpu-testing"></a>
 #### GPUテストのためのサンプルワークロード実行
 Kubernetesクラスターに属すGPUノードはCPUとメモリの他に`nvidia.com/gpu`という名前のリソースを提供します。
 GPUを使用したい場合は`nvidia.com/gpu`リソースを割り当てられるように、下記のサンプルファイルのように入力してください。
@@ -414,7 +426,7 @@ totalMemory: 14.73GiB freeMemory: 14.62GiB
 > GPUが必要ないワークロードがGPUノードに割り当てられることを防ぎたい場合は[TaintおよびTolerationの概要](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/)を参照してください。
 
 <a id="autoscaler"></a>
-### オートスケーラー
+### オートスケーラー { #autoscaler }
 オートスケーラーは、ノードグループの利用可能なリソースが不足したり、ノードの使用率が一定レベル以下で維持される場合、ノードの数を自動的に調整する機能です。この機能は、ノードグループごとに設定することができ、互いに独立して動作します。NKSでは2つの方式のオートスケーラーをサポートしています。
 
 * 指標ベースのオートスケーラー
@@ -1009,7 +1021,7 @@ autoscaler-test-default-w-ohw5ab5wpzug-node-0   Ready    <none>   22d   v1.28.3
 ```
 
 <a id="user-script-old"></a>
-### ユーザースクリプト(old)
+### ユーザースクリプト(old) { #user-script-old }
 クラスタを作成する時と追加ノードグループを作成する時、ユーザースクリプトを登録できます。ユーザースクリプト機能には次のような特徴があります。
 
 * 機能設定
@@ -1029,7 +1041,7 @@ autoscaler-test-default-w-ohw5ab5wpzug-node-0   Ready    <none>   22d   v1.28.3
         * スクリプト標準出力および標準エラーストリーム：`/var/log/userscript.output`
 
 <a id="user-script"></a>
-### ユーザースクリプト
+### ユーザースクリプト { #user-script }
 2022年7月26日以降に作成されるノードグループには新しいバージョンのユーザースクリプト機能が搭載されます。以前のバージョンの機能と比較して次のような特徴があります。
 
 * **ワーカーノードグループが作成された後もユーザースクリプトの内容を変更できます。**
@@ -1049,10 +1061,11 @@ autoscaler-test-default-w-ohw5ab5wpzug-node-0   Ready    <none>   22d   v1.28.3
         2. 新規バージョンのユーザースクリプト
 
 <a id="instance-flavor-update"></a>
-### インスタンスタイプの変更
+### インスタンスタイプの変更 { #instance-flavor-update }
 ワーカーノードグループのインスタンスタイプを変更します。ワーカーノードグループに属す全てのワーカーノードのインスタンスタイプが変更されます。
 
 
+<a id="instance-flavor-update-process"></a>
 #### 進行プロセス
 
 インスタンスタイプの変更は次の順序で行います。
@@ -1069,6 +1082,7 @@ autoscaler-test-default-w-ohw5ab5wpzug-node-0   Ready    <none>   22d   v1.28.3
 インスタンスタイプの変更は、ワーカーコンポーネントアップグレードと同様の方法で行われます。バッファノードの作成と削除、Podの追放については[クラスタアップグレード](/Container/NKS/ja/user-guide/#cluster-upgrade)を参照してください。
 
 
+<a id="instance-flavor-update-constraints"></a>
 #### 制約事項
 
 インスタンスの現在タイプによって変更できるタイプが異なります。
@@ -1078,13 +1092,14 @@ autoscaler-test-default-w-ohw5ab5wpzug-node-0   Ready    <none>   22d   v1.28.3
 * u2タイプのインスタンスは作成後にタイプを変更できません。同じu2タイプへの変更もできません。
 
 <a id="custom-image"></a>
-### カスタムイメージをワーカーイメージとして活用
+### カスタムイメージをワーカーイメージとして活用 { #custom-image }
 
 ユーザーのカスタムイメージをベースにしたウォーカーノードグループを作成することができます。カスタムイメージがワーカーノードイメージとして活用できるようにNHN Cloud Image Builderサービスで追加作業(NKSワーカーノード化)が必要です。 Image BuilderサービスでNHN Kubernetes Service(NKS)ワーカーノードアプリケーションでイメージテンプレートを作成してカスタムワーカーノードイメージを作成できます。 Image Builderサービスの詳細については[Image Builderユーザーガイド](/Compute/Image%20Builder/ko/console-guide/#_1)を参照してください。
 
 > [注意]
 > NKSワーカーノード化作業にはパッケージのインストールや設定変更などが含まれているため、正常に動作しないイメージで作業を進める場合、失敗する可能性があります。
 > Image Builderサービスの使用に対して課金される場合があります。
+<a id="custom-image-constraints"></a>
 #### 制約事項
 サポートされるOSイメージとOSイメージごとに選択しなければならないアプリケーションのバージョン情報は以下の表の通りです。カスタムイメージを作成するベースインスタンスのイメージに合わせて正しいバージョンのアプリケーションを選択する必要があります。
 
@@ -1109,6 +1124,7 @@ autoscaler-test-default-w-ohw5ab5wpzug-node-0   Ready    <none>   22d   v1.28.3
 > [参考]
 > カスタムイメージをワーカーノードイメージに変換する過程で選択したオプションによってGPUドライバーがインストールされます。
 > したがって、 カスタムGPUワーカーノードイメージを作成する場合にも、カスタムイメージの作成をGPUインスタンスで行う必要はありません。
+<a id="custom-image-process"></a>
 #### 進行過程
 
 カスタムイメージをワーカーノードイメージとして活用するため、Image Builderサービスで下記のようなプロセスを実行します。
@@ -1130,7 +1146,7 @@ autoscaler-test-default-w-ohw5ab5wpzug-node-0   Ready    <none>   22d   v1.28.3
 ![nkscustom_image_3.png](http://static.toastoven.net/prod_infrastructure/container/kubernetes/nkscustom_image_3.png)
 
 <a id="extra-volumes"></a>
-### 追加ブロックストレージ
+### 追加ブロックストレージ { #extra-volumes }
 ノードグループに追加ブロックストレージを使用できます。クラスターおよびノードグループを作成する際に追加ブロックストレージを指定して作成したり、既存のノードグループに追加ブロックストレージを作成して使用できます。追加ブロックストレージには次のような特徴があります。
 
 * 追加ブロックストレージは、ノードグループごとに最大3つまで設定することができ、ブロックストレージのサイズは1～2048GBの範囲で指定可能です。
@@ -1148,7 +1164,7 @@ autoscaler-test-default-w-ohw5ab5wpzug-node-0   Ready    <none>   22d   v1.28.3
 > 追加ブロックストレージの設定変更は、既存ボリュームのマウント解除を含むため、使用中のサービスに影響を与える可能性があります。
 
 <a id="extra-security-groups"></a>
-### 追加セキュリティグループ
+### 追加セキュリティグループ { #extra-security-groups }
 ノードグループに追加セキュリティグループを設定できます。クラスター及びノードグループを作成する際に追加セキュリティグループを指定して作成したり、既存のノードグループに追加セキュリティグループを設定できます。追加セキュリティグループの特徴は次のとおりです。
 
 * 追加セキュリティグループは、サブネットごとに最大8つまで設定できます。
@@ -1163,7 +1179,7 @@ autoscaler-test-default-w-ohw5ab5wpzug-node-0   Ready    <none>   22d   v1.28.3
 > 追加セキュリティグループを変更すると、ネットワーク設定が変更されるため、設定が適用される間、一時的に通信に影響が出る可能性があります。
 
 <a id="fip-auto-bind"></a>
-### フローティングIP自動割り当て
+### フローティングIP自動割り当て { #fip-auto-bind }
 ノードグループにフローティングIP自動割り当て機能を使用できます。この機能が有効化されたノードグループは、ノード作成時にフローティングIPを自動的に割り当てます。クラスター及び追加ノードグループを作成する際に、機能を有効にするかどうかを選択することができ、設定したオプションは後から変更できます。フローティングIP自動割り当て機能を有効にするために必要な項目は次のとおりです。
 
 | 項目 | 説明 | 
@@ -1181,11 +1197,11 @@ autoscaler-test-default-w-ohw5ab5wpzug-node-0   Ready    <none>   22d   v1.28.3
   * 機能が有効になっているノードグループで機能を無効にしても、既存のノードに割り当てられたフローティングIPは解除されません。
 
 <a id="cluster-management"></a>
-## クラスター管理
+## クラスター管理 { #cluster-management }
 遠隔のホストからクラスターを操作し、管理するには、Kubernetesが提供するコマンドラインツール(CLI)、`kubectl`が必要です。
 
 <a id="kubectl-install"></a>
-### kubectlインストール
+### kubectlインストール { #kubectl-install }
 kubectlは、インストール不要で、実行ファイルをダウンロードしてすぐに使用できます。各OSのダウンロードパスは次のとおりです。
 
 > [注意]
@@ -1199,6 +1215,7 @@ kubectlは、インストール不要で、実行ファイルをダウンロー�
 
 その他、インストール方法とオプションなどの詳細は、[Install and Set Up kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/)文書を参照してください。
 
+<a id="kubectl-install-change-permission"></a>
 #### 権限変更
 ダウンロードしたファイルは基本的に実行権限がありません。実行権限を追加する必要があります。
 
@@ -1206,6 +1223,7 @@ kubectlは、インストール不要で、実行ファイルをダウンロー�
 $ chmod +x kubectl
 ```
 
+<a id="kubectl-install-change-the-location-or-set-the-path"></a>
 #### 位置変更またはパス指定
 どのパスからでもkubectlを実行できるように環境変数に指定されたパスに移すか、kubectlがあるパスを環境変数に追加します。
 
@@ -1221,7 +1239,7 @@ $ export PATH=$PATH:$(pwd)
 ```
 
 <a id="kubectl-set-kubeconfig"></a>
-### 設定
+### 設定 { #kubectl-set-kubeconfig }
 kubectlでKubernetesクラスターにアクセスするには、クラスター設定ファイル(kubeconfig)が必要です。NHN Cloud Webコンソールで**Container > NHN Kubernetes Service(NKS)**サービスページを開き、アクセスするクラスターを選択します。下部、**基本情報**タブで**設定ファイル**項目の**ダウンロード**ボタンを押して設定ファイルをダウンロードします。ダウンロードした設定ファイルは、任意の位置へ移動させ、kubectl実行時に参照できるように準備します。
 
 > [注意]
@@ -1236,7 +1254,7 @@ $ export KUBECONFIG={クラスター設定ファイルパス}
 クラスター設定ファイルのパスを環境変数に保存したくない場合は、kubectlの基本設定ファイル、`$HOME/.kube/config`にコピーして使用することもできます。しかし、クラスターを複数運用する場合は、環境変数の値を変更する方法が便利です。
 
 <a id="kubectl-check-connection"></a>
-### 接続確認
+### 接続確認 { #kubectl-check-connection }
 `kubectl version`コマンドで、正常に設定できているかを確認します。問題がなければ`Server Version`が出力されます。
 
 ```
@@ -1249,9 +1267,10 @@ Server Version: version.Info{Major:"1", Minor:"15", GitVersion:"v1.15.7", GitCom
 * Server Version：クラスターを構成しているKubernetesのバージョン情報
 
 <a id="certificatesigningrequest"></a>
-### CSR(CertificateSigningRequest)
+### CSR(CertificateSigningRequest) { #certificatesigningrequest }
 Kubernetesの認証API(Certificate API)を通してKubernetes APIクライアントのためのX.509証明書(certificate)をリクエストして発行できます。 CSRリソースは証明書をリクエストして、リクエストに対して承認/拒否を決定できるようにします。詳細事項は[Certificate Signing Requests](https://kubernetes.io/docs/reference/access-authn-authz/certificate-signing-requests/)文書を参照してください。
 
+<a id="certificatesigningrequest-csr-request-and-issue-approval-example"></a>
 #### CSRリクエストと発行承認例
 まず秘密鍵(private key)を作成します。証明書作成に関する詳細は[Certificates](https://kubernetes.io/docs/tasks/administer-cluster/certificates/)文書を参照してください。
 
@@ -1350,11 +1369,12 @@ status:
 > * 坪村リージョン：2020年12月24日以降に作成したクラスター
 
 <a id="admission-controller"></a>
-### 承認コントローラー(admission controller)プラグイン
+### 承認コントローラー(admission controller)プラグイン { #admission-controller }
 承認コントローラーはKubernetes APIサーバーリクエストを奪ってオブジェクトを変更したり、リクエストを拒否できます。承認コントローラーの詳細は[承認コントローラー](https://kubernetes.io/docs/reference/access-authn-authz/admission-controllers/)を参照してください。また承認コントローラーの使用例は[承認コントローラーガイド](https://kubernetes.io/blog/2019/03/21/a-guide-to-kubernetes-admission-controllers/)を参照してください。
 
 クラスタバージョンとクラスタ作成時点によって、承認コントローラーに適用されるプラグインの種類が異なります。詳細についてはリージョン別の作成時点によるプラグインリストを参照してください。
 
+<a id="admission-controller-v11913-or-earlier"></a>
 #### v1.19.13以前のバージョン
 パンギョリージョン2021年2月22日以前に作成したクラスタおよび坪村リージョン2021年2月17日以前に作成したクラスタは次のように適用されます。
 
@@ -1381,6 +1401,7 @@ status:
 * ServiceAccount
 * ValidatingAdmissionWebhook
 
+<a id="admission-controller-v12012-or-later"></a>
 #### v1.20.12以降のバージョン
 Kubernetesバージョン別の基本アクティブ承認コントローラーはすべて有効になります。基本アクティブ承認コントローラーに以下のコントローラーが有効になります。
 
@@ -1388,9 +1409,10 @@ Kubernetesバージョン別の基本アクティブ承認コントローラー�
 * PodSecurityPolicy
 
 <a id="cluster-upgrade"></a>
-### クラスタアップグレード
+### クラスタアップグレード { #cluster-upgrade }
 NHN Kubernetes Service(NKS)は動作中のKubernetesクラスタのKubernetesコンポーネントのアップグレードをサポートします。 
 
+<a id="cluster-upgrade-policy-of-supporting-different-kubernetes-versions"></a>
 #### Kubernetesバージョン違いサポートポリシー
 Kubernetesのバージョンは`x.y.z`で表現されます。 `x`はメジャーバージョン、`y`はマイナーバージョン、`z`はパッチバージョンです。機能が追加される場合、メジャーバージョンまたはマイナーバージョンをアップロードし、バグ修正など以前のバージョンと互換性のある機能を提供する場合はパッチバージョンをアップロードします。詳しい内容は[こちら](https://semver.org/)を参照してください。
 
@@ -1398,6 +1420,7 @@ Kubernetesクラスタは、動作中の状態でKubernetesコンポーネント
 
 <br>
 
+<a id="cluster-upgrade-manage-nks-cluster-version"></a>
 #### NKSクラスターのバージョン管理
 NKSクラスタは、クラスタコントロールプレーンとワーカーノードグループごとにKubernetesバージョンとプラットフォームバージョンを管理します。Kubernetesバージョンとプラットフォームバージョンの違いは次のとおりです。
 
@@ -1436,6 +1459,7 @@ NKSクラスタは、クラスタコントロールプレーンとワーカー�
 
 <br>
 
+<a id="cluster-upgrade-upgrade-rules"></a>
 #### アップグレードルール
 NKSクラスタバージョン管理方式とKubernetesバージョン違いサポートポリシーによりコンポーネントごとに順序に合わせてアップグレードする必要があります。NKSクラスタアップグレード機能に適用されるルールは次のとおりです。
 
@@ -1470,7 +1494,8 @@ NKSクラスタバージョン管理方式とKubernetesバージョン違いサ�
 
 <br>
 
-### etcdバージョン変更に伴う注意事項
+<a id="cluster-upgrade-considerations-for-etcd-version-changes"></a>
+#### etcdバージョン変更に伴う注意事項
 クラスターのアップグレード作業の進行時、アップグレード対象のプラットフォームバージョンに定義された[etcdバージョン](/Container/NKS/ko/user-guide/#platform-version-etcd-version)が現在のクラスターのetcdバージョンと異なる場合に限り、etcdのアップグレード作業が併せて進行されます。該当作業を開始する前に注意事項を必ず認知し、事前の告知/メンテナンス時間の確保などの措置を推奨します。
 
 ##### データの整合性確認のため頻繁なリソース変更は自制
@@ -1484,6 +1509,7 @@ etcdのアップグレードが失敗すると、クラスターを以前の状�
 
 <br>
 
+<a id="cluster-upgrade-upgrade-strategy"></a>
 #### アップグレード戦略
 NKSクラスターはRolling Upgrade、Blue/Green Upgradeの2種類のアップグレード戦略を提供します。ユーザーは運営政策によって適切な戦略を選択してクラスターをアップグレードできます。
 
@@ -1561,83 +1587,12 @@ NKSクラスターのコントロールプレーンは高可用性を保証し�
 ##### 4. Blue環境(以前バージョンの全てのワーカーノードグループ)を廃棄します。
 Blue環境のリソースを全て破棄すると、コントロールプレーンと全てのワーカーノードグループのバージョンが全て一致することになります。
 
-<a id="api_endpoint_ipacl"></a>
-### クラスタCNIの変更
-NHN Kubernetes Service(NKS)は動作中のKubernetesクラスタのCNI(container network interface)変更をサポートします。 
-クラスタCNI変更機能を使用するとNHN Kubernetes Service(NKS)のCNIがFlannel CNIからCalico CNI-VXLANに変更されます。
-
-#### CNI変更ルール
-NKSクラスタCNI変更機能に適用されるルールは次のとおりです。
-
-* CNI変更機能はNHN Kubernetes Service(NKS)バージョン1.24.3以上の場合に使用できます。
-* 既存NHN Kubernetes Service(NKS)で使用しているCNIがFlannelの場合にのみCNI変更を使用できます。
-* CNI変更開始時、コントロールプレーンとすべてのワーカーノードグループに対して一括で作業を行います。
-* Calico-VXLAN、Calico-eBPFからFlannelへのCNI変更はサポートしません。
-* FlannelからCalico-eBPFへのCNI変更はサポートしません。
-* Calico-VXLANからCalico-eBPFへのCNI変更はサポートしません。
-* コントロールプレーンのKubernetesバージョンとすべてのワーカーノードグループのKubernetesバージョンが一致すればCNI変更が可能です。
-
-* 他の機能の動作により、クラスタがアップデート中の状態ではCNIの変更ができません。
-
-次の例は、Kubernetes CNI変更過程で変更できるかどうかを表で示したものです。例に使用された条件は次のとおりです。 
-
-NHN CloudがサポートするKubernetesバージョンリスト：v1.23.3、v1.24.3、v1.25.4
-クラスタはv1.23.3で作成
-
-| 状態 | クラスタバージョン | 現在CNI | CNI変更可否
-| --- | :-: | :-: | :-: | :-: |
-| 初期状態| v1.23.3 | Flannel | 不可 <sup>(注1)(#footnote_calico_change_rule_1)</sup> |
-| クラスタアップグレード後の状態 | v1.24.3 | Flannel | 可能 <sup>(注2)(#footnote_calico_change_rule_2)</sup> | 
-| CNI変更後の状態 | v1.24.3 | Calico-VXLAN | 不可 <sup>(注3)(#footnote_calico_change_rule_3)</sup> |
-
-
-注釈
-
-* <a name="footnote_calico_change_rule_1">(注1)</a>クラスタバージョンが1.24.3未満のためCNI変更不可
-* <a name="footnote_calico_change_rule_2">(注2)</a>クラスタバージョンが1.24.3以上のためCNI変更可能
-* <a name="footnote_calico_change_rule_3">(注3)</a>CNIがすでにCalico-VXLANのためCNI変更不可
-
-#### FlannelからCalico-VXLAN CNIへの変更進行プロセス
-CNIの変更は次の順序で行われます。
-
-1. すべてのワーカーノードグループにバッファノード<sup>(注1)(#footnote_calico_change_step_1)</sup>を追加します。<sup>(注2)(#footnote_calico_change_step_2)</sup>
-2. クラスタにCalico-VXLAN CNIが配布されます。<sup>(注3)(#footnote_calico_change_step_3)</sup>
-3. クラスタオートスケーラ機能を無効化します。<sup>(注4)(#footnote_calico_change_step_4)</sup>
-3. すべてのワーカーノードグループ内のすべてのワーカーノードに対して以下の作業を順次実行します。<sup>(注5)(#footnote_calico_change_step_5)</sup>
-    1. 該当ワーカーノードで動作中のPodを追放し、ノードをスケジュール不可能な状態に切り替えます。
-    2. ワーカーノードのPod IPをCalico-VXLAN CIDRに再割当てします。該当ノードに配布されているすべてのPodは再配布されます。<sup>(注6)(#footnote_calico_change_step_6)</sup>
-    3. ノードをスケジュール可能な状態に切り替えます。
-5. バッファノードで動作中のPodを追放し、バッファノードを削除します。
-6. クラスタオートスケーラ機能を再度有効にします。<sup>(注4)(#footnote_calico_change_step_4)</sup>
-7. Flannel CNIを削除します。
-
-
-注釈
-
-* <a name="footnote_calico_change_step_1">(注1)</a>バッファノードとは、CNI変更過程で既存ワーカーノードから追放されたPodが再びスケジューリングできるように作成しておく空きノードを指します。該当ワーカーノードグループで定義したワーカーノードと同じ規格のノードとして作成され、アップグレードプロセスが終了すると自動的に削除されます。このノードはInstance料金ポリシーに基づいて費用が請求されます。 
-* <a name="footnote_calico_change_step_2">(注2)</a>CNI変更時にバッファノード数を設定できます。デフォルト値は1で、0に設定するとバッファノードを追加しません。最小値は0で、最大値は(ノードグループあたりの最大ノード数クォーター - 該当ワーカーノードグループの現在ノード数)です。
-* <a name="footnote_calico_change_step_3">(注3)</a>クラスタにCalico-VXLAN CNIが配布されると、FlannelとCalico-VXLAN CNIが共存します。この状態で新しいPodが配布されるとPod IPはFlannel CNIに設定されて配布されます。Flannel CIDR IPを持つPodとCalico-VXLAN CIDR IPを持つPodはお互いに通信できます。
-* <a name="footnote_calico_change_step_4">(注4)</a>このステップはアップグレード機能開始前にクラスタオートスケーラ機能が有効になっている場合にのみ有効です。
-* <a name="footnote_calico_change_step_5">(注5)</a>CNI変更時に設定した最大サービス不可ノードの数だけ作業を実行します。デフォルト値は1です。最小値は1で、最大値は現在クラスタのすべてのノード数です。
-* <a name="footnote_calico_change_step_6">(注6)</a>既に配布されているPodのIPは全てFlannel CIDRに割り当てられています。Calico-VXLAN CNIに変更するためにFlannel CIDRのIPが割り当てられてているPodを全て再配布してCalico-VXLAN CIDR IPを割り当てます。新しいPodが配布されるとPod IPはCalico-VXLAN CNIに設定されて配布されます。
-
-この過程で以下のようなことが発生することがあります。
-
-* サービス中のPodが追放され、他のノードにスケジューリングされます。(Podの追放ついては[クラスタアップグレード](/Container/NKS/ja/user-guide/#cluster-upgrade)を参照してください)
-* クラスタに配布されているすべてのPodが再配布されます。(Podの再配布については、以下のPod再配布注意事項を参照してください)
-* オートスケーラ機能が動作しません。 
-
-
-> [Pod再配布注意事項]
-> 1. Pod追放プロセスによって他のノードに移されなかったPodに対して行われます。
-> 2. CNI変更プロセス中にFlannel CIDRとCalico-VXLAN CIDR間の正常な通信のためにCNI変更Podネットワーク値は既存Flannel CIDR値と同じであってはいけません。
-> 3. 既に配布されていたPodのpauseコンテナは全て停止し、kubeletによって再作成されます。Pod名とローカル記憶領域などの設定はそのまま維持されますが、IPはCalico-VXLAN CIDRのIPに変更されます。
-
 <a id="api-endpoint-ipacl"></a>
-### クラスタAPIエンドポイントにIPアクセス制御を適用
+### クラスタAPIエンドポイントにIPアクセス制御を適用 { #api-endpoint-ipacl }
 クラスタAPIエンドポイントにIPアクセス制御を適用または解除できます。
 IPアクセス制御機能の詳細については、[IPアクセス制御](/Network/Load%20Balancer/ko/overview/#ip)文書を参照してください。
 
+<a id="api-endpoint-ipacl-ip-access-control-rules"></a>
 #### IPアクセス制御対象ルール
 クラスタAPIエンドポイントのIPアクセス制御対象を追加する場合、以下のルールが適用されます。
 
@@ -1648,7 +1603,7 @@ IPアクセス制御機能の詳細については、[IPアクセス制御](/Net
 * IP アクセス制御対象は1つ以上存在する必要があります。
 
 <a id="rotate-certificate"></a>
-### クラスタ証明書の更新
+### クラスタ証明書の更新 { #rotate-certificate }
 Kubernetesはコンポーネント間のTLS認証のためにPKI証明書が必要です。PKI証明書の詳細については、[PKI証明書及び要件](https://kubernetes.io/ko/docs/setup/best-practices/certificates/)を参照してください。 NKSクラスタを作成する場合クラスタに必要な証明書を自動的に作成し、この証明書の基本有効期間は5年に設定されています。
 
 証明書の有効期限が切れると、APIサーバー、コントローラーマネージャー、etcdなどクラスタの主要構成要素が動作しなくなり、クラスタを使用できません。
@@ -1681,7 +1636,7 @@ Kubernetesはコンポーネント間のTLS認証のためにPKI証明書が必�
 > > このような作業の影響を最小限に抑えるためには、証明書の更新作業が進行中、新規Podの作成などの作業を行わないようにしてください。
 
 <a id="k8s-component"></a>
-### Kubernetesコンポーネント設定機能
+### Kubernetesコンポーネント設定機能 { #k8s-component }
 
 Kubernetesコンポーネントの様々なオプションを設定できます。クラスター作成時に設定でき、設定したオプションはクラスター作成完了後に変更することもできます。
 
@@ -1692,7 +1647,8 @@ Kubernetesコンポーネントの様々なオプションを設定できます�
 > * ワーカーノードで動作するコンポーネントの設定を変更した場合、ワーカーノードのコンポーネントが再起動されます。
 > * ワーカーノードで動作するコンポーネントの設定は、ワーカーノードグループ別に設定できます。(プラットフォームバージョン1.202602.0以降のバージョンに限る)
 
-### コントロールプレーンオプション
+<a id="control-plain-options"></a>
+### コントロールプレーンオプション { #control-plain-options }
 
 | コンポーネント | オプション | 説明 |
 | --- | --- | --- |
@@ -1701,7 +1657,8 @@ Kubernetesコンポーネントの様々なオプションを設定できます�
 | kube-controller-manager | node-monitor-grace-period | ノードが異常状態の時、該当ノードを異常とみなすまで待機する時間を定義します。<br>(単位：秒、デフォルト値：40、最小値：0、最大値：86400) |
 | kube-controller-manager | unhealthy-zone-threshold | アベイラビリティゾーン(zone)を異常とみなすNotReadyノードの割合のしきい値を定義します。<br>(単位：パーセント、デフォルト値：55、最小値：0、最大値：100) |
 
-### ワーカーノードオプション
+<a id="worker-node-options"></a>
+### ワーカーノードオプション { #worker-node-options }
 
 | コンポーネント | オプション | 説明 |
 | --- | --- | --- |
@@ -1709,12 +1666,13 @@ Kubernetesコンポーネントの様々なオプションを設定できます�
 | kubelet | max-pods | ノードで実行可能な最大Pod数を定義します。<br>(デフォルト値：110、最小値：1、最大値：Podネットワーク及びサブネットサイズの設定に応じて計算された最大作成可能Pod IP数)<br>プラットフォームバージョン1.202602.0以降のバージョンで対応します。 |
 
 <a id="k8s-label"></a>
-### Kubernetesラベル設定機能
+### Kubernetesラベル設定機能 { #k8s-label }
 ノードグループごとにKubernetesラベル設定機能を使用できます。この機能でラベルが設定されたノードグループは、ノード作成時にユーザーが設定したラベルを自動的に追加します。ラベルはPod、ノードなどのオブジェクトに添付されたキーと値のペアで、オブジェクトの特性を識別するために使用されます。ラベルの詳細については[Labels and Selectors](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/)を参照してください。
 
 
 Kubernetesのラベルはキーと値のペアで構成され、有効なラベルのキーと値はそれぞれ次のようなルールを遵守する必要があります。
 
+<a id="k8s-label-label-key"></a>
 #### ラベルキー
 ラベルキーはスラッシュ(/)で区切られたプレフィックスと名前の構造を持つことができ、プレフィックスは省略可能です。
 * プレフィックス
@@ -1727,6 +1685,7 @@ Kubernetesのラベルはキーと値のペアで構成され、有効なラベ�
     * アルファベット大文字小文字、数字、ハイフン(-)、アンダースコア(_)、ドット(.)のみ許可され、英数字で開始及び終了する必要があります。
 
 
+<a id="k8s-label-label-value"></a>
 #### ラベル値
 * 空白または63文字以下でなければなりません。
 * アルファベット大文字/小文字、数字、ダッシュ(-)、アンダースコア(_)、ドット(.)のみ許可され、英数字で始まり、英数字で終わる必要があります。
@@ -1736,7 +1695,7 @@ Kubernetesのラベルはキーと値のペアで構成され、有効なラベ�
 > * Kubernetesラベル設定を変更すると、その後新規に作成されるノードから変更された設定が適用されます。
 
 <a id="oidc-auth"></a>
-### OIDC認証設定機能
+### OIDC認証設定機能 { #oidc-auth }
 
 OIDC(OpenID Connect)は、OAuth 2.0フレームワークをベースにした相互運用可能な認証プロトコルです。OIDCを利用すれば、外部認証サービスを介してユーザーを認証できます。OIDCの詳しい動作方式は[What is OpenID Connect](https://openid.net/developers/how-connect-works/)を参照してください。
 
@@ -1755,7 +1714,7 @@ NKSクラスターは、OIDCを利用した認証を処理するように設定�
 | Signing Algs| X | 許可されたJOSE非対称署名アルゴリズムリスト。デフォルト値: 'RS256' |
 
 <a id="control-plane-k8s-log"></a>
-### コントロールプレーンKubernetesコンポーネントログ保存
+### コントロールプレーンKubernetesコンポーネントログ保存 { #control-plane-k8s-log }
 NHN Kubernetes Service(NKS)はコントロールプレーンで実行中の主要なKubernetesコンポーネントのログを提供します。これにより、クラスター内で発生する様々なイベントと動作をより明確に把握することができ、サービスの状態診断や問題解決に有用に活用できます。
 
 コントロールプレーンKubernetesコンポーネントログ保存機能の特徴は次のとおりです。
@@ -1867,11 +1826,12 @@ OBSコンテナにログが作成されるパスは次のとおりです。
   nks-test-master-0/kube-apiserver/2025/04/20250428-101500-index0.gz
 
 <a id="k8s-taint"></a>
-### Kubernetesテイント設定機能
+### Kubernetesテイント設定機能 { #k8s-taint }
 ノードグループごとにKubernetesテイント(taint)設定機能を使用できます。この機能を通じて作成されたノードグループは、ユーザーが設定したテイントを設定した状態で初期化されます。Taintの詳細については、[Taints and Tolerations](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/)を参照してください。
 
 Kubernetesテイントはキー、値、効果(effect)で構成され、各項目は次のような規則を遵守する必要があります。
 
+<a id="k8s-taint-taint-key"></a>
 #### テイントのキー
 
 テイントのキーはスラッシュ(/)で区切られるプレフィックスと名前の構造を持つことができ、プレフィックスは省略可能です。
@@ -1885,11 +1845,13 @@ Kubernetesテイントはキー、値、効果(effect)で構成され、各項�
     * 63文字以下である必要があります。
     * アルファベット大文字小文字、数字、ハイフン(-)、アンダースコア(_)、ドット(.)のみ許可され、英数字で開始及び終了する必要があります。
 
+<a id="k8s-taint-taint-value"></a>
 #### テイントの値
 
 * 空白または63文字以下である必要があります。
 * アルファベット大文字小文字、数字、ハイフン(-)、アンダースコア(_)、ドット(.)のみ許可され、英数字で開始及び終了する必要があります。
 
+<a id="k8s-taint-taint-effect"></a>
 #### テイントの効果(Effect)
 
 次の3つの値のいずれかを指定する必要があります。
@@ -1907,7 +1869,7 @@ Kubernetesテイントはキー、値、効果(effect)で構成され、各項�
 * Kubernetesテイントの設定を変更すると、それ以降に新規作成されるノードから変更された設定が適用されます。
 
 <a id="konnectivity-description"></a>
-### konnectivity
+### konnectivity { #konnectivity-description }
 
 Konnectivityは、Kubernetesにおいてコントロールプレーン(APIサーバー)とワーカーノード間のネットワーク通信を安全にプロキシするコンポーネントです。従来はAPIサーバーがノードのkubeletやPodに直接アクセスする必要があり、ネットワーク構成が複雑になるという問題がありました。
 
@@ -1930,29 +1892,32 @@ Konnectivity ServerとKonnectivity Agentが先に接続を確立してトンネ�
 > Konnectivityはプラットフォームバージョン1.202605.0以降で提供されます。
 
 <a id="worker-node-management"></a>
-
-## ワーカーノード管理
+## ワーカーノード管理 { #worker-node-management }
 
 <a id="container-management"></a>
+### コンテナ管理 { #container-management }
 
-### コンテナ管理
-
+<a id="container-management-clusters-of-kubernetes-v1243-or-older"></a>
 #### Kubernetes v1.24.3以前のバージョンのクラスタ
 Kubernetes v1.24.3以前のバージョンのクラスタはDockerを利用してコンテナランタイムを構成します。ワーカーノードでdocker CLIを利用してコンテナ状態照会、コンテナイメージ照会などの作業が行えます。docker CLIの詳細な説明と使用方法については[Use the Docker command line](https://docs.docker.com/engine/reference/commandline/cli/)を参照してください。
 
+<a id="container-management-clusters-of-kubernetes-v1243-and-later"></a>
 #### Kubernetes v1.24.3以降のバージョンのクラスタ
 
 Kubernetes v1.24.3以降のバージョンのクラスタはcontainerdを利用してコンテナランタイムを構成します。ワーカーノードでdocker CLIの代わりにnerdctlを利用してコンテナ状態照会、コンテナイメージ照会などの作業ができます。Nerdctlの詳細な説明と使用方法については[nerdctl: Docker-compatible CLI for containerd](https://github.com/containerd/nerdctl#nerdctl-docker-compatible-cli-for-containerd)を参照してください。
 
 <a id="network-management"></a>
-### ネットワーク管理
+### ネットワーク管理 { #network-management }
 
+<a id="network-management-default-network-interface"></a>
 #### 基本ネットワークインタフェース
 すべてのワーカーノードはクラスター作成時に入力したVPC/サブネットに接続されるネットワークインタフェースを持っています。この基本ネットワークインタフェースの名前は"eth0"で、ワーカーノードはこのネットワークインタフェースを介してコントロールプレーンと接続されます。
 
+<a id="network-management-additional-network-interface"></a>
 #### 追加ネットワークインタフェース
 クラスタまたはワーカーノードグループ作成時に追加ネットワークを設定すると、該当ワーカーノードグループのワーカーノードに追加ネットワークインタフェースが作成されます。追加ネットワークインタフェースは追加ネットワーク設定に入力した順序通りにインタフェース名が設定されます(eth1, eth2, ...)。
 
+<a id="network-management-default-route-settings"></a>
 #### 基本パス(default route)設定
 ワーカーノードに複数のネットワークインタフェースが存在する場合、ネットワークインタフェースごとに基本パスが設定されます。あるシステムに複数の基本パスが設定されている場合、マトリックス(metric)値が最も低い基本パスがシステム基本パスとして動作します。ネットワークインタフェースごとの基本パスはインタフェース番号が小さいほど小さいマトリックス値が設定されています。このため動作中のネットワークインタフェースのうち最も小さい番号のネットワークインタフェースがシステム基本パスとして動作します。
 
@@ -2012,6 +1977,7 @@ Destination     Gateway         Genmask         Flags Metric Ref    Use Iface
 ...
 ```
 
+<a id="network-management-change-default-route-settings-using-user-script"></a>
 #### ユーザースクリプト機能を利用した基本パス設定の変更
 ユーザースクリプト機能を利用するとノード増設などでノードが新たに初期化される時も上記のような設定を維持できます。次のユーザースクリプトはCentOSを使用するワーカーノードでeth0のマトリックス値を100に、eth1のマトリックス値を0に設定する例です。このようにすると現在システムに適用されている基本パスごとのマトリックス値も変更され、これはワーカーノードの再起動後にも維持されます。
 ```
@@ -2025,7 +1991,7 @@ route add -net 0.0.0.0/0 gw 192.168.0.1 dev eth1 metric 0
 ```
 
 <a id="kubelet-argument"></a>
-### kubeletユーザー定義引数設定機能
+### kubeletユーザー定義引数設定機能 { #kubelet-argument }
 kubeletはすべてのワーカーノードで動作するノードエージェントです。kubeletはコマンドラインアギュメントを利用して様々な設定を入力します。NKSが提供するkubeletユーザー定義引数設定機能を利用すると、kubelet起動時に入力される引数を追加できます。kubeletカスタム引数は次のように設定し、システムに適用できます。
 
 * ワーカーノードの`/etc/kubernetes/kubelet-user-args`ファイルに`KUBELET_USER_ARGS="User Defined Argument"`形式でユーザー定義引数を入力します。
@@ -2040,8 +2006,7 @@ kubeletはすべてのワーカーノードで動作するノードエージェ�
 > * 設定されたユーザー定義引数はシステム再起動時にもそのまま適用されます。
 
 <a id="containerd-registry-config"></a>
-
-### カスタムcontainerdレジストリ設定機能(deprecated)
+### カスタムcontainerdレジストリ設定機能(deprecated) { #containerd-registry-config }
 
 > [注意]
 > この機能はKubernetes v1.34以上では動作しません。
@@ -2086,6 +2051,7 @@ v1.24.3以上のNKSクラスタはコンテナランタイムとしてcontainerd
 }
 ```
 
+<a id="containerd-registry-config-example-1"></a>
 #### 例1 
 
 `docker.io` 以外に追加のレジストリを登録する場合は次のように設定できます。
@@ -2107,6 +2073,7 @@ v1.24.3以上のNKSクラスタはコンテナランタイムとしてcontainerd
 ]
 ```
 
+<a id="containerd-registry-config-example-2"></a>
 #### 例2 
 
 `docker.io` レジストリを削除してHTTPをサポートするレジストリだけ登録する場合は、次のように設定できます。
@@ -2124,6 +2091,7 @@ v1.24.3以上のNKSクラスタはコンテナランタイムとしてcontainerd
 ]
 ```
 
+<a id="containerd-registry-config-example-3"></a>
 #### 例3
 
 ノード作成時、ユーザー定義のcontainerdレジストリ設定ファイルを例2の内容で作成するため、ユーザースクリプトを次のように設定できます。
@@ -2144,8 +2112,7 @@ echo '[ { "registry": "user-defined.registry.io", "endpoint_list": [ "http://use
 >     * `docker.io`レジストリを使用しない場合は、`docker.io` レジストリの設定を含まないようにします。ただし、1つ以上のレジストリ設定が存在する必要があります。
 
 <a id="constraints-on-cgroup"></a>
-
-### KubernetesバージョンとCGroupバージョンによる制約事項
+### KubernetesバージョンとCGroupバージョンによる制約事項 { #constraints-on-cgroup }
 CGroup(Control Group)はLinuxカーネルの機能であり、プロセスグループのCPU、メモリ、ディスクI/O、ネットワークなどシステムリソースの使用量を制限、隔離し、監視できるようにします。Kubernetesを含むコンテナ技術の核心的な基盤の1つです。CGroupは最初のバージョン1(v1)から始まり、メモリ・I/O制御機能を強化してバージョン2(v2)へと発展しました。Linuxカーネルの機能であるため、CGroup v2はLinuxカーネルへの依存性を持ちます。したがって、比較的最新のディストリビューション及びバージョンでのみCGroup v2がサポートされます。
 
 NKSクラスターv1.34からは、ワーカーノードがCGroup v2で動作する必要があります。これは、Kubernetesコミュニティにおいて、今後はcontainerd 1.xの代わりにcontainerd 2.xを使用し、CGroup v1の代わりにv2を基盤として動作させるという方針から出された制約事項です。 
@@ -2174,15 +2141,13 @@ CGroupバージョンをv1からv2に変更できるOSイメージのディス�
 デフォルトのCGroupバージョンがv1であり、CGroupバージョンをv2に変更できないOSイメージで作成したワーカーノードグループは、ローリングアップグレード方式でKubernetes v1.34へアップグレードできません。この場合、Blue-Green方式でワーカーノードグループをアップグレードできます。
 
 <a id="worker-management-caution"></a>
-
-### ワーカーノード管理上の注意事項
+### ワーカーノード管理上の注意事項 { #worker-management-caution }
 * ワーカーノードにpullされているcontainer imageを削除してはいけません。NKSクラスタに必要なPodが動作しなくなる可能性があります。
 * `shutdown`, `halt`, `poweroff`などのコマンドでシステムを停止させると、コンソールから再起動できません。ワーカーノードの開始/停止機能を使ってください。
 * ワーカーノード内の様々な設定ファイルを勝手に修正したり、システムサービスを操作してはいけません。NKSクラスタに致命的な問題が発生する可能性があります。
 
 <a id="cni"></a>
-
-## CNI(Container Network Interface)
+## CNI(Container Network Interface) { #cni }
 NHN Kubernetes Service(NKS)は、アドオン機能を通じて他の種類のContainer Network Interface(CNI)を提供します。クラスター作成時にCalico-VXLAN、Calico-eBPF、Ciliumの中から1つのCNIを選択でき、デフォルト設定はCalico-VXLANです。Calico-eBPFは、コンテナワークロードをBGPルーティングプロトコルで構成し、eBPF技術を基盤として直接通信し、一部の区間(NodePortなど)はVXLANを利用して通信します。CalicoのeBPF関連の内容は[about eBPF](https://docs.tigera.io/calico/latest/about/kubernetes-training/about-ebpf)を参照してください。CiliumはVXLANオーバーレイネットワークを基盤とし、eBPF技術を活用して高いネットワークパフォーマンスを提供します。CiliumのeBPF関連の内容は[eBPF Datapath](https://docs.cilium.io/en/stable/network/ebpf/)を参照してください。
 
 CNI別に選択できるOSの制約事項は次のとおりです。
@@ -2195,8 +2160,7 @@ CNI別に選択できるOSの制約事項は次のとおりです。
 | Cilium | Rocky, Ubuntu |
 
 <a id="calico-cni-types"></a>
-
-### Calico CNIの種類
+### Calico CNIの種類 { #calico-cni-types }
 NHN Kubernetes Service(NKS)が提供するCalico-VXLAN、Calic-eBPFは下記のような違いがあります。
 
 |  | Calico-VXLAN | Calico-eBPF |
@@ -2219,13 +2183,11 @@ NHN Kubernetes Service(NKS)が提供するCalico-VXLAN、Calic-eBPFは下記の�
 > 該当イメージを使用するには、アドオン管理機能を通じてCalicoをv3.28.2以上にアップデートする必要があります。
 
 <a id="security-group"></a>
-
-## セキュリティグループ
+## セキュリティグループ { #security-group }
 クラスタ作成時に強化されたセキュリティルールをTrueに設定すると、ワーカーノードセキュリティグループの作成時に必須のセキュリティルールだけが作成されます。
 
 <a id="mandatory-sg-rules"></a>
-
-### クラスタワーカーノード必須セキュリティルール
+### クラスタワーカーノード必須セキュリティルール { #mandatory-sg-rules }
 
 | 方向 | IPプロトコル | ポート範囲 | Ether | 遠隔 | 説明 | 特記事項 |
 | :-: | :-: | :-: | :-: | :-: | :-: | :-: |
@@ -2275,7 +2237,7 @@ NHN Kubernetes Service(NKS)が提供するCalico-VXLAN、Calic-eBPFは下記の�
 > 強化されたセキュリティルールを使用する場合、該当Podのポートに対するingress、egressセキュリティルールを手動で追加する必要があります。
 
 <a id="cilium-optional-security-group-rules"></a>
-### Cilium CNIのオプション機能使用時の追加セキュリティグループルール
+### Cilium CNIのオプション機能使用時の追加セキュリティグループルール { #cilium-optional-security-group-rules }
 
 Cilium CNIを使用するクラスターでHubble、Envoy、Prometheusのようなオプション機能を有効にするには、該当機能に必要なセキュリティグループルールを追加で設定する必要があります。
 
@@ -2298,8 +2260,7 @@ Cilium CNIを使用するクラスターでHubble、Envoy、Prometheusのよう�
 > オプション機能を使用するには、Ciliumの設定変更及び該当機能に必要なセキュリティグループルールを手動で追加する必要があります。
 
 <a id="relaxd-sg-rules"></a>
-
-### 強化されたセキュリティールールを使用しない場合に作成されるルール
+### 強化されたセキュリティールールを使用しない場合に作成されるルール { #relaxd-sg-rules }
 
 強化されたセキュリティルールを使用しない場合、NodePortタイプのサービスと外部ネットワーク通信に必要なセキュリティルールが追加で作成されます。
 
@@ -2315,19 +2276,21 @@ Cilium CNIを使用するクラスターでHubble、Envoy、Prometheusのよう�
 
 
 <a id="addon-mgmt"></a>
-## アドオン管理機能
+## アドオン管理機能 { #addon-mgmt }
 アドオンとは、Kubernetesクラスターの必須コンポーネントではありませんが、NKSクラスターの機能を拡張したり、特化した機能を提供するために用意されたコンポーネントを指します。アドオンには、ネットワーキング、サービスディスカバリー、モニタリング、ストレージプロビジョニングなどの機能を持つコンポーネントが含まれることがあります。ユーザーはアドオン管理機能を通じて、NHN Cloudが提供するアドオンをクラスターにインストール・変更・削除できます。
 
 > [注意]
 > NKSレジストリが有効化されていないクラスターはアドオン管理機能を使用できません。
 <a id="addon-mgmt-operation"></a>
-### 動作方式
+### 動作方式 { #addon-mgmt-operation }
 アドオン管理機能の動作方式について説明します。
 
+<a id="addon-mgmt-operation-server-side-apply"></a>
 #### Server-side apply
 アドオン管理機能を利用してクラスターにアドオンをインストール/変更する時、KubernetesのServer-side applyを利用します。Client-side applyはクライアントがローカルでリソースのステータスを計算して全体のリソースをAPIサーバーに送る方式です。一方、Server-side applyは、APIサーバーがリソースのマージとフィールドの所有権管理を行い、APIサーバーがリソースのマージと競合検出を行うことができます。Server-side applyの詳細は[Server-Side Apply](https://kubernetes.io/docs/reference/using-api/server-side-apply/)を参照してください。
 
 
+<a id="addon-mgmt-operation-conflict-resolution-options"></a>
 #### 競合処理オプション
 ユーザーがアドオンが管理するフィールドを変更して使用する場合、アドオンのインストール・変更時にクラッシュが発生する可能性があります。ユーザーはアドオンのインストール・アップデート時に適切な競合処理オプション(resolve-conflicts)を選択して競合状況を管理できます。アドオン管理機能で提供する競合処理オプションは次のとおりです。
 
@@ -2341,6 +2304,7 @@ Cilium CNIを使用するクラスターでHubble、Envoy、Prometheusのよう�
 > [保存オプションに関する注意事項]
 > アドオンを構成するリソースの全ての変更事項を保存することはできません。
 > 保存不可能なフィールドで競合が発生した場合、インストール/変更作業は失敗として処理されます。
+<a id="addon-mgmt-operation-main-features"></a>
 #### 提供機能
 アドオン管理機能を利用してアドオンをクラスターにインストール・変更・削除できます。
 
@@ -2360,11 +2324,12 @@ Cilium CNIを使用するクラスターでHubble、Envoy、Prometheusのよう�
 > [注意]
 > Kubernetesのバージョンアップ機能を通じたCNI、corednsなどのアップグレードは今後提供されません。
 > 代わりに、アドオンの変更機能を使って各アドオンのバージョンを変更できます。
+<a id="addon-mgmt-operation-enable-add-on-management"></a>
 #### アドオン管理機能有効化
 アドオン管理機能が有効化されていない既存のクラスターでもアドオン管理機能を使用できます。アドオンが設定されていないクラスターはcalico, corednsなどが動作しているにもかかわらず、アドオンがインストールされていないように表示されます。この状態で各アドオンをインストールすると、アドオン管理機能を使ってアドオンを管理できます。アドオンを構成するリソースの設定を変更して使用する場合、競合処理オプションを「保存」に選択してインストールすると、既存リソースの設定を維持できます。
 
 <a id="addon-mgmt-types"></a>
-### アドオンタイプ
+### アドオンタイプ { #addon-mgmt-types }
 アドオンタイプは、クラスターにインストールされるアドオンを特性によって区分したものです。
 
 | タイプ | 必須かどうか | 説明|
@@ -2377,7 +2342,7 @@ Cilium CNIを使用するクラスターでHubble、Envoy、Prometheusのよう�
 | nfs-csi-plugin | X | NHN CloudのNFSをプロビジョニングして管理できるCSIドライバーです。 |
 
 <a id="addon-mgmt-addon-list"></a>
-### アドオンリスト
+### アドオンリスト { #addon-mgmt-addon-list }
 
 <a id="addon-mgmt-addon-calico"></a>
 #### Calico
@@ -2413,7 +2378,6 @@ CalicoはKubernetesのネットワーキングとネットワークセキュリ�
 >     * v3.31.4以上
 
 <a id="addon-mgmt-addon-calico-datastore"></a>
-
 ##### Calicoのデータストア
 calicoは、ポッドIP、ノード別のIP範囲など様々な情報をデータストアに保存します。従来提供されていたバージョンではデータストアとしてetcdを使用していましたが、新しく提供されるバージョンではデータストアとしてKDD(Kubernetes Datastore Driver)を使用します。KDDはKubernetes CRDを利用して各種情報をKubernetesレベルのリソース/オブジェクトに保存します。KDDを使用すると、ネットワークトポロジーが単純になり、関連情報が全てCRとして公開されるため、管理上のメリットがあります。
 
@@ -2429,7 +2393,6 @@ calicoは、ポッドIP、ノード別のIP範囲など様々な情報をデー�
 > * データストアをKDDからetcdに変更するアドオンアップデートはサポートされていません。 
 
 <a id="addon-mgmt-addon-cilium"></a>
-
 #### Cilium
 Ciliumは、Kubernetesのネットワーキングとネットワークセキュリティを提供するCNIプラグインです。
 
@@ -2445,7 +2408,6 @@ Ciliumは、Kubernetesのネットワーキングとネットワークセキュ�
     * v1.18.0-nks1
     
 <a id="addon_mgmt_addon_coredns"></a>
-
 #### CoreDNS
 CoreDNSはKubernetesクラスターの基本DNSサーバーです。
 
@@ -2551,13 +2513,11 @@ NFS CSI Pluginは、NHN CloudのNFSをプロビジョニングして管理でき
         * オプション項目であるsnapshot設定が必須として要求されていた問題を解決しました。
 
 <a id="addon-mgmt-addon-coredns"></a>
-
-## LoadBalancerサービス
+#### LoadBalancerサービス
 Kubernetesアプリケーションの基本実行単位Podは、CNI(container network interface)でクラスターネットワークに接続されます。基本的にクラスターの外部からPodにはアクセスできません。Podのサービスをクラスターの外部に公開するにはKubernetesの`LoadBalancer`サービス(Service)オブジェクト(object)を利用して外部に公開するパスを作成する必要があります。LoadBalancerサービスオブジェクトを作成すると、クラスターの外部にNHN Cloud Load Balancerが作成され、サービスオブジェクトと接続されます。
 
 <a id="create-webserver-pod"></a>
-
-### WebサーバーPod作成
+### WebサーバーPod作成 { #create-webserver-pod }
 次のように2個のnginx Podを実行するデフォルトデプロイメント(deployment)オブジェクトマニフェストファイルを作成し、オブジェクトを作成します。
 
 ```yaml
@@ -2598,8 +2558,7 @@ nginx-deployment-7fd6966748-wv7rd   1/1     Running   0          4m13s
 ```
 
 <a id="create-lb-service"></a>
-
-### LoadBalancerサービスの作成
+### LoadBalancerサービスの作成 { #create-lb-service }
 Kubernetesのサービスオブジェクトを定義するには、次の項目で構成されたマニフェストが必要です。
 
 | 項目 | 説明 |
@@ -2657,8 +2616,7 @@ nginx-svc    LoadBalancer   10.254.134.18   123.123.123.30   8080:30013/TCP   3m
 > ロードバランサーのIPは、外部からアクセスできるFloating IPです。**Network > Floating IP**ページで確認できます。
 
 <a id="internet-test-via-service"></a>
-
-### インターネットによるサービステスト
+### インターネットによるサービステスト { #internet-test-via-service }
 ロードバランサーに接続されたFloating IPにHTTPリクエストを送ってKubernetesクラスターのWebサーバーPodが応答するかを確認します。サービスオブジェクトのTCP/8080ポートをPodのTCP/80ポートと接続するように設定したため、TCP/8080ポートにリクエストを送る必要があります。外部ロードバランサーとサービスオブジェクト、Podが正常に接続されていれば、Webサーバーはnginx基本ページをレスポンスします。
 
 ```
@@ -2691,8 +2649,7 @@ Commercial support is available at
 ```
 
 <a id="advanced-lb-configuration"></a>
-
-### ロードバランサー詳細オプション設定
+### ロードバランサー詳細オプション設定 { #advanced-lb-configuration }
 Kubernetesのサービスオブジェクトを定義する時、ロードバランサーの複数のオプションを設定できます。設定可能な項目は次のとおりです。
 
 * ロードバランサー名設定
@@ -2718,12 +2675,14 @@ Kubernetesのサービスオブジェクトを定義する時、ロードバラ�
 * ヘルスチェックホストヘッダ設定
 * L7ルール及び条件
 
+<a id="advanced-lb-configuration-global-setting-and-per-listener-setting"></a>
 #### グローバル設定とリスナー別設定
 設定項目ごとにグローバル設定とリスナー別設定が可能です。グローバル設定とリスナー別設定がどちらもない場合、設定別デフォルト値を使用します。
 
 * リスナー別設定：対象リスナーにのみ適用される設定です。
 * グローバル設定：対象リスナーにリスナー別設定がない場合にこの設定を適用します。
 
+<a id="advanced-lb-configuration-format-of-per-listener-setting"></a>
 #### リスナー別設定形式
 リスナー別設定は、グローバル設定キーにリスナーを表すprefixをつけて設定できます。リスナーを表すprefixはサービスオブジェクトのポートプロトコル(`spec.ports[].protocol`)とポート番号(`spec.ports[].port`)をダッシュ(`-`)でつなげたものです。例えばプロトコルがTCPで、ポート番号が80の場合、prefixは`TCP-80`です。このポートに接続しているリスナーにセッション持続性設定を行いたい場合は.metadata.annotations下のTCP-80.loadbalancer.nhncloud/pool-session-persistenceに設定できます。
 
@@ -2777,7 +2736,6 @@ spec:
 >
 
 <a id="loadbalancer-update-without-modification"></a>
-
 #### 設定を変更せずにロードバランサーをアップデートする方法
 
 証明書の更新など、ロードバランサーの設定変更なしにロードバランサーのアップデートが必要な場合は、以下のコマンドを使用できます。
@@ -2791,6 +2749,7 @@ kubectl annotate svc <name> loadbalancer.nhncloud/force-reconcile=true
 > [注意]
 > この機能はプラットフォームバージョンが1.202605.0以上であるクラスターで動作します。
 
+<a id="advanced-lb-configuration-setting-load-balancer-name"></a>
 #### ロードバランサー名設定
 
 ロードバランサーの名前を設定できます。
@@ -2807,6 +2766,7 @@ kubectl annotate svc <name> loadbalancer.nhncloud/force-reconcile=true
 > * サービスオブジェクトが作成された後、ロードバランサー名を修正
 > * プロジェクト内に同じ名前のロードバランサーを作成
 
+<a id="advanced-lb-configuration-set-load-balancer-type"></a>
 #### ロードバランサータイプ設定
 ロードバランサーのタイプを設定できます。ロードバランサーの詳細については[ロードバランサーコンソール使用ガイド](/Network/Load%20Balancer/ko/console-guide/)を参照してください。
 
@@ -2823,6 +2783,7 @@ kubectl annotate svc <name> loadbalancer.nhncloud/force-reconcile=true
 > 物理ロードバランサーはFloating IPを接続できません。その代わり、物理ロードバランサー作成時に自動で割り当てられたパブリックIP1つをバランシング対象トラフィックを受信するIPとして使用します。このパブリックIPはサービスIPという名前でコンソールに表示されます。
 > このような特性によりKubernetesサービスオブジェクトを通じてロードバランサーの正確な状態(接続されたFloating IPなど)を取得できません。物理ロードバランサーの状態などはコンソールでご確認ください。
 
+<a id="advanced-lb-configuration-set-static-routes"></a>
 #### 静的ルート設定
 ロードバランサーの静的ルートを適用するかどうかを設定できます。
 
@@ -2835,6 +2796,7 @@ kubectl annotate svc <name> loadbalancer.nhncloud/force-reconcile=true
 > [注意]
 > 静的ルート設定は、2024年8月27日以降に作成されたクラスター、またはk8sバージョンをアップグレードしたクラスターで設定可能です。
 
+<a id="advanced-lb-configuration-set-the-session-affinity"></a>
 #### セッション持続性設定
 ロードバランサーのセッション持続性を設定できます。
 
@@ -2849,6 +2811,7 @@ kubectl annotate svc <name> loadbalancer.nhncloud/force-reconcile=true
 * v1.19.13以降のクラスタ
     * ロードバランサーの作成後も変更可能です。
 
+<a id="advanced-lb-configuration-set-whether-to-keep-a-floating-ip-address"></a>
 #### ロードバランサーを削除する時にFloating IPアドレスを保存するかどうかの設定
 ロードバランサーにはFloating IPが接続されています。ロードバランサーの削除時にロードバランサーに接続されたFloating IPを削除あるいは保存するかどうかを設定できます。
 
@@ -2861,6 +2824,7 @@ kubectl annotate svc <name> loadbalancer.nhncloud/force-reconcile=true
 > [注意]
 > 2021年10月26日以前に作成されたv1.18.19クラスタは、ロードバランサーが削除される時、Floating IPが削除されない問題があります。サポートの1:1お問い合わせを通してお問い合わせください。この問題を解決するための手順を詳しくお伝えします。
 
+<a id="advanced-lb-configuration-set-the-load-balancer-ip"></a>
 #### ロードバランサーIP設定
 ロードバランサーを作成するときにロードバランサーのIPを設定できます。
 
@@ -2891,6 +2855,7 @@ spec:
   type: LoadBalancer
 ```
 
+<a id="advanced-lb-configuration-set-whether-to-use-the-floating-ip"></a>
 #### Floating IP使用設定
 ロードバランサーを作成するときにFloating IPを使用するかどうかを設定できます。
 
@@ -2934,6 +2899,7 @@ Floating IP使用設定とロードバランサーIP設定の組み合わせに�
 | true | 設定 | ロードバランサーに指定されたVIPを接続します。 |
 
 
+<a id="advanced-lb-configuration-set-vpc"></a>
 #### VPC設定
 ロードバランサー作成時、ロードバランサーが接続されるVPCを設定できます。
 
@@ -2941,6 +2907,7 @@ Floating IP使用設定とロードバランサーIP設定の組み合わせに�
 * **リスナー別の設定を適用できません。**
 * 設定しない場合はクラスタ作成時に設定したVPCに設定します。
 
+<a id="advanced-lb-configuration-set-subnet"></a>
 #### サブネット設定
 ロードバランサー作成時、ロードバランサーが接続されるサブネットを設定できます。設定されたサブネットにロードバランサーのプライベートIPが接続されます。メンバーサブネット設定がない場合、このサブネットに接続されたワーカーノードがロードバランサーメンバーとして追加されます。
 
@@ -2970,6 +2937,7 @@ spec:
   type: LoadBalancer
 ```
 
+<a id="advanced-lb-configuration-set-member-subnet"></a>
 #### メンバーサブネット設定
 ロードバランサー作成時、ロードバランサーメンバーが接続されるサブネットを設定できます。このサブネットに接続されたワーカーノードがロードバランサーメンバーとして追加されます。
 
@@ -3029,6 +2997,7 @@ spec:
 > メンバーサブネットは2023年11月28日以降v1.24.3以上のバージョンにアップグレードされたか、新しく作成されたクラスタで設定可能です。
 
 
+<a id="advanced-lb-configuration-set-the-listener-connection-limit"></a>
 #### リスナー接続制限設定
 リスナーの接続制限を設定できます。
 
@@ -3042,6 +3011,7 @@ spec:
     * 設定しない場合や範囲外の値を入力した場合はデフォルト値の60000に設定されます。
 
 
+<a id="advanced-lb-configuration-set-the-listener-protocol"></a>
 #### リスナープロトコル設定
 リスナーのプロトコルを設定できます。
 
@@ -3133,6 +3103,7 @@ metadata:
 > Certificate Managerに登録された証明書を利用する方法は、2024年5月28日以降に作成された、またはk8sバージョンをアップグレードしたクラスタで設定可能です。
 > リスナーと連動したCertificate Managerの証明書を削除すると、ロードバランサーの動作に影響を与える可能性があります。
 
+<a id="advanced-lb-configuration-set-the-listener-proxy-protocol"></a>
 #### リスナープロキシプロトコル(Proxy Protocol)設定
 リスナープロトコルがTCPまたはHTTPSの場合、リスナーにプロキシプロトコルを設定できます。プロキシプロトコルの詳細については[ロードバランサープロキシモード](/Network/Load%20Balancer/ko/overview/#_4)をご覧ください。
 
@@ -3142,6 +3113,7 @@ metadata:
     * true：プロキシプロトコルを有効にします。
     * false：プロキシプロトコルを無効にします。未設定時のデフォルト値です。
 
+<a id="advanced-lb-configuration-set-the-load-balancing-method"></a>
 #### ロードバランシング方式設定
 ロードバランシング方式を設定できます。
 
@@ -3153,6 +3125,7 @@ metadata:
     * SOURCE_IP
 
 
+<a id="advanced-lb-configuration-set-the-health-check-protocol"></a>
 #### ヘルスチェックプロトコル設定
 ヘルスチェックプロトコルを設定できます。
 
@@ -3183,6 +3156,7 @@ HTTPステータスコードは次のように設定できます。
 * 単一値(例：200)、リスト(例：200,202)、範囲(例：200-204)形式で入力できます。
 * 設定しない場合やルールに合わない値を入力するとデフォルト値の200に設定されます。
 
+<a id="advanced-lb-configuration-set-the-health-check-interval"></a>
 #### ヘルスチェックサイクルの設定
 ヘルスチェック周期を設定できます。
 
@@ -3192,6 +3166,7 @@ HTTPステータスコードは次のように設定できます。
 * 最小値1、最大値5000です。
 * 設定しない場合や範囲外の値を入力するとデフォルト値の60に設定されます。
 
+<a id="advanced-lb-configuration-set-the-health-check-maximum-response-time"></a>
 #### ヘルスチェック最大レスポンス時間設定
 ヘルスチェック最大レスポンス時間を設定できます。
 
@@ -3203,6 +3178,7 @@ HTTPステータスコードは次のように設定できます。
 * 設定しない場合や範囲外の値を入力するとデフォルト値の30に設定されます。
 * ただし、入力値または設定値がヘルスチェックサイクル設定より大きい場合は、ヘルスチェックサイクル設定の1/2に設定されます。
 
+<a id="advanced-lb-configuration-set-the-maximum-number-of-retries-for-a-health-check"></a>
 #### ヘルスチェック最大再試行回数設定
 ヘルスチェック最大再試行回数を設定できます。
 
@@ -3211,6 +3187,7 @@ HTTPステータスコードは次のように設定できます。
 * 最小値1、最大値10です。
 * 設定しない場合や範囲外の値を入力するとデフォルト値の3に設定されます。
 
+<a id="advanced-lb-configuration-health-check-port-settings"></a>
 #### ヘルスチェックポート設定
 ヘルスチェックの対象となるメンバーポートを設定できます。
 * 設定位置は .metadata.annotations 下の loadbalancer.nhncloud/healthmonitor-health-check-port です。
@@ -3218,12 +3195,14 @@ HTTPステータスコードは次のように設定できます。
 * 最小値0、最大値65535です。
 * 0を指定する場合、各メンバーごとに指定されたポート番号を対象にヘルスチェックを実行します。
 * 設定しないか範囲外の値を入力すると、デフォルト値の0に設定されます。
+<a id="advanced-lb-configuration-health-check-host-header-settings"></a>
 #### ヘルスチェックホストヘッダ設定
 ヘルスチェックに使用するホストヘッダのフィールド値を設定できます。
 * 設定位置は .metadata.annotations 下の loadbalancer.nhncloud/healthmonitor-http-host-header です。
 * リスナーごとの設定を適用できます。
 * ヘルスチェックプロトコルをTCPに設定した場合、このフィールドに設定した値は無視されます。
 
+<a id="advanced-lb-configuration-setting-keep-alive-timeout"></a>
 #### keep-aliveタイムアウト設定
 keep-aliveタイムアウト値を設定できます。
 
@@ -3236,6 +3215,7 @@ keep-aliveタイムアウト値を設定できます。
 > [注意]
 > keep-alive timeoutは2023年11月28日以降にv1.24.3以上のバージョンにアップグレードされたか、新規に作成されたクラスタで設定可能です。
 
+<a id="advanced-lb-configuration-l7-rules"></a>
 #### L7ルール
 リスナーごとにL7ルールを設定できます。 L7ルールは次のように動作します。
 
@@ -3265,6 +3245,7 @@ L7ルール設定には以下の制約があります。
 * 一つのリスナーに設定されるL7ルールは、異なるインデックス値で設定する必要があります。
 * 一つのリスナーに設定されるL7ルールは、異なる名前で設定する必要があります。
 
+<a id="advanced-lb-configuration-l7-conditions"></a>
 #### L7条件
 L7ルールごとにL7条件を設定できます。L7条件は次のように動作します。
 
@@ -3366,19 +3347,20 @@ spec:
 ```
 
 <a id="ingress-controller"></a>
-## イングレスコントローラー
+## イングレスコントローラー { #ingress-controller }
 イングレスコントローラー(Ingress Controller)は、イングレスオブジェクトに定義されているルールを参照してクラスタ外部から内部サービスにHTTPとHTTPSリクエストをルーティングし、SSL/TSL終了、仮想ホスティングなどを提供します。イングレスコントローラーとイングレスの詳細については[イングレスコントローラー](https://kubernetes.io/ko/docs/concepts/services-networking/ingress-controllers/)、[イングレス](https://kubernetes.io/ko/docs/concepts/services-networking/ingress/)文書を参照してください。
 
 <a id="install-nginx-ingress-controller"></a>
-### NGINX Ingress Controllerのインストール
+### NGINX Ingress Controllerのインストール { #install-nginx-ingress-controller }
 NGINX Ingress Controllerは、よく使われるイングレスコントローラーの1つです。詳細については[NGINX Ingress Controller](https://kubernetes.github.io/ingress-nginx/)と[NGINX Ingress Controller for Kubernetes](https://www.nginx.com/products/nginx-ingress-controller/)文書を参照してください。 NGINX Ingress Controllerのインストールは[Installation Guide](https://kubernetes.github.io/ingress-nginx/deploy/)文書を参照してください。
 
 <a id="uri-based-service-routing"></a>
-### URIベースのサービス分岐
+### URIベースのサービス分岐 { #uri-based-service-routing }
 イングレスコントローラーはURIに基づいてサービスを分岐できます。次の図はURIに基づいてサービスを分岐する簡単な例の構造を表しています。
 
 ![ingress-01.png](http://static.toastoven.net/prod_infrastructure/container/kubernetes/ingress-01.png)
 
+<a id="uri-based-service-routing-create-services-and-pods"></a>
 #### サービスとPod作成
 次のようにサービスとPodを作成するためのマニフェストを作成します。 `tea-svc`サービスには`tea` Podを接続し、`coffee-svc`サービスには`coffee` Podを接続します。
 
@@ -3479,6 +3461,7 @@ pod/tea-5c457db9-fdkxl        1/1     Running   0          27m
 pod/tea-5c457db9-z6hl5        1/1     Running   0          27m
 ```
 
+<a id="uri-based-service-routing-create-ingress"></a>
 #### イングレス(Ingress)作成
 リクエストパスに基づいてサービスに接続するイングレスマニフェストを作成します。エンドポイントが`/tea`のリクエストは`tea-svc`サービスに接続し、`/coffee`のリクエストは`coffee-svc`サービスに接続します。
 
@@ -3520,6 +3503,7 @@ NAME               CLASS   HOSTS   ADDRESS          PORTS   AGE
 cafe-ingress-uri   nginx   *       123.123.123.44   80      23s
 ```
 
+<a id="uri-based-service-routing-send-http-requests"></a>
 #### HTTPリクエストの送信
 外部ホストからingressの**ADDRESS**フィールドに設定されたIPアドレスにHTTPリクエストを送信してイングレスが正しく設定されていることを確認します。
 
@@ -3578,6 +3562,7 @@ $ curl 123.123.123.44/unknown
 </html>
 ```
 
+<a id="uri-based-service-routing-delete-resources"></a>
 #### リソース削除
 テストに使用したリソースは作成するときに使用したマニフェストを利用して削除できます。
 
@@ -3593,14 +3578,16 @@ service "tea-svc" deleted
 ```
 
 <a id="host-based-service-routing"></a>
-### ホストベースのサービス分岐
+### ホストベースのサービス分岐 { #host-based-service-routing }
 イングレスコントローラーはホスト名に基づいてサービスを分岐できます。次の図はホスト名に基づいてサービスを分岐する簡単な例の構造を表しています。
 
 ![ingress-02.png](http://static.toastoven.net/prod_infrastructure/container/kubernetes/ingress-02.png)
 
+<a id="host-based-service-routing-create-services-and-pods"></a>
 #### サービスとPod作成
 [URIベースのサービス分岐](/Container/NKS/ja/user-guide/#uri)と同じマニフェストを利用してサービスとPodを作成します。
 
+<a id="host-based-service-routing-create-ingress"></a>
 #### イングレス作成
 ホスト名に基づいてサービスに接続するイングレスマニフェストを作成します。 `tea.cafe.example.com`ホストに入ったリクエストは`tea-svc`サービスに接続し、`coffee.cafe.example.com`ホストに入ったリクエストは`coffee-svc`サービスに接続します。
 
@@ -3646,6 +3633,7 @@ NAME                CLASS   HOSTS                                          ADDRE
 cafe-ingress-host   nginx   tea.cafe.example.com,coffee.cafe.example.com   123.123.123.44   80      36s
 ```
 
+<a id="host-based-service-routing-send-http-requests"></a>
 #### HTTP Request送信
 外部ホストからイングレスのADDRESSに設定されたIPにHTTPリクエストを送信します。ただしホスト名を利用してサービスを分岐するようにイングレスを構成したため、ホスト名を利用してリクエストを送信する必要があります。
 
@@ -3689,9 +3677,10 @@ $ curl 123.123.123.44/unknown
 ```
 
 <a id="ingress-nginx-internal-communication"></a>
-### ingress-nginxコントローラー内部通信構造及び注意事項
+### ingress-nginxコントローラー内部通信構造及び注意事項 { #ingress-nginx-internal-communication }
 ingress-nginxコントローラーを通じてサービスを外部に公開する場合、リクエストを送信するクライアントの位置(クラスタ内部または外部)によって、リクエストがワークロードに伝達される経路が異なります。
 
+<a id="ingress-nginx-internal-communication-cluster-external-client"></a>
 #### クラスタ外部クライアント
 クラスタ外部クライアントが送信するリクエストはロードバランサーを通じてIngress Controllerへ伝達されます。ロードバランサーはIngress Controller Serviceの外部エンドポイントの役割をし、Ingress ControllerはIngressルールに従ってリクエストを目的地Backend Podへルーティングします。
 
@@ -3699,6 +3688,7 @@ ingress-nginxコントローラーを通じてサービスを外部に公開す�
 クラスタ外部クライアント → ロードバランサー → ingress-nginx Service → ingress-nginx Controller Pod → Backend Pod
 ```
 
+<a id="ingress-nginx-internal-communication-cluster-internal-client"></a>
 #### クラスタ内部クライアント
 クラスタ内部PodがIngressアドレスへリクエストする場合、トラフィックはロードバランサーを経由しません。リクエストはIngress Controller ServiceのClusterIPを通じて内部経路へ直接伝達され、この過程でCNIによって以下の方式でルーティングされます。
 
@@ -3710,6 +3700,7 @@ ingress-nginxコントローラーを通じてサービスを外部に公開す�
 内部Pod → ingress-nginx Service (ClusterIP) → ingress-nginx Controller Pod → Backend Pod
 ```
 
+<a id="ingress-nginx-internal-communication-cautions"></a>
 #### 注意事項
 
 - 内部リクエストはロードバランサーポリシーの適用を受けません。ロードバランサーのTLS設定、セキュリティポリシー、ファイアウォールルールなどは内部トラフィックに影響を与えません。
@@ -3718,7 +3709,7 @@ ingress-nginxコントローラーを通じてサービスを外部に公開す�
 
 
 <a id="k8s-dashboard"></a>
-## Kubernetesダッシュボード
+## Kubernetesダッシュボード { #k8s-dashboard }
 NHN Kubernetes Service(NKS)は基本Web UIダッシュボード(dashboard)を提供します。 Kubernetesダッシュボードの詳細については[Web UI (ダッシュボード)](https://kubernetes.io/ko/docs/tasks/access-application-cluster/web-ui-dashboard/)文書を参照してください。
 
 > [注意]
@@ -3727,7 +3718,7 @@ NHN Kubernetes Service(NKS)は基本Web UIダッシュボード(dashboard)を提
 > * NHN CloudコンソールでKubernetesリソースを照会できます。
 
 <a id="expose-dashboard"></a>
-### ダッシュボードサービス公開
+### ダッシュボードサービス公開 { #expose-dashboard }
 ユーザーKubernetesにはダッシュボードを公開するための`kubernetes-dashboard`サービスオブジェクトがあらかじめ作成されています。
 
 ```
@@ -3755,6 +3746,7 @@ Events:            <none>
 
 しかし`kubernetes-dashboard`サービスオブジェクトはClusterIPタイプのため、まだクラスタ外部に公開されていません。ダッシュボードを外部公開するにはサービスオブジェクトをLoadBalancerタイプに変更するか、イングレスコントローラーとイングレスオブジェクトを作成する必要があります。
 
+<a id="expose-dashboard-change-into-loadbalancer"></a>
 #### LoadBalancerサービスオブジェクトに変更
 
 `LoadBalancer`タイプにサービスオブジェクトを変更すると、クラスタ外部にNHN Cloud Load Balancerが作成され、ロードバランサーとサービスオブジェクトが接続されます。ロードバランサーに接続したサービスオブジェクトを照会すると**EXTERNAL-IP**フィールドにロードバランサーのIPが表示されます。 `LoadBalancer`タイプのサービスオブジェクトについては[LoadBalancerサービス](/Container/NKS/ja/user-guide/#loadbalancer)を参照してください。次の図は`LoadBalancer`タイプのサービスを利用してダッシュボードを外部に公開する構造を表しています。
@@ -3786,6 +3778,7 @@ Webブラウザで`https://{EXTERNAL-IP}`に接続するとKubernetesダッシ�
 > [参考]
 > Kubernetesダッシュボードは自動作成されるプライベート証明書を使用するため、Webブラウザの種類とセキュリティ設定によっては安全ではないページと表示されることがあります。
 
+<a id="expose-dashboard-open-services-with-ingress"></a>
 #### イングレス(Ingress)を利用したサービス公開
 
 イングレスは、クラスタ内部の複数のサービスにアクセスするためのルーティングを提供するネットワークオブジェクトです。イングレスオブジェクトの設定は、イングレスコントローラーで動作します。 `kubernetes-dashboard`サービスオブジェクトをイングレスを介して公開できます。イングレスとイングレスコントローラーの詳細については[イングレスコントローラー](/Container/NKS/ja/user-guide/#ingress-controller)を参照してください。次の図はイングレスを介してダッシュボードを外部に公開する構造を表しています。
@@ -3838,7 +3831,7 @@ k8s-dashboard-ingress   nginx   *       123.123.123.44   80, 443   34s
 Webブラウザで`https://{ADDRESS}`に接続するとKubernetesダッシュボードページがローディングされます。ログインのために必要なトークンは[ダッシュボードアクセストークン](/Container/NKS/ja/user-guide/#dashboard-access-token)を参照してください。
 
 <a id="dashboard-access-token"></a>
-### ダッシュボードアクセストークン
+### ダッシュボードアクセストークン { #dashboard-access-token }
 Kubernetesダッシュボードにログインするにはトークンが必要です。トークンは次のコマンドで取得できます。
 
 ```
@@ -3851,7 +3844,7 @@ eyJhbGc...-QmXA
 出力されたトークンをブラウザのトークン入力ウィンドウに入力すると、クラスタ管理者権限を付与されたユーザーとしてログインできます。
 
 <a id="persistent-volume"></a>
-## パシステントボリューム
+## パシステントボリューム { #persistent-volume }
 パシステントボリューム(Persistent Volume, PV)は物理記憶装置(volume)を表すKubernetesのリソースです。1つのPVは1つのNHN Cloud Block Storageに接続されます。詳細については[パシステントボリューム](https://kubernetes.io/ko/docs/concepts/storage/persistent-volumes/)文書を参照してください。
 
 PVをPodに接続して使用するにはパシステントボリュームクレーム(Persistent Volume Claims, PVC)オブジェクトが必要です。 PVCは容量、読み取り/書き込みモードなど必要なボリュームの要求事項を定義します。
@@ -3859,7 +3852,7 @@ PVをPodに接続して使用するにはパシステントボリュームクレ
 PVとPVCでユーザーは使用したいボリュームのプロパティを定義し、システムはユーザーの要求事項に合ったボリュームリソースを割り当てる方式でリソースの使用と管理を分離します。
 
 <a id="pv-lifecycle"></a>
-### PV/PVCのライフサイクル
+### PV/PVCのライフサイクル { #pv-lifecycle }
 PVとPVCは4段階のライフサイクル(life cycle)に従います。
 
 * プロビジョニング(provisioning)
@@ -3881,15 +3874,17 @@ PVをPodにマウントして使用します。
 | 再利用(Recycle) | PVを削除するとき、接続しているボリュームを削除せず、再利用できる状態にします。この方法は停止(deprecated)しています。 |
 
 <a id="storageclass"></a>
-### ストレージクラス(StorageClass)
+### ストレージクラス(StorageClass) { #storageclass }
 プロビジョニングを行うには、まずストレージクラスが定義されている必要があります。ストレージクラスは特定の特性でストレージを分類できる方法を提供します。ストレージ提供者(provisioner)の情報を含め、メディアの種類やアベイラビリティゾーンなどを設定できます。 
 
+<a id="storageclass-storage-provider-provisioner"></a>
 #### ストレージ提供者(provisioner)
 ストレージの提供者情報を設定します。Kubernetesバージョンに応じてサポートされているストレージプロバイダー情報は次のとおりです。
 
 * v1.19.13以前のバージョン：provisionerフィールドを必ず`kubernetes.io/cinder`に設定する必要があります。
 * v1.20.12以降のバージョン：provisionerフィールドを`cinder.csi.openstack.org`に設定して使用できます。
 
+<a id="storageclass-parameters-parameter"></a>
 #### パラメータ(parameter)
 ストレージクラスを介して次のパラメータを設定できます。
 
@@ -3901,18 +3896,21 @@ PVをPodにマウントして使用します。
     * 坪村リージョン：**kr2-pub-a**または**kr2-pub-b**
     * クァンジュリージョン：**kr3-pub-a** または **kr3-pub-b**
     
+<a id="storageclass-volume-binding-mode-volumebindingmode"></a>
 #### ボリュームバインディングモード(VolumeBindingMode)
 ボリュームバインディングモードは、ボリュームバインディングと動的プロビジョニングの開始時点を制御します。この設定はストレージ提供者がcinder.csi.openstack.orgの場合にのみ設定できます。
 
 * **Immediate**：パシステントボリュームクレームが作成されるとすぐにボリュームバインディングと動的プロビジョニングが始まります。パシステントボリュームクレームが作成される時点ではボリュームを接続するPodの事前知識がない状態です。そのためボリュームのアベイラビリティゾーンとPodがスケジューリングされるノードのアベイラビリティゾーンが異なる場合はPodが正常に動作しません。 
 * **WaitForFirstConsumer**：パシステントボリュームクレームが作成されるときはボリュームバインディングと動的プロビジョニングを行いません。このパシステントボリュームクレームが初めてPodに接続すると、 Podがスケジューリングされたノードのアベイラビリティゾーン情報をもとにボリュームバインディングと動的プロビジョニングを行います。したがってImmediateモードなど、ボリュームのアベイラビリティゾーンとインスタンスのアベイラビリティゾーンが異なりPodが正常に動作しない場合が発生しません。
 
+<a id="storageclass-allow-volume-expansion-allowvolumeexpansion"></a>
 #### ボリューム拡張許可(allowVolumeExpansion)
 作成されたボリュームの拡張を許可するかどうかを設定します(未入力の場合はfalseが設定されます)。
 
 * **True**：ボリューム拡張を許可します。
 * **False**：ボリューム拡張を許可しません。
 
+<a id="storageclass-example-1"></a>
 #### 例1
 以下のストレージクラスマニフェストはv1.19.13以前のバージョンを使用するKubernetesクラスタで使用できます。パラメータを介してアベイラビリティゾーンとボリュームタイプを指定できます。
 
@@ -3939,6 +3937,7 @@ NAME     PROVISIONER            RECLAIMPOLICY   VOLUMEBINDINGMODE   ALLOWVOLUMEE
 sc-ssd   kubernetes.io/cinder   Delete          Immediate           false                  3s
 ```
 
+<a id="storageclass-example-2"></a>
 #### 例2
 次のストレージクラスマニフェストは、v1.20.12以降のバージョンを使用するKubernetesクラスタで使用できます。ボリュームバインディングモードをWaitForFirstConsumerに設定してパシステントボリュームクレームがPodに接続されるときにボリュームバインディングと動的プロビジョニングを開始します。
 
@@ -3964,7 +3963,7 @@ csi-storageclass   cinder.csi.openstack.org   Delete          WaitForFirstConsum
 ```
 
 <a id="static-provisioning"></a>
-### 静的プロビジョニング
+### 静的プロビジョニング { #static-provisioning }
 
 静的プロビジョニング(static provisioning)は、ユーザーが直接ブロックストレージを準備する必要があります。 NHN Cloud Webコンソールの**Storage > Block Storage**サービスページで**ブロックストレージ作成**ボタンをクリックしてPVに接続するブロックストレージを作成します。ブロックストレージガイドの[ブロックストレージ作成](/Storage/Block%20Storage/ko/console-guide/#_1)を参照してください。
 
@@ -4049,7 +4048,7 @@ pv-static-001   10Gi       RWO            Delete           Bound    default/pvc-
 ```
 
 <a id="dynamic-provisioning"></a>
-### 動的プロビジョニング
+### 動的プロビジョニング { #dynamic-provisioning }
 
 動的プロビジョニング(dynamic provisioning)はストレージクラスに定義されているプロパティを参照して自動的にブロックストレージを作成します。動的プロビジョニングを使用するには、ストレージクラスのボリュームバインディングモード設定を行わないか、**Immediate**に設定する必要があります。
 
@@ -4102,7 +4101,7 @@ persistentvolumeclaim/pvc-dynamic   Bound    pvc-1056949c-bc67-45cc-abaa-1d1bd9e
 > 動的プロビジョニングで作成されたブロックストレージはWebコンソールから削除できません。またクラスタを削除するとき、自動的に削除されません。したがってクラスタを削除する前にPVCをすべて削除する必要があります。PVCを削除せずにクラスタを削除すると課金されることがあります。動的プロビジョニングを作成されたPVCのreclaimPolicyは基本的に`Delete`に設定されるため、PVを削除するだけでPVとブロックストレージが削除されます。
 
 <a id="pod-pvc-mount"></a>
-### PodにPVCマウント
+### PodにPVCマウント { #pod-pvc-mount }
 
 PodにPVCをマウントするにはPodマニフェストにマウント情報を定義する必要があります。 `spec.volumes.persistenVolumeClaim.claimName`に使用するPVC名を入力します。そして`spec.containers.volumeMounts.mountPath`にマウントするパスを入力します。
 
@@ -4157,250 +4156,12 @@ NOTE(kyungjun.kim)
 
 > 重複した内容が存在するようです。 ご確認ください. もし重複でしたら、注釈内容の削除をお願いします
 
-#### ボリューム拡張の許可(allowVolumeExpansion)
-作成されたボリュームの拡張を許可するかどうかを設定します(未入力の場合はfalseが設定されます)。
-
-* **True**：ボリュームの拡張を許可します。
-* **False**：ボリュームの拡張を許可しません。
-
-#### 例1
-以下のストレージクラスマニフェストはv1.19.13以前のバージョンを使用するKubernetesクラスタで使用できます。パラメータを利用してアベイラビリティゾーンとボリュームタイプを指定できます。
-
-```yaml
-# storage_class.yaml
-apiVersion: storage.k8s.io/v1
-kind: StorageClass
-metadata:
-  name: sc-ssd
-provisioner: kubernetes.io/cinder
-parameters:
-  type: General SSD
-  availability: kr-pub-a
-```
-
-ストレージクラスを作成し、確認します。
-
-```
-$ kubectl apply -f storage_class.yaml
-storageclass.storage.k8s.io/sc-ssd created
-
-$ kubectl get sc
-NAME     PROVISIONER            RECLAIMPOLICY   VOLUMEBINDINGMODE   ALLOWVOLUMEEXPANSION   AGE
-sc-ssd   kubernetes.io/cinder   Delete          Immediate           false                  3s
-```
-
-#### 例2
-以下のストレージクラスマニフェストはv1.20.12以降のバージョンを使用するKubernetesクラスタで使用できます。ボリュームバインディングモードをWaitForFirstConsumerに設定してパシステントボリュームクレームがPodに接続される時にボリュームバインディングと動的プロビジョニングを開始します。
-
-```yaml
-# storage_class_csi.yaml
-apiVersion: storage.k8s.io/v1
-kind: StorageClass
-metadata:
-  name: csi-storageclass
-provisioner: cinder.csi.openstack.org
-volumeBindingMode: WaitForFirstConsumer
-```
-
-ストレージクラスを作成し、確認します。
-
-```
-$ kubectl apply -f storage_class_csi.yaml
-storageclass.storage.k8s.io/csi-storageclass created
-
-$ kubectl get sc
-NAME               PROVISIONER                RECLAIMPOLICY   VOLUMEBINDINGMODE      ALLOWVOLUMEEXPANSION   AGE
-csi-storageclass   cinder.csi.openstack.org   Delete          WaitForFirstConsumer   false                  7s
-```
-
-
-### 静的プロビジョニング
-
-静的プロビジョニング(static provisioning)はユーザーが直接ブロックストレージを準備する必要があります。NHN Cloud Webコンソールの**Storage > Block Storage**サービスページで**ブロックストレージ作成**ボタンをクリックしてPVと接続するブロックストレージを作成します。ブロックストレージガイドの[ブロックストレージ作成](/Storage/Block%20Storage/ko/console-guide/#_2)を参照してください。
-
-PVを作成するにはブロックストレージのIDが必要です。**Storage > Block Storage**サービスページのブロックストレージリストから使用するブロックストレージを選択します。下部の**情報**タブのブロックストレージ名項目でIDを確認できます。
-
-ブロックストレージと接続するPVマニフェストを作成します。**spec.storageClassName**にはストレージクラス名を入力します。NHN Cloud Block Storageを使用するには**spec.accessModes**は必ず`ReadWriteOnce`に設定する必要があります。**spec.presistentVolumeReclaimPolicy**は`Delete`または`Retain`に設定できます。
-
-> [注意]
-> Kubernetesバージョンに合ったストレージプロバイダーが定義されたストレージクラスを設定する必要があります。
-
-```yaml
-# pv-static.yaml
-apiVersion: v1
-kind: PersistentVolume
-metadata:
-  name: pv-static-001
-spec:
-  capacity:
-    storage: 10Gi
-  volumeMode: Filesystem
-  accessModes:
-    - ReadWriteOnce
-  persistentVolumeReclaimPolicy: Delete
-  storageClassName: sc-default
-  cinder:
-    fsType: "ext3"
-    volumeID: "e6f95191-d58b-40c3-a191-9984ce7532e5"
-```
-
-PVを作成し、確認します。
-
-```
-$ kubectl apply -f pv-static.yaml
-persistentvolume/pv-static-001 created
-
-$ kubectl get pv -o wide
-NAME            CAPACITY   ACCESS MODES   RECLAIM POLICY   STATUS      CLAIM   STORAGECLASS   REASON   AGE   VOLUMEMODE
-pv-static-001   10Gi       RWO            Delete           Available           sc-default              7s    Filesystem
-```
-
-作成したPVを使用するためのPVCマニフェストを作成します。**spec.volumeName**にはPVの名前を指定する必要があります。他の項目はPVマニフェストの内容と同じように設定します。
-
-```yaml
-# pvc-static.yaml
-apiVersion: v1
-kind: PersistentVolumeClaim
-metadata:
-  name: pvc-static
-  namespace: default
-spec:
-  volumeName: pv-static-001
-  accessModes:
-  - ReadWriteOnce
-  resources:
-    requests:
-      storage: 10Gi
-  storageClassName: sc-default
-```
-
-PVCを作成し、確認します。
-
-```
-$ kubectl apply -f pvc-static.yaml
-persistentvolumeclaim/pvc-static created
-
-$ kubectl get pvc -o wide
-NAME         STATUS   VOLUME          CAPACITY   ACCESS MODES   STORAGECLASS   AGE   VOLUMEMODE
-pvc-static   Bound    pv-static-001   10Gi       RWO            sc-default     7s    Filesystem
-```
-
-PVCを作成した後、PVの状態を照会してみると、**CLAIM**項目にPVC名が指定され、**STATUS**項目が`Bound`に変更されていることを確認できます。
-
-```
-$ kubectl get pv -o wide
-NAME            CAPACITY   ACCESS MODES   RECLAIM POLICY   STATUS   CLAIM                STORAGECLASS   REASON   AGE   VOLUMEMODE
-pv-static-001   10Gi       RWO            Delete           Bound    default/pvc-static   sc-default              79s   Filesystem
-```
-
-
-### 動的プロビジョニング
-
-動的プロビジョニング(dynamic provisioning)はストレージクラスに定義されたプロパティを参照して自動的にブロックストレージを作成します。動的プロビジョニングを使用するにはストレージクラスのボリュームバインディングモードを設定しないか、**Immediate**に設定する必要があります。
-
-```yaml
-# storage_class_csi_dynamic.yaml
-apiVersion: storage.k8s.io/v1
-kind: StorageClass
-metadata:
-  name: csi-storageclass-dynamic
-provisioner: cinder.csi.openstack.org
-volumeBindingMode: Immediate
-```
-
-動的プロビジョニングはPVを作成する必要がありません。したがってPVCマニフェストには**spec.volumeName**を設定しません。
-
-```yaml
-# pvc-dynamic.yaml
-apiVersion: v1
-kind: PersistentVolumeClaim
-metadata:
-  name: pvc-dynamic
-  namespace: default
-spec:
-  accessModes:
-  - ReadWriteOnce
-  resources:
-    requests:
-      storage: 10Gi
-  storageClassName: csi-storageclass-dynamic
-```
-
-ボリュームバインディングモードを設定しないか、**Immediate**に設定してPVCを作成すると、PVが自動的に作成されます。PVに接続されたブロックストレージも自動的に作成され、NHN Cloud Webコンソール**Storage > Block Storage**サービスページのブロックストレージリストで確認できます。
-
-```
-$ kubectl apply -f pvc-dynamic.yaml
-persistentvolumeclaim/pvc-dynamic created
-
-$ kubectl get sc,pv,pvc
-NAME                                                   PROVISIONER                RECLAIMPOLICY   VOLUMEBINDINGMODE   ALLOWVOLUMEEXPANSION   AGE
-storageclass.storage.k8s.io/csi-storageclass-dynamic   cinder.csi.openstack.org   Delete          Immediate           false                  50s
-
-NAME                                                        CAPACITY   ACCESS MODES   RECLAIM POLICY   STATUS   CLAIM                 STORAGECLASS               REASON   AGE
-persistentvolume/pvc-1056949c-bc67-45cc-abaa-1d1bd9e51467   10Gi       RWO            Delete           Bound    default/pvc-dynamic   csi-storageclass-dynamic            5s
-
-NAME                                STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS               AGE
-persistentvolumeclaim/pvc-dynamic   Bound    pvc-1056949c-bc67-45cc-abaa-1d1bd9e51467   10Gi       RWO            csi-storageclass-dynamic   9s
-```
-
-> [注意]
-> 動的プロビジョニングによって作成されたブロックストレージはWebコンソールから削除できません。またクラスタを削除する時に自動的に削除されません。したがってクラスタを削除する前にPVCを全て削除する必要があります。PVCを削除せずにクラスタを削除すると課金される可能性があります。動的プロビジョニングを作成されたPVのreclaimPolicyは基本的に`Delete`に設定されるため、PVCのみ削除してもPVとブロックストレージが削除されます。
-
-
-### PodにPVCマウント
-
-PodにPVCをマウントするにはPodマニフェストにマウント情報を定義する必要があります。`spec.volumes.persistenVolumeClaim.claimName`に使用するPVC名を入力します。そして`spec.containers.volumeMounts.mountPath`にマウントするパスを入力します。
-
-以下の例は静的プロビジョニングで作成したPVCをPodの`/usr/share/nginx/html`にマウントします。
-
-```yaml
-# pod-pvc.yaml
-apiVersion: v1
-kind: Pod
-metadata:
-  name: nginx-with-static-pv
-spec:
-  containers:
-    - name: web
-      image: nginx
-      ports:
-        - name: web
-          containerPort: 80
-          hostPort: 8082
-          protocol: TCP
-      volumeMounts:
-        - name: html-volume
-          mountPath: "/usr/share/nginx/html"
-  volumes:
-    - name: html-volume
-      persistentVolumeClaim:
-        claimName: pvc-static
-```
-
-Podを作成し、ブロックストレージがマウントされていることを確認します。
-
-```
-$ kubectl apply -f pod-static-pvc.yaml
-pod/nginx-with-static-pv created
-
-$ kubectl get pods
-NAME                   READY   STATUS    RESTARTS   AGE
-nginx-with-static-pv   1/1     Running   0          50s
-
-$ kubectl exec -ti nginx-with-static-pv -- df -h
-Filesystem      Size  Used Avail Use% Mounted on
-...
-/dev/vdc        9.8G   23M  9.7G   1% /usr/share/nginx/html
-...
-```
-
-NHN Cloud Webコンソール**Storage > Block Storage**サービスページでもブロックストレージの接続情報を確認できます。 -->
-
 <a id="volume-expansion"></a>
-### ボリューム拡張
+### ボリューム拡張 { #volume-expansion }
 PersistentVolumeClaim (PVC)オブジェクトを編集して既存ボリュームのサイズを調整できます。PVCオブジェクトの**spec.resources.requests.storage**項目を修正することでボリュームサイズを変更できます。ボリューム縮小はサポートされません。ボリューム拡張機能を使用するにはStorageClassの**allowVolumeExpansion**プロパティが**True**である必要があります。
 
 
+<a id="volume-expansion-from-v11913-and-older"></a>
 #### v1.19.13以前のバージョンのボリューム拡張
 v1.19.13以前のバージョンのストレージプロバイダー**kubernetes.io/cinder**は使用中のボリュームの拡張機能を提供しません。使用中のボリュームの拡張機能を使用するにはv1.20.12以降のバージョンの**cinder.csi.openstack.org**ストレージプロバイダーを使用する必要があります。クラスタアップグレード機能を利用してv1.20.12以降のバージョンにアップグレードして**cinder.csi.openstack.org**ストレージプロバイダーを使用できます。
 
@@ -4447,14 +4208,15 @@ status:
   phase: Bound
 ```
 
+<a id="volume-expansion-from-v12012-and-older"></a>
 #### v1.20.12以降のバージョンのボリューム拡張
 v1.20.12以降のバージョンのストレージプロバイダー**cinder.csi.openstack.org**は基本的に使用中のボリュームの拡張機能をサポートします。PVCオブジェクトの**spec.resources.requests.storage**項目の値を修正してボリュームサイズを変更できます。
 
 <a id="service-integration"></a>
-## NHN Cloudサービス連動
+## NHN Cloudサービス連動 { #service-integration }
 
 <a id="ncr-integration"></a>
-### NHN Cloud Container Registry(NCR)サービス連動
+### NHN Cloud Container Registry(NCR)サービス連動 { #ncr-integration }
 NHN Cloud Container Registryに保存したイメージを使うことができます。レジストリに保存したイメージを使うためには、ユーザーレジストリにログインするためのシークレット(secret)を作成する必要があります。
 
 NHN Cloud (Old) Container Registryを使用するには次のようにシークレットを作成する必要があります。
@@ -4502,12 +4264,13 @@ spec:
 > NHN Cloud Container Registryの使い方は[NHN Cloud Container Registry(NCR)ユーザーガイド](/Container/NCR/ko/user-guide)文書を参照してください。
 
 <a id="nas-integration"></a>
-### NHN Cloud NASサービス連動
+### NHN Cloud NASサービス連動 { #nas-integration }
 NHN Cloudで提供するNASボリュームをPVとして活用できます。NASサービスを使用するにはv1.20以降のバージョンのクラスタを使用する必要があります。NHN Cloud NASに関する詳細は[NASコンソール利用ガイド](/Storage/NAS%20(online)/ko/console-guide)を参照してください。
 
 > [参考]
 > NHN Cloud NASサービスは現在(2024年08月基準)、一部リージョンでのみ提供されています。NHN Cloud NASサービスのサポートリージョンの詳細については[NASサービス概要](/Storage/NAS%20(online)/ko/overview)を参照してください。
 
+<a id="nas-integration-run-the-rpcbind-service-on-all-worker-nodes"></a>
 #### すべてのワーカーノードでrpcbindサービスを実行
 NASボリュームを使用するには全てのワーカーノードでrpcbindサービスを実行する必要があります。全てのワーカーノードに接続した後、以下のコマンドでrpcbindサービスを実行します。
 
@@ -4526,6 +4289,7 @@ $ systemctl start rpcbind
 | egress | TCP | 111 | IPv4 | NAS IPアドレス | rpcのportmapperポート、方向: csi-nfs-node(worker node) → NAS |
 | egress | TCP | 635 | IPv4 | NAS IPアドレス |  rpcのmountdポート、方向: csi-nfs-node(worker node) → NAS |
 
+<a id="nas-integration-install-csi-driver-nfs"></a>
 #### csi-driver-nfsのインストール
 NHN Cloud NASサービスを使用するには、クラスターにNHN Kubernetes Service(NKS)のアドオン機能として[nfs-csi-plugin](/Container/NKS/ko/user-guide/#addon-mgmt-addon-nfs-csi-plugin)をデプロイする必要があります。
 
@@ -4536,6 +4300,7 @@ csi-driver-nfsを使用して複数のPVを構成する場合、csi-driver-nfs�
 <br>
 ![nfs-csi-driver-02.png](http://static.toastoven.net/prod_infrastructure/container/kubernetes/nfs-csi-driver-02.png)
 
+<a id="nas-integration-how-to-use-existing-nhn-cloud-nas-volume-when-provisioning"></a>
 #### プロビジョニング時に既存のNHN Cloud NASボリュームを利用する方法
 PVマニフェスト作成時にNAS情報を入力するか、StorageClassマニフェストにNAS情報を入力して既存のNASボリュームをPVとして使用できます。
 
@@ -4733,6 +4498,7 @@ Filesystem                                                                 Size 
 ...
 ```
 
+<a id="nas-integration-how-to-create-new-nhn-cloud-nas-volume-when-provisioning"></a>
 #### プロビジョニング時に新規NHN Cloud NASボリュームを作成する方法
 StorageClass及びPVCマニフェスト作成時にNAS情報を入力すると、自動的に作成されたNASボリュームをPVとして使用できます。
 
@@ -4899,7 +4665,7 @@ tmpfs                                                                          1
 > podにPVをマウントするプロセスでsubdirectoryのみマウントされるのではなく、nfsストレージ全体がマウントされるため、アプリケーションがプロビジョニングされたサイズだけボリュームを使用するように強制できません。
 
 <a id="encrypted-block-storage-integration"></a>
-### NHN Cloud暗号化ブロックストレージ連動
+### NHN Cloud暗号化ブロックストレージ連動 { #encrypted-block-storage-integration }
 NHN Cloudが提供する暗号化ブロックストレージをPVとして活用できます。NHN Cloudの暗号化ブロックストレージの詳細については、[暗号化ブロックストレージ](/Storage/Block%20Storage/ja/console-guide/#_2)を参照してください。
 
 > [参考]
@@ -4909,6 +4675,7 @@ NHN Cloudが提供する暗号化ブロックストレージをPVとして活用
 
 > [注意]
 > v1.24.3以前のバージョンのクラスタをアップグレードせずにcinder-csi-pluginコンテナイメージだけを交換して使用する場合、誤動作を引き起こす可能性があります。
+<a id="encrypted-block-storage-integration-updating-cinder-csi-plugin-image-for-encrypted-block-storage-integration"></a>
 #### 暗号化ブロックストレージ連動のためのcinder-csi-pluginイメージアップデート
 下記のコマンドを実行して、現在のクラスタに配布されたcinder-csi-pluginイメージのタグを確認できます。
 
@@ -4944,6 +4711,7 @@ $ kubectl -n kube-system patch daemonset csi-cinder-nodeplugin -p "{\"spec\": {\
 > cinder-csi-pluginコンテナイメージは NHN Cloud NCR で管理されています。クローズドネットワーク環境で構成されたクラスタはインターネットに接続されていないため、イメージを正常に受け取るためにはPrivate URIを使うための環境設定が必要です。Private URIの使い方についての詳細は[NHN Cloud Container Registry(NCR) ユーザーガイド](/Container/NCR/ja/user-guide/#private-uri)を参照してください。
 
 
+<a id="encrypted-block-storage-integration-static-provisioning"></a>
 #### 静的プロビジョニング
 PVを生成するには、暗号ブロックストレージのIDが必要です。Storage > Block Storageサービスページのブロックストレージ一覧から使用するブロックストレージを選択します。下部の情報タブのブロックストレージ名項目でIDを確認できます。
 
@@ -4977,6 +4745,7 @@ spec:
 
 PVCマニフェスト作成およびPodのマウントのプロセスは、一般的なブロックストレージの静的プロビジョニングと同じです。詳細は[静的プロビジョニング](/Container/NKS/ja/user-guide/#static-provisioning)を参照してください。
 
+<a id="encrypted-block-storage-integration-dynamic-provisioning"></a>
 #### 動的プロビジョニング
 ストレージクラスマニフェスト作成時に暗号化ブロックストレージの作成に必要な情報を入力して、自動的に作成された暗号化ブロックストレージをPVとして使用することができます。
 
@@ -5007,16 +4776,18 @@ parameters:
 PVCマニフェストの作成およびPodにマウントするプロセスは一般的なブロックストレージの動的プロビジョニングと同じです。詳細は[動的プロビジョニング](/Container/NKS/ja/user-guide/#dynamic-provisioning)を参照してください。
 
 <a id="etcd-encryption-with-skm"></a>
-### 機密データの暗号化/復号時のSecure Key Managerサービス連携
+### 機密データの暗号化/復号時のSecure Key Managerサービス連携 { #etcd-encryption-with-skm }
 
 NKSクラスターは、secretリソースをデータストア(etcd)に保存する際、データを暗号化して保存します。NKSは、このデータを暗号化するために2つの方式を提供します。
 
+<a id="etcd-encryption-with-skm-standard"></a>
 #### 基本方式
 
 * クラスター作成時に共通鍵を自動作成してコントロールプレーンに保存
 * 該当の鍵でetcdデータを暗号化
 * 鍵の管理がクラスター内部で行われる
 
+<a id="etcd-encryption-with-skm-skm-integration"></a>
 #### SKM連携方式
 
 * データストア暗号化プロバイダーをSecure Key Manager(SKM)に設定

--- a/ja/version-guide.md
+++ b/ja/version-guide.md
@@ -1,22 +1,27 @@
-## Container > NHN Kubernetes Service(NKS) > バージョンガイド
+<!-- pre-align:aligned sig=c2b4f6b0a381 -->
+
+<a id="container-nhn-kubernetes-servicenks-version-guide"></a>
+## Container > NHN Kubernetes Service(NKS) > バージョンガイド { #container-nhn-kubernetes-servicenks-version-guide }
 
 <a id="cluster-version-management"></a>
-
-## クラスタバージョン管理
+## クラスタバージョン管理 { #cluster-version-management }
 
 NKSクラスタは、クラスタコントロールプレーンとワーカーノードグループごとにKubernetesバージョンとプラットフォームバージョンを管理します。両バージョンの違いは次のとおりです。
 
-### Kubernetesバージョン
+<a id="kubernetes-version"></a>
+### Kubernetesバージョン { #kubernetes-version }
 - アップストリームKubernetesで定義するバージョンです。
 - NKSクラスタを構成するKubernetesの主要コンポーネントのバージョンを決定します。
 - 主要コンポーネント: `kube-apiserver`, `kube-controller-manager`, `kube-scheduler`, `kubelet`, `kube-proxy`
 
-### プラットフォームバージョン
+<a id="cluster-version-management-platform-version"></a>
+### プラットフォームバージョン { #cluster-version-management-platform-version }
 - NKSサービスレベルで定義するバージョンです。
 - クラスタを構成する複数のコンポーネントを1つのバージョンとして定義して管理します。
 - 主要コンポーネント: `containerd`, `etcd`などコントロールプレーン及びワーカーノードの主要コンポーネント、各種システムコンポーネント及びシステム管理ツールなど
 
-### バージョン状態に応じたアップグレード対象
+<a id="upgrade-targets-by-version-status"></a>
+### バージョン状態に応じたアップグレード対象 { #upgrade-targets-by-version-status }
 
 | Kubernetesバージョンは最新か | プラットフォームバージョンは最新か | アップグレード対象 |
 |----------------------------|----------------------|----------------|
@@ -28,15 +33,16 @@ NKSクラスタは、クラスタコントロールプレーンとワーカー�
 > コントロールプレーンのバージョン情報は**クラスタ照会**画面で、ワーカーノードグループのバージョン情報は各**ワーカーノードグループ照会**画面で確認できます。
 
 <a id="support-policy"></a>
+## Kubernetesバージョンサポートポリシー { #support-policy }
 
-## Kubernetesバージョンサポートポリシー
-
-### クラスタ作成可能バージョン
+<a id="available-cluster-versions"></a>
+### クラスタ作成可能バージョン { #available-cluster-versions }
 - NKSでリリースしたKubernetesバージョンのうち最新3つのバージョンで新規クラスタを作成できます。
 - 新規バージョンがリリースされると、既存の作成可能バージョンリストのうち最も低いバージョンは自動的に削除されます。
 - Kubernetesバージョンのパッチバージョンは内部ポリシーに従ってアップデートされる場合があります。
 
-### サービスサポートポリシー
+<a id="service-support-policy"></a>
+### サービスサポートポリシー { #service-support-policy }
 安定したサービス運営のために、Kubernetesバージョンごとのサービスサポートポリシーを適用します。
 
 - NKSは**Kubernetesバージョン**を基準にサービスサポート可否が決定されます。
@@ -48,6 +54,7 @@ NKSクラスタは、クラスタコントロールプレーンとワーカー�
 | **サービスサポート** | Kubernetesバージョンリリース後約14か月未満 | 保証 | 可能 |
 | **サービス未サポート** | Kubernetesバージョンリリース後約14か月以上 | 保証しない | ただし、サービスサポート終了後10か月間アップグレードサポート |
 
+<a id="service-support-policy-example-lifecycle-of-version-v133-released-in-november-2025"></a>
 #### 例: 2025年11月にリリースされたv1.33バージョンのライフサイクル
 
 | 区分 | 期間 | 主な特徴 |
@@ -63,22 +70,23 @@ NKSクラスタは、クラスタコントロールプレーンとワーカー�
 
 
 <a id="k8s-version-support-time-table"></a>
-
-## Kubernetesバージョン別サポート日程
+## Kubernetesバージョン別サポート日程 { #k8s-version-support-time-table }
 
 > [案内] 2025年11月からKubernetesバージョンサポートポリシーが変更されます。
 > - v1.32までは既存の日程とポリシーが適用されます。
 > - v1.33からは新規ポリシーが適用されます。
 > - 表の日付はUTC+00:00基準です。
 
-### 新規ポリシー適用バージョン (v1.33以上)
+<a id="new-policy-applied-version-v133-or-later"></a>
+### 新規ポリシー適用バージョン (v1.33以上) { #new-policy-applied-version-v133-or-later }
 
 | バージョン | リリース | サービスサポート終了(アップグレードサポート) | サービスサポート終了(EOS) |
 |------|--------|---------------------------------|---------------------|
 | v1.33 | 2025.11 | 2027.01.31 | 2027.11.30 |
 | v1.34 | 2026.05 | 2027.07.31 | 2028.05.31 |
 
-### 既存ポリシー適用バージョン (v1.32以下)
+<a id="old-policy-applied-version-v132-or-earlier"></a>
+### 既存ポリシー適用バージョン (v1.32以下) { #old-policy-applied-version-v132-or-earlier }
 
 | バージョン | リリース | サービスサポート終了(アップグレードサポート) | サービスサポート終了(EOS) |
 |------|--------|---------------------------------|---------------------|
@@ -89,12 +97,10 @@ NKSクラスタは、クラスタコントロールプレーンとワーカー�
 | v1.32.3 | 2025.05 | 2027.02.28 (予定) | 2027.02.28 (予定) |
 
 <a id="platform-version"></a>
-
-## プラットフォームバージョン
+## プラットフォームバージョン { #platform-version }
 
 <a id="platform-version-info"></a>
-
-### プラットフォームバージョン別情報
+### プラットフォームバージョン別情報 { #platform-version-info }
 
 | バージョン | リリース時点 | Kubernetes互換バージョン | 説明 |
 |------|------------|--------------------|-----|
@@ -105,8 +111,7 @@ NKSクラスタは、クラスタコントロールプレーンとワーカー�
 | 1.202605.0 | 2026.05 | v1.30～v1.34 | 機能改善<br>- ワーカーノードCGroup v1 → v2のマイグレーションサポート<br>- Kubernetes v1.34クラスターの`ImageVolume` feature gate有効化<br>- kube-apiserverとpod間の通信のためのkonnectivityサポート<br>- etcdアップグレードサポート |
 
 <a id="platform-component-versions"></a>
-
-### プラットフォームバージョン別の主要コンポーネントバージョン
+### プラットフォームバージョン別の主要コンポーネントバージョン { #platform-component-versions }
 
 | プラットフォームバージョン | etcd | containerd |
 | :--- | :--- | :--- |
@@ -117,8 +122,7 @@ NKSクラスタは、クラスタコントロールプレーンとワーカー�
 | **1.202605.0** | v3.5.29 | k8s v1.33以下：1.7.27 </br> k8s v1.34以上：2.2.1 |
 
 <a id="platform-version-cgroup-v2-support"></a>
-
-### CGroup v2 OSイメージ使用のためのプラットフォームバージョン
+### CGroup v2 OSイメージ使用のためのプラットフォームバージョン { #platform-version-cgroup-v2-support }
 * プラットフォームバージョン1.202602.0未満のクラスターは、CGroupバージョンがv2に設定されたOSイメージを使用できません。
 * OSイメージのリリース日に応じて、設定されているCGroupバージョンが異なります。
   * 2026/03/10以前のリリースイメージ：CGroup v1

--- a/ko/backup-guide.md
+++ b/ko/backup-guide.md
@@ -1,6 +1,10 @@
-## Container > NHN Kubernetes Service(NKS) > 백업 가이드
+<!-- pre-align:aligned sig=dd3a912dfca5 -->
 
-## 개요
+<a id="container-nhn-kubernetes-service-nks-backup-guide"></a>
+## Container > NHN Kubernetes Service(NKS) > 백업 가이드 { #container-nhn-kubernetes-service-nks-backup-guide }
+
+<a id="overview"></a>
+## 개요 { #overview }
 
 NHN Kubernetes Service(NKS) 클러스터의 백업이 필요한 경우 Velero 플러그인을 사용하여 Object Storage에 백업할 수 있습니다.
 본 문서는 Object Storage와 Velero를 활용하여 클러스터를 백업 및 복구하는 방법에 대해 기술합니다.
@@ -11,12 +15,15 @@ NHN Kubernetes Service(NKS) 클러스터의 백업이 필요한 경우 Velero �
 
 Velero에 대한 자세한 내용은 [Velero Docs](https://velero.io/docs/v1.9/)를 참고해 주세요.
 
-## Velero를 이용한 클러스터 백업 및 복구
+<a id="cluster-backup-and-restoration-with-velero"></a>
+## Velero를 이용한 클러스터 백업 및 복구 { #cluster-backup-and-restoration-with-velero }
 
-### 사전 준비
+<a id="prerequisites"></a>
+### 사전 준비 { #prerequisites }
 
 Object Storage API를 사용하려면 테넌트 아이디(tenant ID) 및 API 엔드포인트(endpoint) 확인, API 비밀번호 설정, Temporary URL Key 생성이 필요합니다.
 
+<a id="prerequisites-check-the-tenant-id-and-api-endpoint"></a>
 #### 테넌트 아이디 및 API 엔드포인트 확인
 
 테넌트 아이디와 API의 엔드포인트는 Object Storage 서비스 페이지의 **API Endpoint 설정** 버튼을 클릭해 확인할 수 있습니다.
@@ -26,6 +33,7 @@ Object Storage API를 사용하려면 테넌트 아이디(tenant ID) 및 API 엔
 | Identity | https://api-identity-infrastructure.nhncloudservice.com/v2.0 | 인증 토큰 발급 |
 | Tenant ID | 숫자 + 영문자로 구성된 32자 길이의 문자열 | 인증 토큰 발급 |
 
+<a id="prerequisites-set-an-api-password"></a>
 #### API 비밀번호 설정
 
 API 비밀번호는 Object Storage 서비스 페이지의 **API Endpoint 설정** 버튼을 클릭해 설정할 수 있습니다.
@@ -36,6 +44,7 @@ API 비밀번호는 Object Storage 서비스 페이지의 **API Endpoint 설정*
 
 Object Storage API에 대한 자세한 내용은 [Object Storage API 가이드](/Storage/Object%20Storage/ko/api-guide/)를 참고해 주세요.
 
+<a id="prerequisites-create-temporary-url-key"></a>
 #### Temporary URL Key 생성
 
 Velero 클라이언트에서 `velero log` 명령어를 사용하기 위해서는 Object Storage에 Temporary URL Key를 생성해야 합니다.
@@ -53,24 +62,28 @@ Velero 클라이언트에서 `velero log` 명령어를 사용하기 위해서는
 $ curl -X POST {Object Store} -H "X-Auth-Token: {tokenId}" -H "X-Account-Meta-Temp-Url-Key: {key}"
 ```
 
-### Velero 클라이언트 설치
+<a id="install-the-velero-client"></a>
+### Velero 클라이언트 설치 { #install-the-velero-client }
 
 Velero 클라이언트는 클러스터의 백업 및 복구 명령을 입력하는 프로그램입니다.
 Velero Github 저장소에서 Velero 클라이언트를 다운로드하여 클러스터 백업 및 복구 시 활용할 수 있습니다. 다운로드한 Velero 클라이언트 명령을 실행하기 전에 백업 및 복구 클러스터의 kubeconfig 파일을 웹 콘솔에서 다운로드해야 하고, **KUBECONFIG 환경 변수를 설정하여 백업 및 복구 대상 클러스터를 정확하게 지정**해야 합니다.
 kubeconfig 설정에 대한 자세한 내용은 [kubectl 설치](/Container/NKS/ko/user-guide/#kubectl)를 참고하세요.
 
+<a id="install-the-velero-client-download-the-velero-client"></a>
 #### Velero 클라이언트 다운로드
 
 ```
 $ wget https://github.com/vmware-tanzu/velero/releases/download/v1.17.0/velero-v1.17.0-linux-amd64.tar.gz
 ```
 
+<a id="install-the-velero-client-decompress-the-file"></a>
 #### 압축 해제
 
 ```
 $ tar xzf velero-v1.17.0-linux-amd64.tar.gz
 ```
 
+<a id="install-the-velero-client-change-the-location-or-set-the-path"></a>
 #### 위치 변경 또는 경로 지정
 
 어느 경로에서든 Velero 클라이언트를 실행할 수 있도록 환경 변수에 지정된 경로로 옮기거나, Velero가 있는 경로를 환경 변수에 추가합니다.
@@ -87,16 +100,19 @@ $ sudo mv velero-v1.17.0-linux-amd64/velero /usr/local/bin
 $ export PATH=$PATH:$(pwd)
 ```
 
-### Velero 서버 설치
+<a id="install-the-velero-server"></a>
+### Velero 서버 설치 { #install-the-velero-server }
 
 Velero 서버는 Helm을 이용하여 설치합니다.
 
+<a id="install-the-velero-server-download-helm"></a>
 #### Helm 다운로드
 
 ```
 $ curl -fsSL -o get_helm.sh https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3
 ```
 
+<a id="install-the-velero-server-change-a-permission"></a>
 #### 권한 변경
 
 다운로드한 파일은 기본적으로 실행 권한이 없습니다. 실행 권한을 추가해 주세요.
@@ -105,12 +121,14 @@ $ curl -fsSL -o get_helm.sh https://raw.githubusercontent.com/helm/helm/main/scr
 $ chmod 700 get_helm.sh
 ```
 
+<a id="install-the-velero-server-install-helm"></a>
 #### Helm 설치
 
 ```
 $ ./get_helm.sh
 ```
 
+<a id="install-the-velero-server-add-the-helm-repository"></a>
 #### Helm Repository 추가
 
 Velero 서버를 설치하기 위해서는 Helm Repository를 추가해야 합니다.
@@ -119,6 +137,7 @@ Velero 서버를 설치하기 위해서는 Helm Repository를 추가해야 합�
 $ helm repo add vmware-tanzu https://vmware-tanzu.github.io/helm-charts
 ```
 
+<a id="install-the-velero-server-2"></a>
 #### Velero 서버 설치
 
 Velero 서버는 `백업 클러스터`와 `복구 클러스터`에 각각 설치해야 합니다. 동일한 Object Storage를 사용하도록 `두 클러스터에 동일한 helm 명령어`를 사용하여 설치하시길 권장합니다.
@@ -174,10 +193,12 @@ $ helm install velero vmware-tanzu/velero \
 | Region | 한국(판교) 리전: `KR1`<br>한국(평촌) 리전: `KR2`<br>한국(광주) 리전: `KR3` |
 | OBS endpoint | Object Storage API Endpoint |
 
+<a id="install-the-velero-server-delete-the-velero-server"></a>
 #### Velero 서버 삭제
 Velero 서버는 `velero uninstall` 명령어로 삭제할 수 있습니다.
 
-### 클러스터 백업
+<a id="back-up-a-cluster"></a>
+### 클러스터 백업 { #back-up-a-cluster }
 
 클러스터 백업은 `velero backup create` 명령어로 설정할 수 있습니다.
 
@@ -203,7 +224,8 @@ my-backup    Completed   0        0          2025-10-13 11:01:53 +0900 KST   29d
 
 * 백업된 정보는 Object Storage 서비스 페이지에서 확인할 수 있습니다.
 
-### 클러스터 복구
+<a id="restore-a-cluster"></a>
+### 클러스터 복구 { #restore-a-cluster }
 
 클러스터 백업/복구는 `velero restore create` 명령어로 설정할 수 있습니다.
 
@@ -220,8 +242,10 @@ $ velero restore create --from-backup {name}
 > [주의]
 > `백업 클러스터`와 `복구 클러스터`의 버전이 다른 경우 복구 시 문제가 발생할 수 있습니다.
 
-### 예시
+<a id="examples"></a>
+### 예시 { #examples }
 
+<a id="examples-example-of-cluster-backup-and-restoration"></a>
 #### 클러스터 백업/복구 예시
 
 * 백업 클러스터에서 velero backup create 명령어를 사용하여 백업합니다.
@@ -250,6 +274,7 @@ $ velero restore create --from-backup my-backup
 $ kubectl get pod --all-namespaces
 ```
 
+<a id="examples-example-of-setting-periodic-backups"></a>
 #### 주기적 백업 설정 예시
 
 `velero schedule create` 명령어로 주기적 백업을 설정할 수 있습니다. 자세한 내용은 [schedule-a-backup](https://velero.io/docs/v1.17/backup-reference/#schedule-a-backup)을 참고하세요.
@@ -269,6 +294,7 @@ my-schedule-20251013055022   Completed   0        0          2025-10-13 14:50:22
 my-schedule-20251013054022   Completed   0        0          2025-10-13 14:40:22 +0900 KST   29d       default            <none>
 ```
 
+<a id="examples-example-of-clearing-periodic-backups"></a>
 #### 주기적 백업 설정 해제 예시
 `velero schedule delete` 명령어로 주기적 백업을 해제할 수 있습니다.
 

--- a/ko/gateway-api-guide.md
+++ b/ko/gateway-api-guide.md
@@ -1,6 +1,10 @@
-## Container > NHN Kubernetes Service(NKS) > 애플리케이션 가이드 > Gateway API
+<!-- pre-align:aligned sig=091ebaa2b119 -->
 
-### 개요
+<a id="container-nhn-kubernetes-service-nks-application-guide-gateway-api"></a>
+## Container > NHN Kubernetes Service(NKS) > 애플리케이션 가이드 > Gateway API { #container-nhn-kubernetes-service-nks-application-guide-gateway-api }
+
+<a id="overview"></a>
+### 개요 { #overview }
 
 Gateway API는 Kubernetes에서 트래픽 라우팅을 관리하기 위한 차세대 표준 API입니다. 기존 Ingress API의 한계를 극복하고 보다 표현력 있고 확장 가능한 방식으로 클러스터 외부에서 내부 서비스로의 HTTP, HTTPS, TCP 등 다양한 트래픽을 라우팅할 수 있습니다. Gateway API와 관련 리소스에 대한 자세한 내용은 [Gateway API](https://gateway-api.sigs.k8s.io/) 문서를 참고하세요.
 
@@ -14,6 +18,7 @@ Gateway API는 다양한 구현체를 지원하며, 사용 환경에 따라 적�
 
 > [참고] 구현체별로 지원하는 Gateway API 버전이 다를 수 있으므로, 자세한 내용은 각 구현체의 공식 문서를 참고하세요.
 
+<a id="overview-key-gateway-api-resources"></a>
 #### Gateway API 주요 리소스
 
 Gateway API는 역할에 따라 리소스를 분리하여 운영자와 애플리케이션 개발자가 각자의 권한 범위 내에서 설정할 수 있도록 설계되어 있습니다.
@@ -31,11 +36,13 @@ Gateway API는 역할에 따라 리소스를 분리하여 운영자와 애플리
 
 > [참고] NGF에서는 NginxProxy 리소스를 통해 NGINX data plane 동작(서비스 설정, 레플리카 수 등)을 추가로 구성할 수 있습니다.
 
-### NGINX Gateway Fabric 설치
+<a id="install-nginx-gateway-fabric"></a>
+### NGINX Gateway Fabric 설치 { #install-nginx-gateway-fabric }
 
 NGINX Gateway Fabric 설치에 대한 자세한 내용은 [NGINX Gateway Fabric 설치 가이드](https://docs.nginx.com/nginx-gateway-fabric/install) 문서를 참고하세요.
 
-### HTTP 라우팅 예제
+<a id="http-routing-example"></a>
+### HTTP 라우팅 예제 { #http-routing-example }
 
 다음은 URI 경로를 기반으로 여러 서비스로 트래픽을 분기하는 예제입니다. 아래 그림은 `/coffee`와 `/tea` 경로에 따라 각각 다른 서비스로 요청을 라우팅하는 구조를 나타냅니다.
 
@@ -45,6 +52,7 @@ NGINX Gateway Fabric 설치에 대한 자세한 내용은 [NGINX Gateway Fabric 
                                          └── /tea    → tea-svc    → tea 파드
 ```
 
+<a id="http-routing-example-deploy-services-and-pods"></a>
 #### 서비스 및 파드 배포
 
 다음과 같이 서비스와 파드를 생성하기 위한 매니페스트를 작성합니다. `coffee-svc` 서비스에는 `coffee` 파드를, `tea-svc` 서비스에는 `tea` 파드를 연결합니다.
@@ -124,6 +132,7 @@ spec:
 kubectl apply -f cafe.yaml
 ```
 
+<a id="http-routing-example-verify-gatewayclass"></a>
 #### GatewayClass 확인
 
 NGINX Gateway Fabric은 Helm 설치 시 `nginx`라는 이름의 GatewayClass가 생성됩니다. 설치 방식에 따라 GatewayClass가 자동 생성되지 않을 수 있으므로, 필요시 직접 생성해야 합니다.
@@ -141,6 +150,7 @@ nginx   gateway.nginx.org/nginx-gateway-controller    True       10s
 
 `ACCEPTED` 항목이 `True`인 경우 GatewayClass가 정상적으로 생성된 것입니다.
 
+<a id="http-routing-example-create-gateway"></a>
 #### Gateway 생성
 
 클러스터 외부에서 트래픽을 수신할 게이트웨이를 생성합니다. 아래 매니페스트는 80번 포트로 HTTP 트래픽을 수신하는 게이트웨이를 정의합니다.
@@ -180,6 +190,7 @@ nginx   nginx   123.123.123.44   True         1m
 
 `PROGRAMMED` 항목이 `True`이고 `ADDRESS`에 IP 주소가 할당된 것을 확인합니다.
 
+<a id="http-routing-example-create-httproute"></a>
 #### HTTPRoute 생성
 
 경로 기반 라우팅 규칙을 정의하는 HTTPRoute를 생성합니다. 아래 매니페스트를 작성하고 적용합니다.
@@ -216,6 +227,7 @@ spec:
 kubectl apply -f cafe-route.yaml
 ```
 
+<a id="http-routing-example-verify-operation"></a>
 #### 동작 확인
 
 외부 호스트에서 게이트웨이의 IP 주소로 HTTP 요청을 전송하여 라우팅이 올바르게 설정되었는지 확인합니다.
@@ -232,7 +244,8 @@ curl http://${GATEWAY_IP}/tea
 
 `/coffee` 경로로 요청 시 `coffee-svc` 서비스에 전달되어 `coffee` 파드가 응답합니다. 응답의 `Server name` 항목을 보면 `coffee` 파드들이 라운드-로빈 방식으로 번갈아 응답하는 것을 확인할 수 있습니다.
 
-### 호스트 기반 라우팅 예제
+<a id="host-based-routing-example"></a>
+### 호스트 기반 라우팅 예제 { #host-based-routing-example }
 
 다음은 요청의 호스트명(Host 헤더)을 기반으로 서로 다른 서비스로 트래픽을 분기하는 예제입니다. 아래 그림은 `coffee.example.com`과 `tea.example.com` 호스트명에 따라 각각 다른 서비스로 요청을 라우팅하는 구조를 나타냅니다.
 
@@ -243,6 +256,7 @@ curl http://${GATEWAY_IP}/tea
 
 서비스 및 파드는 앞선 예제의 `cafe.yaml`을 그대로 사용합니다.
 
+<a id="host-based-routing-example-create-httproute"></a>
 #### HTTPRoute 생성
 
 호스트명별로 HTTPRoute를 각각 생성합니다. `spec.hostnames` 필드에 라우팅할 호스트명을 지정합니다.
@@ -284,6 +298,7 @@ spec:
 kubectl apply -f cafe-route-host.yaml
 ```
 
+<a id="host-based-routing-example-verify-operation"></a>
 #### 동작 확인
 
 외부 호스트에서 `--resolve` 옵션으로 호스트명을 게이트웨이 IP에 매핑하여 요청을 전송합니다.
@@ -304,7 +319,8 @@ curl --resolve tea.example.com:80:${GATEWAY_IP} \
 
 > [참고] 실제 운영 환경에서는 DNS에 각 호스트명이 게이트웨이의 외부 IP로 등록되어 있어야 합니다. 테스트 시에는 위와 같이 `--resolve` 옵션으로 호스트명을 게이트웨이 IP로 직접 매핑하거나, `/etc/hosts` 파일에 레코드를 추가하여 확인할 수 있습니다.
 
-### 네임스페이스 간 라우팅 예제
+<a id="cross-namespace-routing-example"></a>
+### 네임스페이스 간 라우팅 예제 { #cross-namespace-routing-example }
 
 Gateway API는 여러 네임스페이스에 걸친 트래픽 라우팅을 지원합니다. 이 예제에서는 `nginx-gateway` 네임스페이스에 Gateway를, `default` 네임스페이스에 HTTPRoute를, `app` 네임스페이스에 Service를 배포합니다.
 
@@ -313,6 +329,7 @@ Gateway API에서 네임스페이스 간 참조는 다음 두 가지 설정으�
 * **`allowedRoutes.namespaces`**: Gateway와 HTTPRoute의 네임스페이스가 다를 때 필요합니다. HTTPRoute가 다른 네임스페이스의 Gateway를 `parentRef`로 참조할 수 있도록 허용합니다.
 * **`ReferenceGrant`**: HTTPRoute와 백엔드 Service의 네임스페이스가 다를 때 필요합니다. HTTPRoute가 다른 네임스페이스의 Service를 `backendRef`로 참조할 수 있도록 허용합니다.
 
+<a id="cross-namespace-routing-example-deploy-services-and-pods"></a>
 #### 서비스 및 파드 배포
 
 예제에서 사용할 `app` 네임스페이스를 생성합니다.
@@ -327,6 +344,7 @@ kubectl create namespace app
 kubectl apply -f cafe.yaml -n app
 ```
 
+<a id="cross-namespace-routing-example-create-gateway"></a>
 #### Gateway 생성
 
 `nginx-gateway` 네임스페이스에 Gateway를 생성합니다. `default` 네임스페이스의 HTTPRoute가 이 Gateway를 참조할 수 있도록 `allowedRoutes.namespaces.from: All`로 설정합니다. 아래 매니페스트를 작성하고 적용합니다.
@@ -355,6 +373,7 @@ spec:
 kubectl apply -f gateway-cross-ns.yaml
 ```
 
+<a id="cross-namespace-routing-example-create-referencegrant"></a>
 #### ReferenceGrant 생성
 
 `default` 네임스페이스의 HTTPRoute가 `app` 네임스페이스의 Service를 참조할 수 있도록 `ReferenceGrant`를 생성합니다. 아래 매니페스트를 작성하고 적용합니다.
@@ -384,6 +403,7 @@ kubectl apply -f reference-grant.yaml
 
 > [참고] ReferenceGrant 리소스는 Gateway API v1.5부터 v1 API로 제공됩니다. 사용 중인 Gateway API 버전 또는 구현체에 따라 v1beta1 API를 사용할 수 있습니다.
 
+<a id="cross-namespace-routing-example-create-httproute"></a>
 #### HTTPRoute 생성
 
 `default` 네임스페이스에 HTTPRoute를 생성합니다. `parentRef`에 Gateway의 네임스페이스(`nginx-gateway`)를, `backendRef`에 Service의 네임스페이스(`app`)를 명시합니다. 아래 매니페스트를 작성하고 적용합니다.
@@ -424,6 +444,7 @@ spec:
 kubectl apply -f cafe-route-cross-ns.yaml
 ```
 
+<a id="cross-namespace-routing-example-verify-operation"></a>
 #### 동작 확인
 
 아래 명령어로 라우팅이 올바르게 설정되었는지 확인합니다.
@@ -438,7 +459,8 @@ curl http://${GATEWAY_IP}/coffee
 curl http://${GATEWAY_IP}/tea
 ```
 
-### Ingress에서 Gateway API로 마이그레이션
+<a id="migrate-from-ingress-to-gateway-api"></a>
+### Ingress에서 Gateway API로 마이그레이션 { #migrate-from-ingress-to-gateway-api }
 
 `ingress2gateway`는 Kubernetes SIG-Network에서 관리하는 도구로, 기존 Ingress 리소스를 Gateway API 리소스(Gateway, HTTPRoute 등)로 변환하는 데 사용할 수 있습니다. 다만 모든 Ingress 설정이 완전히 변환되는 것은 아니며, 일부 기능은 수동 보정이 필요할 수 있습니다. 자세한 내용은 [ingress2gateway](https://github.com/kubernetes-sigs/ingress2gateway) 문서를 참고하세요.
 
@@ -446,10 +468,12 @@ curl http://${GATEWAY_IP}/tea
 
 > [참고] 모든 Ingress 어노테이션이 Gateway API로 변환되는 것은 아닙니다. 변환 후 지원되지 않는 어노테이션이 있는 경우 경고 메시지가 출력됩니다. 자세한 내용은 [지원 프로바이더 목록](https://github.com/kubernetes-sigs/ingress2gateway?tab=readme-ov-file#supported-providers)을 참고하세요.
 
+<a id="migrate-from-ingress-to-gateway-api-install-ingress2gateway"></a>
 #### ingress2gateway 설치
 
 ingress2gateway 설치에 대한 자세한 내용은 [ingress2gateway 설치 가이드](https://github.com/kubernetes-sigs/ingress2gateway?tab=readme-ov-file#installation) 문서를 참고하세요.
 
+<a id="migrate-from-ingress-to-gateway-api-convert-ingress-resources"></a>
 #### Ingress 리소스 변환
 
 현재 클러스터에 배포된 Ingress 리소스를 Gateway API 리소스로 변환합니다. `--providers` 옵션으로 사용 중인 Ingress 컨트롤러를 지정하고, `-A` 옵션으로 모든 네임스페이스의 리소스를 변환합니다. 변환 결과를 파일로 저장하려면 아래 명령어를 사용합니다.
@@ -470,6 +494,7 @@ kubectl get ingress -A -o yaml > /path/to/ingress.yaml
 ingress2gateway print --providers=ingress-nginx --input-file /path/to/ingress.yaml > gateway-resources.yaml
 ```
 
+<a id="migrate-from-ingress-to-gateway-api-conversion-example"></a>
 #### 변환 예시
 
 아래는 변환 전 Ingress 리소스와 변환 후 Gateway API 리소스의 예시입니다.
@@ -553,6 +578,7 @@ status:
 
 > [참고] 변환된 리소스의 `gatewayClassName`은 기존 Ingress 클래스명(`nginx`)을 그대로 사용합니다. 앞서 설치 시 지정한 GatewayClass 이름과 일치하는지 확인하세요.
 
+<a id="migrate-from-ingress-to-gateway-api-apply-conversion-results"></a>
 #### 변환 결과 적용
 
 변환된 리소스를 검토한 후 클러스터에 적용합니다.

--- a/ko/istio-guide.md
+++ b/ko/istio-guide.md
@@ -1,14 +1,20 @@
-## Container > NHN Kubernetes Service(NKS) > 외부 서비스 연동 가이드 > Istio
+<!-- pre-align:aligned sig=f2738c580f82 -->
 
-### 개요
+<a id="container-nhn-kubernetes-service-nks-application-guide-istio"></a>
+## Container > NHN Kubernetes Service(NKS) > 외부 서비스 연동 가이드 > Istio { #container-nhn-kubernetes-service-nks-application-guide-istio }
+
+<a id="overview"></a>
+### 개요 { #overview }
 이 문서는 사용자가 NKS(NHN Kubernetes Service) 클러스터에 Istio를 구성하고 테스트할 수 있는 예제에 대해 기술한 가이드 문서입니다. NKS에서는 인터넷에 연결되지 않은 클러스터에서도 Istio를 구성할 수 있도록 가이드 및 NCR 레지스트리를 통한 Istio 이미지를 제공하고 있습니다. 사용자는 이 가이드 문서를 통해 NKS에서 제공하는 이미지를 사용하여 Istio를 구성하거나, Istio 공식 가이드 문서를 참고하여 직접 Istio를 구성할 수 있습니다.
 
-### Istio
+<a id="istio"></a>
+### Istio { #istio }
 서비스 메시(Service Mesh)는 분산 시스템에서 서비스 간 통신을 제어하고, 효율적으로 관리할 수 있도록 하는 데 특화된 마이크로서비스를 위한 인프라 계층입니다.
 Istio는 많이 사용되는 오픈소스 서비스 메시 중 하나입니다. 이 예제에서는 클러스터에 demo 프로파일의 Istio 서비스를 배포한 후 동작하는 것을 보여줍니다. Istio에 대한 자세한 내용은 [Istio](https://istio.io/latest/about/service-mesh/)를 참고하세요.
 
 
-### Istio 배포를 위한 사전 준비
+<a id="prerequisites-for-istio-deployment"></a>
+### Istio 배포를 위한 사전 준비 { #prerequisites-for-istio-deployment }
 배포하려는 Istio 버전 및 클러스터에 맞는 올바른 레지스트리 정보를 확인 후 변수에 지정합니다. 설정한 변수는 이후 배포 과정에 사용됩니다.
 
 ```
@@ -16,6 +22,7 @@ $ VERSION="{다운로드하려는 istio 버전}"
 $ REGISTRY="{리전별 레지스트리}"
 ```
 
+<a id="prerequisites-for-istio-deployment-supported-kubernetes-versions-by-istio-version"></a>
 #### Istio 버전별 지원되는 Kubernetes 버전
 
 | 버전 | 지원되는 Kubernetes 버전 |
@@ -27,6 +34,7 @@ $ REGISTRY="{리전별 레지스트리}"
 > NKS는 위 표에 명시된 Istio 버전에 대해서만 설치를 제공합니다. NKS에서 제공하지 않는 버전을 사용하려면 사용자가 직접 Istio를 구성해야 합니다. 지원되는 Istio 버전에 관한 정보는 [istio 지원 정책](https://istio.io/latest/docs/releases/supported-releases/)을 참고하세요.
 
 
+<a id="prerequisites-for-istio-deployment-registry-information-by-region-and-internet-environment"></a>
 #### 리전 및 인터넷 환경별 레지스트리 정보
 | 리전 | 인터넷 연결 | 레지스트리 |
 | --- | --- | --- |
@@ -41,6 +49,7 @@ $ REGISTRY="{리전별 레지스트리}"
 > 인터넷에 연결되어 있지 않은 클러스터가 NCR 레지스트리를 사용하기 위해서는 Private URI를 사용하기 위한 환경 구성이 필요합니다. Private URI 사용법에 대한 자세한 내용은 [NHN Cloud Container Registry(NCR) 사용자 가이드](/Container/NCR/ko/user-guide/#private-uri)를 참고하세요.
 
 
+<a id="prerequisites-for-istio-deployment-install-the-oras-command-line-tool"></a>
 #### ORAS 명령줄 도구 설치
 아티팩트 pull을 위해 ORAS(OCI Registry As Storage) 명령줄 도구를 다운로드합니다. ORAS는 OCI 레지스트리에서 OCI 아티팩트를 push 및 pull 하는 방법을 제공하는 툴입니다.
 아래 커맨드를 실행하여 ORAS 명령줄 도구를 설치합니다. ORAS 명령줄 도구의 자세한 사용법은 [ORAS docs](https://oras.land/docs/)를 참고하세요.
@@ -56,8 +65,10 @@ $ export PATH="/usr/local/bin:$PATH"
 ```
 
 
-### Istio 설치
+<a id="install-istio"></a>
+### Istio 설치 { #install-istio }
 
+<a id="install-istio-download-and-install-istioctl-using-the-oras-command-line-tool"></a>
 #### 1. ORAS 명령줄 도구를 사용하여 istioctl을 다운로드 및 설치합니다.
 istioctl은 Istio가 제공하는 서비스 메시 배포를 디버깅하고 진단할 수 있게 해주는 구성 명령줄 유틸리티로 Istio 배포 구성 옵션 설정 등 다양한 기능을 제공합니다. istioctl에 대한 자세한 설명은 [istioctl](https://istio.io/latest/docs/reference/commands/istioctl/)을 참고하세요. 
 
@@ -69,6 +80,7 @@ $ cd istio-${VERSION}
 $ export PATH=$PWD/bin:$PATH
 ```
 
+<a id="install-istio-deploy-istio-components-using-istioctl"></a>
 #### 2. istioctl을 사용해 Istio 구성 요소를 배포합니다.
 프로파일은 Istio 컨트롤 플레인과 데이터 플레인의 사이드카에 대한 사용자 정의 배포 기능을 제공합니다. 설정된 프로파일에 따라 배포 시 활성화되는 구성 요소가 달라집니다. 사용자는 클러스터의 환경 구성에 따라 기본 제공되는 프로파일을 사용하거나 특정 요구에 맞춰 구성을 사용자 정의할 수 있습니다. Istio 프로파일에 대한 자세한 설명은 [Istio 설치 구성 프로파일](https://istio.io/latest/docs/setup/additional-setup/config-profiles/)을 참고하세요. 이 예제에서는 기본으로 제공되는 demo 프로파일을 사용하여 배포합니다.
 
@@ -158,9 +170,11 @@ replicaset.apps/istio-ingressgateway-b8844867c   1         1         1       86s
 replicaset.apps/istiod-8c7fbbdc8                 1         1         1       90s
 ```
 
-### 애플리케이션 배포
+<a id="deploy-application"></a>
+### 애플리케이션 배포 { #deploy-application }
 Istio가 정상적으로 설치되고, 동작하는지 확인하기 위해 애플리케이션을 배포합니다. 이 예제에서는 Istio에서 기본적으로 제공하는 Bookinfo 샘플 애플리케이션을 사용합니다. 샘플 애플리케이션은 productpage, details, reviews, ratings 4개의 마이크로서비스로 구성되어 있습니다. Bookinfo 샘플 애플리케이션에 대한 자세한 내용은 [Istio Bookinfo Application](https://istio.io/latest/docs/examples/bookinfo/)을 참고하세요.
 
+<a id="deploy-application-label-namespace"></a>
 #### 1. 네임스페이스에 레이블을 지정하기
 Istio 사이드카 프락시를 사용하기 위해 파드가 생성될 네임스페이스에 레이블을 지정해야 합니다. 레이블은 Istio 구성 요소를 배포할 네임스페이스를 식별하는 데 사용됩니다. 레이블이 설정되어 있는 네임스페이스에 파드가 배포되면 파드에 자동으로 Istio 사이드카 프락시가 배포됩니다.
 
@@ -170,6 +184,7 @@ $ kubectl label namespace default istio-injection=enabled
 namespace/default labeled
 ```
 
+<a id="deploy-application-components"></a>
 #### 2. 애플리케이션 구성 요소 배포하기
 애플리케이션 구성 요소를 배포하고 정상적으로 배포되었는지 확인합니다.
 
@@ -217,9 +232,11 @@ $ kubectl exec "$(kubectl get pod -l app=ratings -o jsonpath='{.items[0].metadat
 <title>Simple Bookstore App</title>
 ```
 
-### 서비스 노출
+<a id="expose-service"></a>
+### 서비스 노출 { #expose-service }
 위의 과정까지 수행했을 때, 서비스는 클러스터 내부의 호스트에서만 접속 가능한 `ClusterIP` 형태로 설정되어 있습니다. Kubernetes에서는 서비스 노출을 위해 `NodePort`, `LoadBalancer` 등 다양한 타입의 `Service` 오브젝트를 제공하지만, Istio에서는 더 넓은 범위에서의 네트워크 트래픽을 처리하기 위한 gateway 오브젝트를 제공하고 있습니다. 아래 예제에서는 Istio에서 기본적으로 제공하는 샘플 bookinfo gateway를 사용하여 서비스를 노출하는 과정을 보여줍니다. Istio gateway에 대한 자세한 설명은 [Istio Gateway](https://istio.io/latest/docs/concepts/traffic-management/#gateways)를 참고하세요.
 
+<a id="expose-service-configure-ingress-gateway"></a>
 #### 인그레스 게이트웨이 구성하기
 서비스를 노출하기 위한 Istio 인그레스 게이트웨이를 추가로 구성합니다.
 
@@ -236,6 +253,7 @@ $ istioctl analyze
 ✔ No validation issues found when analyzing namespace: default.
 ```
 
+<a id="expose-service-access-service"></a>
 #### 서비스 접근하기
 노출된 서비스에 접근하기 위해 게이트웨이 URL 정보를 확인합니다. 게이트웨이 URL은 기본적으로 `인그레스 호스트:인그레스 IP`의 구성으로 되어 있습니다. 클러스터가 인터넷망 또는 폐쇄망 환경에 구성되었는지에 따라 게이트웨이 URL 정보를 확인하는 방법이 달라집니다. 인터넷망에 구성된 클러스터는 로드 밸런서의 `EXTERNAL-IP` 정보를 기반으로 게이트웨이 URL이 구성되며 폐쇄망 환경에 구성된 클러스터는 노드 포트를 기반으로 게이트웨이 URL이 구성됩니다.
 
@@ -271,7 +289,8 @@ $ curl http://114.110.160.79:80/productpage
 ```
 
 
-### Istio 제거
+<a id="delete-istio"></a>
+### Istio 제거 { #delete-istio }
 아래 명령어를 수행하여 예제에서 사용되었던 bookinfo 애플리케이션 관련 구성 요소를 제거합니다.
 ```
 $ kubectl delete -f samples/bookinfo/networking/bookinfo-gateway.yaml

--- a/ko/overview.md
+++ b/ko/overview.md
@@ -1,7 +1,11 @@
-## Container > NHN Kubernetes Service(NKS) > 개요
+<!-- pre-align:aligned sig=380a0a4ca9e2 -->
+
+<a id="container-nhn-kubernetes-service-nks-overview"></a>
+## Container > NHN Kubernetes Service(NKS) > 개요 { #container-nhn-kubernetes-service-nks-overview }
 여기에서는 Kubernetes(쿠버네티스)가 무엇인지 간략히 알아보고, NHN Cloud에서 제공하는 NHN Kubernetes Service(NKS)를 살펴봅니다.
 
-## Kubernetes
+<a id="kubernetes"></a>
+## Kubernetes { #kubernetes }
 Kubernetes는 컨테이너화된 워크로드와 서비스를 관리할 수 있는 오픈소스 플랫폼입니다. Kubernetes는 다음과 같은 기능을 제공합니다.
 
 * 서비스 디스커버리와 로드 밸런싱
@@ -15,20 +19,25 @@ Kubernetes는 컨테이너화된 워크로드와 서비스를 관리할 수 있�
 
 * [쿠버네티스란 무엇인가?](https://kubernetes.io/ko/docs/concepts/overview/)
 
-## Kubernetes 클러스터
+<a id="kubernetes-cluster"></a>
+## Kubernetes 클러스터 { #kubernetes-cluster }
 Kubernetes 클러스터는 서로 연결되어 하나의 유닛처럼 동작하는 컴퓨터 클러스터입니다. Kubernetes가 제공하는 기능은 클러스터 단위로 동작하며, 클러스터 단위로 설정할 수 있습니다.
 
-### 구성
+<a id="configuration"></a>
+### 구성 { #configuration }
 Kubernetes 클러스터는 컨트롤 플레인과 노드로 구성됩니다.
 
+<a id="configuration-control-plane"></a>
 #### 컨트롤 플레인
 컨트롤 플레인은 클러스터 관리를 담당합니다. 애플리케이션을 스케줄링하거나 스케일링, 업데이트하는 등 클러스터 내의 모든 활동을 관리합니다. 일반적으로 컨트롤 플레인의 구성 요소들은 별도의 머신(가상 머신 혹은 물리 머신)에서 구동됩니다. 고가용성 보장을 위해 한 클러스터에 다수의 컨트롤 플레인 구성 요소를 구성할 수도 있습니다.
 
+<a id="configuration-node"></a>
 #### 노드
 노드는 사용자의 애플리케이션이 구동되는 워커 머신입니다. 하나의 클러스터에는 다수의 노드가 존재할 수 있습니다. 노드는 컨트롤 플레인과 연결되야 동작합니다. 컨트롤 플레인의 애플리케이션 구동, 정지 등의 명령에 따라 그대로 수행합니다.
 
 
-## NHN Kubernetes Service(NKS)
+<a id="nhn-kubernetes-service-nks"></a>
+## NHN Kubernetes Service(NKS) { #nhn-kubernetes-service-nks }
 NHN Kubernetes Service(NKS)는 클라우드에서 Kubernetes를 올바르고 안전하게 구동할 수 있게 Kubernetes 클러스터를 생성하고 관리할 수 있는 서비스입니다. 사용자는 웹 콘솔을 이용해 NHN Cloud에 꼭 맞는 Kubernetes 클러스터를 만들고 관리할 수 있습니다. 안전하고 효율적으로 운영할 수 있게 컨트롤 플레인은 NHN Cloud에서 관리하고, 사용자는 노드와 서비스, Pod(파드) 등을 관리합니다.
 
 NHN Kubernetes Service(NKS)의 주요 기능은 다음과 같습니다.

--- a/ko/public-api.md
+++ b/ko/public-api.md
@@ -1,4 +1,5 @@
-## Container > NHN Kubernetes Service(NKS) > API v2 가이드
+<a id="container-nhn-kubernetes-service-nks-api-v2-guide"></a>
+## Container > NHN Kubernetes Service(NKS) > API v2 가이드 { #container-nhn-kubernetes-service-nks-api-v2-guide }
 
 Kubernetes 클러스터를 구성하기 위한 API를 기술합니다.
 NKS는 API 호출 시 인증/인가를 위해 IaaS 토큰을 사용합니다. IaaS 토큰은 NHN Cloud의 OpenStack 기반 인프라 서비스(IaaS)에서 사용하는 인증 토큰입니다. IaaS 토큰 발급 및 사용에 대한 자세한 내용은 [IaaS 토큰](/nhncloud/ko/public-api/iaas-token)을 참고하세요.
@@ -12,11 +13,13 @@ NKS는 API 호출 시 인증/인가를 위해 IaaS 토큰을 사용합니다. Ia
 
 API 응답에 가이드에 명시되지 않은 필드가 나타날 수 있습니다. 이런 필드는 NHN Cloud 내부 용도로 사용되며 사전 공지 없이 변경될 수 있으므로 사용하지 않습니다.
 
-## API에 사용되는 리소스 정보 확인
+<a id="check-the-information-of-resources-used-in-api"></a>
+## API에 사용되는 리소스 정보 확인 { #check-the-information-of-resources-used-in-api }
 
 NHN Kubernetes Service(NKS) API는 클러스터 및 노드 그룹 구성을 위해 여러 가지 리소스를 사용합니다. 리소스별 정보 확인 방법은 다음과 같습니다.
 
-### 인터넷 게이트웨이에 연결된 VPC 네트워크 UUID
+<a id="uuid-of-the-vpc-network-attached-to-the-internet-gateway"></a>
+### 인터넷 게이트웨이에 연결된 VPC 네트워크 UUID { #uuid-of-the-vpc-network-attached-to-the-internet-gateway }
 
 인터넷 게이트웨이에 연결된 VPC 네트워크는 VPC 네트워크 목록 조회 API에 **router:external=True** 쿼리 파라미터를 이용해 조회할 수 있습니다.
 
@@ -27,44 +30,54 @@ GET /v2.0/networks?router:external=True
 네트워크 목록 조회 API에 대한 좀 더 자세한 내용은 [네트워크 목록 보기](/Network/VPC/ko/public-api/#_2)를 참고하세요.
 
 
-### 인터넷 게이트웨이에 연결된 서브넷 UUID 목록
+<a id="list-of-uuids-of-subnets-attached-to-the-internet-gateway"></a>
+### 인터넷 게이트웨이에 연결된 서브넷 UUID 목록 { #list-of-uuids-of-subnets-attached-to-the-internet-gateway }
 
 인터넷 게이트웨이에 연결된 VPC 네트워크와 연결된 서브넷 UUID를 입력합니다. 여러 서브넷이 조회되었다면 콜론(`:`)으로 연결해 입력합니다. 서브넷 목록 조회 API에 대한 좀 더 자세한 내용은 [서브넷 목록 보기](/Network/VPC/ko/public-api/#vpc_7)를 참고하세요.
 
 
-### VPC 네트워크 UUID
+<a id="vpc-network-uuid"></a>
+### VPC 네트워크 UUID { #vpc-network-uuid }
 
 노드와 연결할 내부 VPC 네트워크 UUID를 입력합니다. 네트워크 목록 조회 API에 대한 좀 더 자세한 내용은 [네트워크 목록 보기](/Network/VPC/ko/public-api/#vpc_1)를 참고하세요.
 
-### VPC 서브넷 UUID
+<a id="vpc-subnet-uuid"></a>
+### VPC 서브넷 UUID { #vpc-subnet-uuid }
 
 노드와 연결할 내부 VPC 네트워크와 연결된 서브넷 UUID를 입력합니다. 서브넷 목록 조회 API에 대한 좀 더 자세한 내용은 [서브넷 목록 보기](/Network/VPC/ko/public-api/#vpc_7)를 참고하세요.
 
-### 가용성 영역 UUID
+<a id="availability-zone-uuid"></a>
+### 가용성 영역 UUID { #availability-zone-uuid }
 
 노드를 생성할 가용성 영역 UUID를 입력합니다. 가용성 영역 목록 조회 API에 대한 좀 더 자세한 내용은 [가용성 목록 보기](/Compute/Instance/ko/public-api/#_9)를 참고하세요.
 
-### 키페어 명
+<a id="key-pair-uuid"></a>
+### 키페어 명 { #key-pair-uuid }
 
 노드 접속 시 사용할 키페어를 입력합니다. 키페어 목록 조회 API에 대한 좀 더 자세한 내용은 [키페어 목록 보기](/Compute/Instance/ko/public-api/#_13)를 참고하세요.
 
-### 베이스 이미지 UUID
+<a id="base-image-uuid"></a>
+### 베이스 이미지 UUID { #base-image-uuid }
 
 노드 생성에 사용할 베이스 이미지 UUID를 입력합니다. NKS 노드 생성에 사용되는 베이스 이미지만을 필터링하기 위해 API 호출 시 쿼리 스트링 파라미터에 `nhncloud_allow_nks_cpu_flavor=true&visibility=public` 값을 입력합니다. 베이스 이미지 목록 조회 API에 대한 좀 더 자세한 내용은 [이미지 목록 조회](/Compute/Image/ko/public-api/#_2)를 참고하세요.
 
-### 블록 스토리지 종류
+<a id="block-storage-type"></a>
+### 블록 스토리지 종류 { #block-storage-type }
 
 노드에 사용할 블록 스토리지 UUID를 입력합니다. 블록 스토리지 타입 목록 조회 API에 대한 좀 더 자세한 내용은 [볼륨 타입 목록 보기](/Storage/Block%20Storage/ko/public-api/#_2)를 참고하세요.
 
-### 인스턴스 타입 UUID
+<a id="flavor-uuid"></a>
+### 인스턴스 타입 UUID { #flavor-uuid }
 
 생성할 노드의 인스턴스 타입 UUID를 입력합니다. 인스턴스 타입 목록 조회 API에 대한 좀 더 자세한 내용은 [인스턴스 타입 목록 보기](/Compute/Instance/ko/public-api/#_2)를 참고하세요.
 
 
 
-## 클러스터
+<a id="cluster"></a>
+## 클러스터 { #cluster }
 
-### 클러스터 목록 보기
+<a id="list-clusters"></a>
+### 클러스터 목록 보기 { #list-clusters }
 
 클러스터 목록을 조회합니다.
 
@@ -76,6 +89,7 @@ OpenStack-API-Version: container-infra latest
 X-Auth-Token: {tokenId}
 ```
 
+<a id="list-clusters-request"></a>
 #### 요청
 
 이 API는 요청 본문을 요구하지 않습니다.
@@ -84,6 +98,7 @@ X-Auth-Token: {tokenId}
 |---|---|---|---|---|
 | tokenId | Header | String | O | 토큰 ID |
 
+<a id="list-clusters-response"></a>
 #### 응답
 
 | 이름 | 종류 | 형식 | 설명 |
@@ -189,7 +204,8 @@ X-Auth-Token: {tokenId}
 
 ---
 
-### 클러스터 보기
+<a id="get-a-cluster"></a>
+### 클러스터 보기 { #get-a-cluster }
 
 개별 클러스터 정보를 조회합니다.
 
@@ -201,6 +217,7 @@ OpenStack-API-Version: container-infra latest
 X-Auth-Token: {tokenId}
 ```
 
+<a id="get-a-cluster-request"></a>
 #### 요청
 
 이 API는 요청 본문을 요구하지 않습니다.
@@ -210,6 +227,7 @@ X-Auth-Token: {tokenId}
 | tokenId | Header | String | O | 토큰 ID |
 | CLUSTER_ID_OR_NAME| URL | UUID or String | O | 클러스터 UUID 또는 클러스터 이름 |
 
+<a id="get-a-cluster-response"></a>
 #### 응답
 
 | 이름 | 종류 | 형식 | 설명 |
@@ -336,7 +354,8 @@ X-Auth-Token: {tokenId}
 
 ---
 
-### 작업 이력 목록 보기
+<a id="view-task-history-list"></a>
+### 작업 이력 목록 보기 { #view-task-history-list }
 
 클러스터의 작업 이력 목록을 조회합니다.
 
@@ -348,6 +367,7 @@ OpenStack-API-Version: container-infra latest
 X-Auth-Token: {tokenId}
 ```
 
+<a id="view-task-history-list-request"></a>
 #### 요청
 
 이 API는 요청 본문을 요구하지 않습니다.
@@ -358,6 +378,7 @@ X-Auth-Token: {tokenId}
 | CLUSTER_UUID | URL | UUID | O | 클러스터 UUID |
 
 
+<a id="view-task-history-list-response"></a>
 #### 응답
 
 | 이름 | 종류 | 형식 | 설명 |
@@ -409,7 +430,8 @@ X-Auth-Token: {tokenId}
 
 ---
 
-### 작업 이력 보기
+<a id="list-task-history"></a>
+### 작업 이력 보기 { #list-task-history }
 
 클러스터의 작업 이력을 조회합니다.
 
@@ -421,6 +443,7 @@ OpenStack-API-Version: container-infra latest
 X-Auth-Token: {tokenId}
 ```
 
+<a id="list-task-history-request"></a>
 #### 요청
 
 이 API는 요청 본문을 요구하지 않습니다.
@@ -432,6 +455,7 @@ X-Auth-Token: {tokenId}
 | EVENT_UUID | URL | UUID | O | 작업 UUID |
 
 
+<a id="list-task-history-response"></a>
 #### 응답
 
 | 이름 | 종류 | 형식 | 설명 |
@@ -478,7 +502,8 @@ X-Auth-Token: {tokenId}
 
 ---
 
-### 클러스터 생성하기
+<a id="create-a-cluster"></a>
+### 클러스터 생성하기 { #create-a-cluster }
 
 클러스터를 생성합니다.
 
@@ -490,6 +515,7 @@ OpenStack-API-Version: container-infra latest
 X-Auth-Token: {tokenId}
 ```
 
+<a id="create-a-cluster-request"></a>
 #### 요청
 
 | 이름 | 종류 | 형식 | 필수 | 설명 |
@@ -626,6 +652,7 @@ X-Auth-Token: {tokenId}
 </p>
 </details>
 
+<a id="create-a-cluster-response"></a>
 #### 응답
 
 | 이름 | 종류 | 형식 | 설명 |
@@ -646,7 +673,8 @@ X-Auth-Token: {tokenId}
 
 ---
 
-### 클러스터 삭제하기
+<a id="delete-a-cluster"></a>
+### 클러스터 삭제하기 { #delete-a-cluster }
 
 클러스터를 삭제합니다.
 
@@ -658,6 +686,7 @@ OpenStack-API-Version: container-infra latest
 X-Auth-Token: {tokenId}
 ```
 
+<a id="delete-a-cluster-request"></a>
 #### 요청
 
 이 API는 요청 본문을 요구하지 않습니다.
@@ -668,13 +697,15 @@ X-Auth-Token: {tokenId}
 | CLUSTER_ID_OR_NAME | URL | UUID or String | O | 클러스터 UUID 또는 클러스터 이름 | 
 
 
+<a id="delete-a-cluster-response"></a>
 #### 응답
 
 이 API는 응답 본문을 반환하지 않습니다.
 
 ---
 
-### 리사이즈
+<a id="resize"></a>
+### 리사이즈 { #resize }
 
 클러스터의 노드 수를 조정합니다.
 
@@ -686,6 +717,7 @@ OpenStack-API-Version: container-infra latest
 X-Auth-Token: {tokenId}
 ```
 
+<a id="resize-request"></a>
 #### 요청
 
 | 이름 | 종류 | 형식 | 필수 | 설명 |
@@ -732,6 +764,7 @@ X-Auth-Token: {tokenId}
 
 
 
+<a id="resize-response"></a>
 #### 응답
 
 | 이름 | 종류 | 형식 | 설명 |
@@ -753,7 +786,8 @@ X-Auth-Token: {tokenId}
 
 ---
 
-### 클러스터 kubeconfig 조회
+<a id="get-kubeconfig-of-a-cluster"></a>
+### 클러스터 kubeconfig 조회 { #get-kubeconfig-of-a-cluster }
 
 클러스터 설정 파일(kubeconfig)을 조회합니다.
 
@@ -765,6 +799,7 @@ OpenStack-API-Version: container-infra latest
 X-Auth-Token: {tokenId}
 ```
 
+<a id="get-kubeconfig-of-a-cluster-request"></a>
 #### 요청
 
 이 API는 요청 본문을 요구하지 않습니다.
@@ -775,6 +810,7 @@ X-Auth-Token: {tokenId}
 | CLUSTER_ID_OR_NAME | URL | UUID or String | O | 클러스터 UUID 또는 클러스터 이름 | 
 
 
+<a id="get-kubeconfig-of-a-cluster-response"></a>
 #### 응답
 
 | 이름 | 종류 | 형식 | 설명 |
@@ -795,7 +831,8 @@ X-Auth-Token: {tokenId}
 </details>
 
 
-### 클러스터 API 엔드포인트 IP 접근 제어 적용
+<a id="enforce-ip-access-control-to-cluster-api-endpoints"></a>
+### 클러스터 API 엔드포인트 IP 접근 제어 적용 { #enforce-ip-access-control-to-cluster-api-endpoints }
 클러스터 API 엔드포인트에 IP 접근 제어를 적용하거나 해제할 수 있습니다.
 IP 접근 제어 기능에 대한 자세한 사항은 [IP 접근제어](/Network/Load%20Balancer/ko/overview/#ip) 문서를 참고하세요.
 클러스터 API 엔드포인트에 IP 접근 제어 규칙에 대한 자세한 사항은 [사용자 가이드](/Container/NKS/ko/user-guide/#api_endpoint_ipacl)를 참고하세요.
@@ -808,6 +845,7 @@ OpenStack-API-Version: container-infra latest
 X-Auth-Token: {tokenId}
 ```
 
+<a id="enforce-ip-access-control-to-cluster-api-endpoints-request"></a>
 #### 요청
 
 | 이름 | 종류 | 형식 | 필수 | 설명 |
@@ -844,6 +882,7 @@ X-Auth-Token: {tokenId}
 </details>
 
 
+<a id="enforce-ip-access-control-to-cluster-api-endpoints-response"></a>
 #### 응답
 
 | 이름 | 종류 | 형식 | 설명 |
@@ -863,7 +902,8 @@ X-Auth-Token: {tokenId}
 </details>
 
 
-### 클러스터 API 엔드포인트 IP 접근 제어 조회
+<a id="get-cluster-api-endpoint-ip-access-control"></a>
+### 클러스터 API 엔드포인트 IP 접근 제어 조회 { #get-cluster-api-endpoint-ip-access-control }
 클러스터 API 엔드포인트에 적용된 IP 접근 제어 정보를 확인할 수 있습니다.
 
 ```
@@ -874,6 +914,7 @@ OpenStack-API-Version: container-infra latest
 X-Auth-Token: {tokenId}
 ```
 
+<a id="get-cluster-api-endpoint-ip-access-control-request"></a>
 #### 요청
 이 API는 요청 본문을 요구하지 않습니다.
 
@@ -883,6 +924,7 @@ X-Auth-Token: {tokenId}
 | CLUSTER_ID_OR_NAME | URL | UUID or String | O | 클러스터 UUID 또는 클러스터 이름 | 
 
 
+<a id="get-cluster-api-endpoint-ip-access-control-response"></a>
 #### 응답
 
 | 이름 | 종류 | 형식 | 설명 |
@@ -931,7 +973,8 @@ X-Auth-Token: {tokenId}
 </details>
 
 ---
-### 클러스터 인증서 갱신
+<a id="renew-cluster-certificate"></a>
+### 클러스터 인증서 갱신 { #renew-cluster-certificate }
 
 클러스터의 인증서를 갱신합니다.
 ```
@@ -942,6 +985,7 @@ OpenStack-API-Version: container-infra latest
 X-Auth-Token: {tokenId}
 ```
 
+<a id="renew-cluster-certificate-name"></a>
 #### 요청
 | 이름 | 종류 | 형식 | 필수 | 설명 |
 |---|---|---|---|---|
@@ -961,6 +1005,7 @@ X-Auth-Token: {tokenId}
 </p>
 </details>
 
+<a id="renew-cluster-certificate-response"></a>
 #### 응답
 
 | 이름 | 종류 | 형식 | 설명 |
@@ -982,7 +1027,8 @@ X-Auth-Token: {tokenId}
 
 ---
 
-### 서비스 게이트웨이 변경하기
+<a id="change-service-gateway"></a>
+### 서비스 게이트웨이 변경하기 { #change-service-gateway }
 
 클러스터 생성 시 서비스 게이트웨이를 설정한 경우 다른 서비스 게이트웨이로 변경할 수 있습니다. 
 ```
@@ -993,6 +1039,7 @@ OpenStack-API-Version: container-infra latest
 X-Auth-Token: {tokenId}
 ```
 
+<a id="change-service-gateway-request"></a>
 #### 요청
 
 | 이름 | 종류 | 형식 | 필수 | 설명 |
@@ -1015,6 +1062,7 @@ X-Auth-Token: {tokenId}
 </p>
 </details>
 
+<a id="change-service-gateway-response"></a>
 #### 응답
 
 | 이름 | 종류 | 형식 | 설명 |
@@ -1036,7 +1084,8 @@ X-Auth-Token: {tokenId}
 
 ---
 
-### 컨트롤 플레인 Kubernetes 컴포넌트 로그 저장
+<a id="store-logs-of-kubernetes-control-plane-components"></a>
+### 컨트롤 플레인 Kubernetes 컴포넌트 로그 저장 { #store-logs-of-kubernetes-control-plane-components }
 NHN Kubernetes Service(NKS)의 컨트롤 플레인에서 실행 중인 주요 Kubernetes 컴포넌트들의 로그를 Log & Crash Search 또는 Object Storage에 저장합니다.
 
 ```
@@ -1047,6 +1096,7 @@ OpenStack-API-Version: container-infra latest
 X-Auth-Token: {tokenId}
 ```
 
+<a id="store-logs-of-kubernetes-control-plane-components-name"></a>
 #### 요청
 
 | 이름 | 종류 | 형식 | 필수 | 설명 |
@@ -1120,6 +1170,7 @@ X-Auth-Token: {tokenId}
 </p>
 </details>
 
+<a id="store-logs-of-kubernetes-control-plane-components-type"></a>
 #### 응답
 
 | 이름 | 종류 | 형식 | 설명 |
@@ -1139,9 +1190,11 @@ X-Auth-Token: {tokenId}
 </details>
 
 
-## 노드 그룹
+<a id="node-group"></a>
+## 노드 그룹 { #node-group }
 
-### 노드 그룹 목록 보기
+<a id="list-node-groups"></a>
+### 노드 그룹 목록 보기 { #list-node-groups }
 
 노드 그룹 목록을 조회합니다.
 
@@ -1153,6 +1206,7 @@ OpenStack-API-Version: container-infra latest
 X-Auth-Token: {tokenId}
 ```
 
+<a id="list-node-groups-request"></a>
 #### 요청
 
 이 API는 요청 본문을 요구하지 않습니다.
@@ -1163,6 +1217,7 @@ X-Auth-Token: {tokenId}
 | CLUSTER_ID_OR_NAME | URL | UUID or String | O | 클러스터 UUID 또는 클러스터 이름 | 
 
 
+<a id="list-node-groups-response"></a>
 #### 응답
 
 | 이름 | 종류 | 형식 | 설명 |
@@ -1207,7 +1262,8 @@ X-Auth-Token: {tokenId}
 
 ---
 
-### 노드 그룹 보기
+<a id="get-a-node-group"></a>
+### 노드 그룹 보기 { #get-a-node-group }
 
 개별 노드 그룹 정보를 조회합니다.
 
@@ -1219,6 +1275,7 @@ OpenStack-API-Version: container-infra latest
 X-Auth-Token: {tokenId}
 ```
 
+<a id="get-a-node-group-request"></a>
 #### 요청
 
 이 API는 요청 본문을 요구하지 않습니다.
@@ -1229,6 +1286,7 @@ X-Auth-Token: {tokenId}
 | CLUSTER_ID_OR_NAME | URL | UUID or String | O | 클러스터 UUID 또는 클러스터 이름 | 
 | NODEGROUP_ID_OR_NAME | URL | UUID or String | O | 노드 그룹 UUID 또는 노드 그룹 이름 | 
 
+<a id="get-a-node-group-response"></a>
 #### 응답
 
 | 이름 | 종류 | 형식 | 설명 |
@@ -1355,7 +1413,8 @@ X-Auth-Token: {tokenId}
 
 ---
 
-### 노드 그룹 생성하기
+<a id="create-a-node-group"></a>
+### 노드 그룹 생성하기 { #create-a-node-group }
 
 노드 그룹을 생성합니다.
 
@@ -1367,6 +1426,7 @@ OpenStack-API-Version: container-infra latest
 X-Auth-Token: {tokenId}
 ```
 
+<a id="create-a-node-group-request"></a>
 #### 요청
 
 | 이름 | 종류 | 형식 | 필수 | 설명 |
@@ -1433,6 +1493,7 @@ X-Auth-Token: {tokenId}
 </p>
 </details>
 
+<a id="create-a-node-group-response"></a>
 #### 응답
 
 | 이름 | 종류 | 형식 | 설명 |
@@ -1513,7 +1574,8 @@ X-Auth-Token: {tokenId}
 
 ---
 
-### 노드 그룹 삭제하기
+<a id="delete-a-node-group"></a>
+### 노드 그룹 삭제하기 { #delete-a-node-group }
 
 지정한 노드 그룹를 삭제합니다.
 ```
@@ -1524,6 +1586,7 @@ OpenStack-API-Version: container-infra latest
 X-Auth-Token: {tokenId}
 ```
 
+<a id="delete-a-node-group-request"></a>
 #### 요청
 
 이 API는 요청 본문을 요구하지 않습니다.
@@ -1534,13 +1597,15 @@ X-Auth-Token: {tokenId}
 | CLUSTER_ID_OR_NAME | URL | UUID or String | O | 클러스터 UUID 또는 클러스터 이름 | 
 | NODEGROUP_ID_OR_NAME | URL | UUID or String | O | 노드 그룹 UUID 또는 노드 그룹 이름 | 
 
+<a id="delete-a-node-group-response"></a>
 #### 응답
 
 이 API는 응답 본문을 반환하지 않습니다.
 
 ---
 
-### 노드 중지하기
+<a id="stop-a-node-group"></a>
+### 노드 중지하기 { #stop-a-node-group }
 
 지정한 노드 목록을 중지시킵니다.
 
@@ -1552,6 +1617,7 @@ OpenStack-API-Version: container-infra latest
 X-Auth-Token: {tokenId}
 ```
 
+<a id="stop-a-node-group-request"></a>
 #### 요청
 
 | 이름 | 종류 | 형식 | 필수 | 설명 |
@@ -1574,6 +1640,7 @@ X-Auth-Token: {tokenId}
 </details>
 
 
+<a id="stop-a-node-group-response"></a>
 #### 응답
 
 | 이름 | 종류 | 형식 | 설명 |
@@ -1594,7 +1661,8 @@ X-Auth-Token: {tokenId}
 
 ---
 
-### 노드 시작하기
+<a id="start-a-node"></a>
+### 노드 시작하기 { #start-a-node }
 
 지정한 노드 목록을 시작시킵니다.
 
@@ -1606,6 +1674,7 @@ OpenStack-API-Version: container-infra latest
 X-Auth-Token: {tokenId}
 ```
 
+<a id="start-a-node-request"></a>
 #### 요청
 
 | 이름 | 종류 | 형식 | 필수 | 설명 |
@@ -1627,6 +1696,7 @@ X-Auth-Token: {tokenId}
 </p>
 </details>
 
+<a id="start-a-node-response"></a>
 #### 응답
 
 | 이름 | 종류 | 형식 | 설명 |
@@ -1647,7 +1717,8 @@ X-Auth-Token: {tokenId}
 
 ---
 
-### 노드 그룹의 클러스터 오토스케일러 설정 보기
+<a id="view-cluster-autoscaler-configuration-of-a-node-group"></a>
+### 노드 그룹의 클러스터 오토스케일러 설정 보기 { #view-cluster-autoscaler-configuration-of-a-node-group }
 
 노드 그룹의 클러스터 오토스케일러 설정을 조회합니다.
 
@@ -1659,6 +1730,7 @@ OpenStack-API-Version: container-infra latest
 X-Auth-Token: {tokenId}
 ```
 
+<a id="view-cluster-autoscaler-configuration-of-a-node-group-request"></a>
 #### 요청
 
 이 API는 요청 본문을 요구하지 않습니다.
@@ -1670,6 +1742,7 @@ X-Auth-Token: {tokenId}
 | NODEGROUP_ID_OR_NAME | URL | UUID or String | O | 노드 그룹 UUID 또는 노드 그룹 이름 | 
 
 
+<a id="view-cluster-autoscaler-configuration-of-a-node-group-response"></a>
 #### 응답
 
 | 이름 | 종류 | 형식 | 설명 |
@@ -1705,7 +1778,8 @@ X-Auth-Token: {tokenId}
 
 ---
 
-### 노드 그룹의 클러스터 오토스케일러 설정 변경하기
+<a id="change-cluster-autoscaler-configuration-of-a-node-group"></a>
+### 노드 그룹의 클러스터 오토스케일러 설정 변경하기 { #change-cluster-autoscaler-configuration-of-a-node-group }
 
 노드 그룹의 클러스터 오토스케일러 설정을 변경합니다.
 
@@ -1717,6 +1791,7 @@ OpenStack-API-Version: container-infra latest
 X-Auth-Token: {tokenId}
 ```
 
+<a id="change-cluster-autoscaler-configuration-of-a-node-group-request"></a>
 #### 요청
 
 | 이름 | 종류 | 형식 | 필수 | 설명 |
@@ -1754,6 +1829,7 @@ X-Auth-Token: {tokenId}
 
 
 
+<a id="change-cluster-autoscaler-configuration-of-a-node-group-response"></a>
 #### 응답
 
 | 이름 | 종류 | 형식 | 설명 |
@@ -1774,7 +1850,8 @@ X-Auth-Token: {tokenId}
 
 ---
 
-### 노드 그룹의 지표 기반 오토스케일러 설정 변경하기
+<a id="change-metric-based-autoscaler-configuration-of-a-node-group"></a>
+### 노드 그룹의 지표 기반 오토스케일러 설정 변경하기 { #change-metric-based-autoscaler-configuration-of-a-node-group }
 
 노드 그룹의 지표 기반 오토스케일러 설정을 변경합니다.
 
@@ -1786,6 +1863,7 @@ OpenStack-API-Version: container-infra latest
 X-Auth-Token: {tokenId}
 ```
 
+<a id="change-metric-based-autoscaler-configuration-of-a-node-group-request"></a>
 #### 요청
 
 | 이름 | 종류 | 형식 | 필수 | 설명 |
@@ -1887,6 +1965,7 @@ X-Auth-Token: {tokenId}
 </details>
 
 
+<a id="change-metric-based-autoscaler-configuration-of-a-node-group-response"></a>
 #### 응답
 
 | 이름 | 종류 | 형식 | 설명 |
@@ -1907,7 +1986,8 @@ X-Auth-Token: {tokenId}
 
 ---
 
-### 클러스터 업그레이드
+<a id="upgrade-a-cluster"></a>
+### 클러스터 업그레이드 { #upgrade-a-cluster }
 
 클러스터를 업그레이드합니다.
 
@@ -1919,6 +1999,7 @@ OpenStack-API-Version: container-infra latest
 X-Auth-Token: {tokenId}
 ```
 
+<a id="upgrade-a-cluster-request"></a>
 #### 요청
 
 | 이름 | 종류 | 형식 | 필수 | 설명 |
@@ -1952,6 +2033,7 @@ X-Auth-Token: {tokenId}
 </details>
 
 
+<a id="upgrade-a-cluster-response"></a>
 #### 응답
 
 | 이름 | 종류 | 형식 | 설명 |
@@ -1972,7 +2054,8 @@ X-Auth-Token: {tokenId}
 
 ---
 
-### 사용자 스크립트 변경하기
+<a id="change-user-script"></a>
+### 사용자 스크립트 변경하기 { #change-user-script }
 
 노드 그룹의 사용자 스크립트를 변경합니다.
 
@@ -1984,6 +2067,7 @@ OpenStack-API-Version: container-infra latest
 X-Auth-Token: {tokenId}
 ```
 
+<a id="change-user-script-request"></a>
 #### 요청
 
 | 이름 | 종류 | 형식 | 필수 | 설명 |
@@ -2007,6 +2091,7 @@ X-Auth-Token: {tokenId}
 </details>
 
 
+<a id="change-user-script-response"></a>
 #### 응답
 
 | 이름 | 종류 | 형식 | 설명 |
@@ -2027,7 +2112,8 @@ X-Auth-Token: {tokenId}
 
 ---
 
-### 인스턴스 타입 변경하기
+<a id="change-instance-flavor"></a>
+### 인스턴스 타입 변경하기 { #change-instance-flavor }
 
 노드 그룹의 인스턴스 타입을 변경합니다.
 
@@ -2039,6 +2125,7 @@ OpenStack-API-Version: container-infra latest
 X-Auth-Token: {tokenId}
 ```
 
+<a id="change-instance-flavor-request"></a>
 #### 요청
 
 | 이름 | 종류 | 형식 | 필수 | 설명 |
@@ -2068,6 +2155,7 @@ X-Auth-Token: {tokenId}
 </details>
 
 
+<a id="change-instance-flavor-response"></a>
 #### 응답
 
 | 이름 | 종류 | 형식 | 설명 |
@@ -2088,7 +2176,8 @@ X-Auth-Token: {tokenId}
 
 ---
 
-### 노드 그룹의 플로팅 IP 자동 할당 설정 변경하기
+<a id="change-floating-ip-auto-assignment-configuration-of-a-node-group"></a>
+### 노드 그룹의 플로팅 IP 자동 할당 설정 변경하기 { #change-floating-ip-auto-assignment-configuration-of-a-node-group }
 
 노드 그룹의 플로팅 IP 자동 할당 설정을 변경합니다.
 
@@ -2100,6 +2189,7 @@ OpenStack-API-Version: container-infra latest
 X-Auth-Token: {tokenId}
 ```
 
+<a id="change-floating-ip-auto-assignment-configuration-of-a-node-group-request"></a>
 #### 요청
 
 | 이름 | 종류 | 형식 | 필수 | 설명 |
@@ -2132,6 +2222,7 @@ X-Auth-Token: {tokenId}
 </details>
 
 
+<a id="change-floating-ip-auto-assignment-configuration-of-a-node-group-response"></a>
 #### 응답
 
 | 이름 | 종류 | 형식 | 설명 |
@@ -2152,7 +2243,8 @@ X-Auth-Token: {tokenId}
 
 ---
 
-### 노드 그룹의 Kubernetes 레이블 설정 변경하기
+<a id="change-kubernetes-label-configuration-of-a-node-group"></a>
+### 노드 그룹의 Kubernetes 레이블 설정 변경하기 { #change-kubernetes-label-configuration-of-a-node-group }
 
 노드 그룹의 Kubernetes 레이블 설정을 변경합니다.
 
@@ -2164,6 +2256,7 @@ OpenStack-API-Version: container-infra latest
 X-Auth-Token: {tokenId}
 ```
 
+<a id="change-kubernetes-label-configuration-of-a-node-group-request"></a>
 #### 요청
 
 | 이름 | 종류 | 형식 | 필수 | 설명 |
@@ -2192,6 +2285,7 @@ X-Auth-Token: {tokenId}
 </details>
 
 
+<a id="change-kubernetes-label-configuration-of-a-node-group-response"></a>
 #### 응답
 
 | 이름 | 종류 | 형식 | 설명 |
@@ -2212,9 +2306,11 @@ X-Auth-Token: {tokenId}
 
 ---
 
-## 애드온 관리 기능
+<a id="add-on-management"></a>
+## 애드온 관리 기능 { #add-on-management }
 
-### NHN Cloud에서 제공하는 애드온 유형 보기
+<a id="view-the-types-of-add-ons-offered-by-nhn-cloud"></a>
+### NHN Cloud에서 제공하는 애드온 유형 보기 { #view-the-types-of-add-ons-offered-by-nhn-cloud }
 NHN Cloud에서 제공하는 애드온 유형을 확인할 수 있습니다.
 
 ```
@@ -2225,6 +2321,7 @@ OpenStack-API-Version: container-infra latest
 X-Auth-Token: {tokenId}
 ```
 
+<a id="view-the-types-of-add-ons-offered-by-nhn-cloud-request"></a>
 #### 요청
 
 | 이름 | 종류 | 형식 | 필수 | 설명 |
@@ -2232,6 +2329,7 @@ X-Auth-Token: {tokenId}
 | tokenId | Header | String | O | 토큰 ID |
 | ADDON_TYPE_UUID_OR_NAME | URL | UUID or String | O | 애드온 유형의 UUID 혹은 이름 |
 
+<a id="view-the-types-of-add-ons-offered-by-nhn-cloud-response"></a>
 #### 응답
 
 | 이름 | 종류 | 형식 | 설명 |
@@ -2256,7 +2354,8 @@ X-Auth-Token: {tokenId}
 
 ---
 
-### NHN Cloud에서 제공하는 애드온 유형 목록 보기
+<a id="view-a-list-of-add-ons-types-offered-by-nhn-cloud"></a>
+### NHN Cloud에서 제공하는 애드온 유형 목록 보기 { #view-a-list-of-add-ons-types-offered-by-nhn-cloud }
 NHN Cloud에서 제공하는 애드온 유형의 목록을 확인할 수 있습니다.
 
 ```
@@ -2267,11 +2366,13 @@ OpenStack-API-Version: container-infra latest
 X-Auth-Token: {tokenId}
 ```
 
+<a id="view-a-list-of-add-ons-types-offered-by-nhn-cloud-request"></a>
 #### 요청
 | 이름 | 종류 | 형식 | 필수 | 설명 |
 |---|---|---|---|---|
 | tokenId | Header | String | O | 토큰 ID |
 
+<a id="view-a-list-of-add-ons-types-offered-by-nhn-cloud-response"></a>
 #### 응답
 
 | 이름 | 종류 | 형식 | 설명 |
@@ -2295,7 +2396,8 @@ X-Auth-Token: {tokenId}
 
 ---
 
-### NHN Cloud에서 제공하는 애드온 보기
+<a id="view-add-ons-offered-by-nhn-cloud"></a>
+### NHN Cloud에서 제공하는 애드온 보기 { #view-add-ons-offered-by-nhn-cloud }
 NHN Cloud에서 제공하는 애드온을 확인할 수 있습니다.
 
 ```
@@ -2306,6 +2408,7 @@ OpenStack-API-Version: container-infra latest
 X-Auth-Token: {tokenId}
 ```
 
+<a id="view-add-ons-offered-by-nhn-cloud-request"></a>
 #### 요청
 
 | 이름 | 종류 | 형식 | 필수 | 설명 |
@@ -2314,6 +2417,7 @@ X-Auth-Token: {tokenId}
 | tokenId | Header | String | O | 토큰 ID |
 
 
+<a id="view-add-ons-offered-by-nhn-cloud-response"></a>
 #### 응답
 
 | 이름 | 종류 | 형식 | 설명 |
@@ -2365,7 +2469,8 @@ X-Auth-Token: {tokenId}
 
 ---
 
-### NHN Cloud에서 제공하는 애드온 목록 보기
+<a id="view-a-list-of-add-ons-offered-by-nhn-cloud"></a>
+### NHN Cloud에서 제공하는 애드온 목록 보기 { #view-a-list-of-add-ons-offered-by-nhn-cloud }
 NHN Cloud에서 제공하는 애드온 목록을 확인할 수 있습니다.
 
 ```
@@ -2376,6 +2481,7 @@ OpenStack-API-Version: container-infra latest
 X-Auth-Token: {tokenId}
 ```
 
+<a id="view-a-list-of-add-ons-offered-by-nhn-cloud-request"></a>
 #### 요청
 
 | 이름 | 종류 | 형식 | 필수 | 설명 |
@@ -2385,6 +2491,7 @@ X-Auth-Token: {tokenId}
 | image | Query | UUID | X | 베이스 이미지 UUID. 지정 시 해당 이미지에 설치 가능한 애드온만 반환합니다. |
 | platform_version | Query | String | X | 플랫폼 버전(예: `1.202605.0`). 지정 시 해당 플랫폼 버전에서 사용 가능한 애드온만 반환합니다. |
 
+<a id="view-a-list-of-add-ons-offered-by-nhn-cloud-response"></a>
 #### 응답
 
 | 이름 | 종류 | 형식 | 설명 |
@@ -2411,7 +2518,8 @@ X-Auth-Token: {tokenId}
 
 ---
 
-### 클러스터에 설치된 애드온 보기
+<a id="view-add-ons-installed-on-a-cluster"></a>
+### 클러스터에 설치된 애드온 보기 { #view-add-ons-installed-on-a-cluster }
 클러스터에 설치된 애드온을 확인할 수 있습니다.
 
 ```
@@ -2422,6 +2530,7 @@ OpenStack-API-Version: container-infra latest
 X-Auth-Token: {tokenId}
 ```
 
+<a id="view-add-ons-installed-on-a-cluster-request"></a>
 #### 요청
 
 | 이름 | 종류 | 형식 | 필수 | 설명 |
@@ -2431,6 +2540,7 @@ X-Auth-Token: {tokenId}
 | ADDON_UUID_OR_NAME | URL | UUID or String | O | 애드온 UUID 또는 애드온 이름 |
 
 
+<a id="view-add-ons-installed-on-a-cluster-response"></a>
 #### 응답
 
 | 이름 | 종류 | 형식 | 설명 |
@@ -2477,7 +2587,8 @@ X-Auth-Token: {tokenId}
 
 ---
 
-### 클러스터에 설치된 애드온 목록 보기
+<a id="view-a-list-of-add-ons-installed-on-a-cluster"></a>
+### 클러스터에 설치된 애드온 목록 보기 { #view-a-list-of-add-ons-installed-on-a-cluster }
 클러스터에 설치된 애드온 목록을 확인할 수 있습니다.
 
 ```
@@ -2488,6 +2599,7 @@ OpenStack-API-Version: container-infra latest
 X-Auth-Token: {tokenId}
 ```
 
+<a id="view-a-list-of-add-ons-installed-on-a-cluster-request"></a>
 #### 요청
 
 | 이름 | 종류 | 형식 | 필수 | 설명 |
@@ -2495,6 +2607,7 @@ X-Auth-Token: {tokenId}
 | tokenId | Header | String | O | 토큰 ID |
 | CLUSTER_ID_OR_NAME | URL | UUID or String | O | 클러스터 UUID 또는 클러스터 이름 |
 
+<a id="view-a-list-of-add-ons-installed-on-a-cluster-response"></a>
 #### 응답
 
 | 이름 | 종류 | 형식 | 설명 |
@@ -2518,7 +2631,8 @@ X-Auth-Token: {tokenId}
 
 ---
 
-### 클러스터에 애드온 설치
+<a id="install-add-ons-on-a-cluster"></a>
+### 클러스터에 애드온 설치 { #install-add-ons-on-a-cluster }
 클러스터에 애드온을 설치합니다.
 
 ```
@@ -2529,6 +2643,7 @@ OpenStack-API-Version: container-infra latest
 X-Auth-Token: {tokenId}
 ```
 
+<a id="install-add-ons-on-a-cluster-request"></a>
 #### 요청
 
 | 이름 | 종류 | 형식 | 필수 | 설명 |
@@ -2551,6 +2666,7 @@ X-Auth-Token: {tokenId}
 </details>
 
 
+<a id="install-add-ons-on-a-cluster-response"></a>
 #### 응답
 
 | 이름 | 종류 | 형식 | 설명 |
@@ -2571,7 +2687,8 @@ X-Auth-Token: {tokenId}
 
 ---
 
-### 클러스터에 애드온 업데이트
+<a id="update-add-ons-to-a-cluster"></a>
+### 클러스터에 애드온 업데이트 { #update-add-ons-to-a-cluster }
 클러스터에 설치된 애드온을 업데이트합니다.
 
 ```
@@ -2582,6 +2699,7 @@ OpenStack-API-Version: container-infra latest
 X-Auth-Token: {tokenId}
 ```
 
+<a id="update-add-ons-to-a-cluster-request"></a>
 #### 요청
 
 | 이름 | 종류 | 형식 | 필수 | 설명 |
@@ -2604,6 +2722,7 @@ X-Auth-Token: {tokenId}
 </details>
 
 
+<a id="update-add-ons-to-a-cluster-response"></a>
 #### 응답
 
 | 이름 | 종류 | 형식 | 설명 |
@@ -2624,7 +2743,8 @@ X-Auth-Token: {tokenId}
 
 ---
 
-### 클러스터에 애드온 제거
+<a id="remove-add-ons-from-a-cluster"></a>
+### 클러스터에 애드온 제거 { #remove-add-ons-from-a-cluster }
 클러스터에 설치된 애드온을 제거합니다.
 
 ```
@@ -2635,6 +2755,7 @@ OpenStack-API-Version: container-infra latest
 X-Auth-Token: {tokenId}
 ```
 
+<a id="remove-add-ons-from-a-cluster-request"></a>
 #### 요청
 
 | 이름 | 종류 | 형식 | 필수 | 설명 |
@@ -2643,6 +2764,7 @@ X-Auth-Token: {tokenId}
 | CLUSTER_ID_OR_NAME | URL | UUID or String | O | 클러스터 UUID 또는 클러스터 이름 |
 | ADDON_UUID_OR_NAME | URL | UUID or String | O | 애드온 UUID 또는 애드온 이름 |
 
+<a id="remove-add-ons-from-a-cluster-response"></a>
 #### 응답
 
 | 이름 | 종류 | 형식 | 설명 |
@@ -2663,9 +2785,11 @@ X-Auth-Token: {tokenId}
 
 
 
-## 기타 기능
+<a id="other-features"></a>
+## 기타 기능 { #other-features }
 
-### 지원되는 Kubernetes 버전 및 작업 종류 보기
+<a id="view-supported-kubernetes-versions-and-task-types"></a>
+### 지원되는 Kubernetes 버전 및 작업 종류 보기 { #view-supported-kubernetes-versions-and-task-types }
 
 NHN Kubernetes Service(NKS)에서 지원하는 Kubernetes 버전 및 작업 타입을 조회합니다.
 
@@ -2677,6 +2801,7 @@ OpenStack-API-Version: container-infra latest
 X-Auth-Token: {tokenId}
 ```
 
+<a id="view-supported-kubernetes-versions-and-task-types-request"></a>
 #### 요청
 
 이 API는 요청 본문을 요구하지 않습니다.
@@ -2686,6 +2811,7 @@ X-Auth-Token: {tokenId}
 | tokenId | Header | String | O | 토큰 ID |
 
 
+<a id="view-supported-kubernetes-versions-and-task-types-response"></a>
 #### 응답
 
 | 이름 | 종류 | 형식 | 설명 |

--- a/ko/release-notes.md
+++ b/ko/release-notes.md
@@ -1,13 +1,19 @@
-## Container > NHN Kubernetes Service(NKS) > 릴리스 노트
+<!-- pre-align:aligned sig=a9faa149ecf3 -->
 
-### 2026. 05. 27.
+<a id="container-nhn-kubernetes-service-nks-release-notes"></a>
+## Container > NHN Kubernetes Service(NKS) > 릴리스 노트 { #container-nhn-kubernetes-service-nks-release-notes }
 
+<a id="may-27-2026"></a>
+### 2026. 05. 27. { #may-27-2026 }
+
+<a id="may-27-2026-added-features"></a>
 #### 기능 추가
 * Kubernetes v1.34.3을 지원합니다.
     * k8s v1.34 이상 버전에서 워커 노드 이미지의 CGroup 버전에 따른 제약 사항이 존재합니다. 자세한 내용은 [Kubernetes 버전과 CGroup 버전에 따른 제약 사항](/Container/NKS/ko/version-guide/#constraints-on-cgroup)을 참고하세요.
     * k8s v1.34 이상 버전에서 사용자 정의 containerd 레지스트리 설정 기능이 동작하지 않습니다. 자세한 내용은 [사용자 정의 containerd 레지스트리 설정 기능](/Container/NKS/ko/version-guide/#containerd-registry-config)을 참고하세요.
 * Cilium CNI를 지원합니다.
 
+<a id="may-27-2026-platform-version-updates"></a>
 #### 플랫폼 버전 업데이트
 * 1.202605.0이 추가되었습니다.
     * Kubernetes 호환 버전: v1.30–v1.34
@@ -16,6 +22,7 @@
         * kube-apiserver와 pod 간의 통신을 위한 konnectivity 지원
         * k8s v1.34 클러스터의 `ImageVolume` feature gate 활성화
 
+<a id="may-27-2026-add-on-updates"></a>
 #### 애드온 업데이트
 * 다음 애드온이 추가되었습니다.
     * nfs_csi_plugin v1.0.2-nks1
@@ -24,15 +31,19 @@
     * calico v3.28.2-nks3
     * calico v3.30.2-nks3
 
-### 2026. 03. 17.
+<a id="march-17-2026"></a>
+### 2026. 03. 17. { #march-17-2026 }
 
+<a id="march-17-2026-platform-version-updates"></a>
 #### 플랫폼 버전 업데이트
 * 1.202602.1이 추가되었습니다.
     * 기능 개선
         * Service 객체로 생성된 LB의 안정성 강화
 
-### 2026. 03. 10.
+<a id="march-10-2026"></a>
+### 2026. 03. 10. { #march-10-2026 }
 
+<a id="march-10-2026-platform-version-updates"></a>
 #### 플랫폼 버전 업데이트
 * 1.202602.0이 추가되었습니다.
     * Kubernetes 호환 버전: v1.29–v1.33
@@ -44,6 +55,7 @@
     * 기능 개선
         * 노드 및 노드 그룹 삭제 시 로드 밸런서 트래픽 유실 개선
 
+<a id="march-10-2026-add-on-updates"></a>
 #### 애드온 업데이트
 * 다음 애드온이 추가되었습니다.
     * calico v3.30.2-nks2
@@ -53,6 +65,7 @@
     * snapshot_controller v4.1.1-nks2
     * nfs_csi_plugin v1.0.1-nks2
 
+<a id="march-10-2026-added-features"></a>
 #### 기능 추가
 * CGroup이 v2로 설정된 OS 이미지를 지원합니다.
     * 2026년 3월 이후 배포되는 OS 이미지는 CGroup이 v2로 설정되어 있습니다.
@@ -60,12 +73,15 @@
 * Kubernetes 테인트 설정 기능이 추가되었습니다.
 * Secure Key Manager 서비스를 이용해 클러스터의 기밀 데이터를 암/복호화할 수 있습니다.
 
-### 2025. 12. 23.
+<a id="december-23-2025"></a>
+### 2025. 12. 23. { #december-23-2025 }
 
+<a id="december-23-2025-platform-version-updates"></a>
 #### 플랫폼 버전 업데이트
 * 1.202511.1이 추가되었습니다.
     * 헬스 체크 확인 포트 설정 오류를 수정했습니다.
 
+<a id="december-23-2025-add-on-updates"></a>
 #### 애드온 업데이트
 * Cinder CSI Plugin v1.27.101-nks2, v1.27.102-nks2가 추가되었습니다.
     * 내부 컨테이너 버전이 다음과 같이 변경되었습니다.
@@ -75,12 +91,15 @@
         * csi-resizer: v1.0.1 → v1.3.0
         * csi-node-driver-registrar: v2.0.1 → v2.3.0
 
-### 2025. 11. 25.
+<a id="november-25-2025"></a>
+### 2025. 11. 25. { #november-25-2025 }
 
+<a id="november-25-2025-changed-service-support-policy"></a>
 #### 서비스 지원 정책 변경
 * NKS의 Kubernetes 버전 지원 정책이 변경됩니다.
     * 자세한 내용은 [버전 가이드](/Container/NKS/ko/version-guide)를 참고하세요.
 
+<a id="november-25-2025-updated-add-on"></a>
 #### 애드온 업데이트
 * 다음 애드온이 추가되었습니다.
     * Calico CNI v3.30.2-nks1
@@ -89,6 +108,7 @@
     * Snapshot Controller v4.1.1-nks1
     * NFS CSI Plugin v1.0.1-nks1
 
+<a id="november-25-2025-added-features"></a>
 #### 기능 추가
 * Kubernetes v1.33.4를 지원합니다.
 * 컨트롤 플레인과 워커 노드 그룹의 플랫폼 버전의 조회 및 업그레이드 기능이 추가되었습니다.
@@ -96,15 +116,19 @@
 * 로드 밸런서 상세 옵션 설정에 상태 확인 호스트 헤더 설정 기능이 추가되었습니다.
 
 
-### 2025. 07. 15.
+<a id="july-15-2025"></a>
+### 2025. 07. 15. { #july-15-2025 }
 
+<a id="july-15-2025-image-update"></a>
 #### 이미지 업데이트
 * 클러스터 및 노드 그룹 생성 시 더 이상 아래 이미지를 지원하지 않습니다.
     * 대상 이미지
         * Ubuntu Server 20.04.3 LTS - Container
 
-### 2025. 05. 27.
+<a id="may-27-2025"></a>
+### 2025. 05. 27. { #may-27-2025 }
 
+<a id="may-27-2025-added-features"></a>
 #### 기능 추가
 * Kubernetes v1.32.3를 지원합니다.
 * 컨트롤 플레인 kubernetes 컴포넌트 로그 저장 기능이 추가되었습니다.
@@ -114,14 +138,17 @@
 * Addon 관리 기능을 사용할 수 있습니다.
     * 자세한 내용은 [사용 가이드](/Container/NKS/ko/user-guide/#addon-mgmt)를 참고하세요.
 
+<a id="may-27-2025-feature-updates"></a>
 #### 기능 개선/변경
 * 클러스터 CNI 변경 기능은 더 이상 지원하지 않습니다.
 * 물리 타입의 로드 밸런서를 더 이상 지원하지 않습니다.
 * Blue/Green Upgrade 시 시스템 파드 업그레이드 단계가 제거되었습니다.
     * Calico, CoreDNS 등의 시스템 파드는 애드온 관리 기능을 통해 업데이트할 수 있습니다.
 
-### 2025. 03. 04.
+<a id="march-4-2025"></a>
+### 2025. 03. 04. { #march-4-2025 }
 
+<a id="march-4-2025-added-features"></a>
 #### 기능 추가
 * Kubernetes v1.31.4를 지원합니다.
 * OIDC(openID connect) 설정 기능을 사용할 수 있습니다.
@@ -129,17 +156,22 @@
     * 클러스터 키페어를 설정한 클러스터는 서비스 사용자의 권한으로 동작합니다.
     * 서비스 사용자의 권한으로 동작하는 클러스터는 오너를 변경/관리할 필요가 없습니다.
 
+<a id="march-4-2025-feature-updates"></a>
 #### 기능 개선/변경
 * 클러스터 오너 변경 기능은 더 이상 지원하지 않습니다.
 
-### 2024. 11. 26.
+<a id="november-26-2024"></a>
+### 2024. 11. 26. { #november-26-2024 }
 
+<a id="november-26-2024-added-features"></a>
 #### 기능 추가
 * Kubernetes 컴포넌트 설정 기능을 사용할 수 있습니다.
 
+<a id="november-26-2024-feature-updates"></a>
 #### 기능 개선
 * 파드 서브넷 크기에 따라 노드당 생성 가능한 최대 파드 수가 자동으로 설정되도록 변경되었습니다.
 
+<a id="november-26-2024-image-update"></a>
 #### 이미지 업데이트
 이미지에 설치된 GPU 드라이버의 버전이 변경되었습니다.
 
@@ -165,18 +197,23 @@
 | Ubuntu Server 20.04.6 LTS (2024.11.19) | 20GB | 30GB |
 | Ubuntu Server 22.04.6 LTS (2024.11.19) | 20GB | 30GB |
 
+<a id="november-26-2024-deprecated-image-support"></a>
 #### 이미지 지원 중단
 * CentOS 이미지를 사용하여 신규 클러스터 및 노드 그룹을 생성할 수 없습니다.
 
-### 2024. 10. 29.
+<a id="october-29-2024"></a>
+### 2024. 10. 29. { #october-29-2024 }
 
+<a id="october-29-2024-feature-updates"></a>
 #### 기능 개선
 
 * CNI 업데이트
     * Kubernetes v1.27.3 이상 클러스터의 Calico CNI 버전이 v3.28.0에서 v3.28.2로 변경되었습니다.
 
-### 2024. 08. 27.
+<a id="august-27-2024"></a>
+### 2024. 08. 27. { #august-27-2024 }
 
+<a id="august-27-2024-added-features"></a>
 #### 기능 추가
 * 노드 그룹에 추가 보안 그룹을 지정하는 기능이 추가되었습니다.
 * 노드 그룹에 추가 블록 스토리지를 지정하는 기능이 추가되었습니다.
@@ -184,18 +221,23 @@
 * 로드 밸런서의 정적 라우트 적용 여부를 설정할 수 있습니다.
 * NKS 레지스트리를 활성화할 수 있습니다.
 
+<a id="august-27-2024-deprecated-image-support"></a>
 #### 이미지 지원 중단
 * Debian 이미지를 사용하여 신규 클러스터 및 노드 그룹을 생성할 수 없습니다.
 
-### 2024. 07. 23.
+<a id="july-23-2024"></a>
+### 2024. 07. 23. { #july-23-2024 }
 
+<a id="july-23-2024-added-features"></a>
 #### 기능 추가
 
 * 로드 밸런서 상세 옵션 설정으로 L7 규칙과 조건을 적용할 수 있습니다.
 * 클러스터 생성 시 Calico-VXLAN과 Calico-eBPF CNI를 선택할 수 있습니다.
 
-### 2024. 05. 28.
+<a id="may-28-2024"></a>
+### 2024. 05. 28. { #may-28-2024 }
 
+<a id="may-28-2024-added-features"></a>
 #### 기능 추가
 
 * Kubernetes v1.29.3을 지원합니다.
@@ -205,15 +247,19 @@
 * Resource Watcher 서비스를 통해 클러스터에서 발생하는 이벤트에 대한 알림을 받을 수 있습니다.
     * 자세한 내용은 [Resource Watcher](/Governance%20&%20Audit/Resource%20Watcher/ko/overview)를 참고하세요.
 
-### 2024. 03. 26.
+<a id="march-26-2024"></a>
+### 2024. 03. 26. { #march-26-2024 }
 
+<a id="march-26-2024-feature-updates"></a>
 #### 기능 개선
 * 클러스터 생성 시 입력하는 서비스 게이트웨이의 유효 범위가 변경되었습니다.
     * 변경 전: 클러스터의 서브넷과 동일한 서브넷에 생성된 서비스 게이트웨이
     * 변경 후: 클러스터의 VPC에 포함되는 서브넷에 생성된 서비스 게이트웨이
 
-### 2024. 02. 27.
+<a id="february-27-2024"></a>
+### 2024. 02. 27. { #february-27-2024 }
 
+<a id="february-27-2024-added-features"></a>
 #### 기능 추가
 
 * 클러스터에 강화된 보안 규칙을 적용할 수 있습니다.
@@ -222,14 +268,17 @@
 * 클러스터와 노드 그룹 조회 화면에서 작업 이력을 확인할 수 있습니다.
 
 
-### 2023. 11. 28.
+<a id="november-28-2023"></a>
+### 2023. 11. 28. { #november-28-2023 }
 
+<a id="november-28-2023-added-features"></a>
 #### 기능 추가
 * kubelet 사용자 정의 아규먼트 설정 기능이 추가되었습니다.
 * 로드 밸런서 상세 옵션 설정으로 멤버 서브넷 설정 기능이 추가되었습니다.
 * 로드 밸런서 상세 옵션 설정으로 keep-alive 타임아웃 값 설정 기능이 추가되었습니다.
 * 암호화된 블록 스토리지를 사용해 PV를 생성하는 기능이 추가되었습니다.
 
+<a id="november-28-2023-image-update"></a>
 #### 이미지 업데이트
 * 클러스터 및 노드 그룹 생성 시 사용 가능한 신규 이미지가 추가되었습니다.
     * 대상 이미지
@@ -247,8 +296,10 @@
         * Rocky Linux 8.8 - Container (2023.11.21)
         * Ubuntu Server 20.04.6 LTS - Container (2023.11.21)
 
-### 2023. 08. 29.
+<a id="august-29-2023"></a>
+### 2023. 08. 29. { #august-29-2023 }
 
+<a id="august-29-2023-added-features"></a>
 #### 기능 추가
 
 * Kubernetes v1.27.3을 지원합니다.
@@ -257,6 +308,7 @@
 * 클러스터와 노드 그룹 목록 조회 화면에서 좀 더 상세한 상태 정보를 제공합니다.
 * 프로비저닝 시 새로운 NAS 볼륨을 생성하는 기능이 추가되었습니다.
 
+<a id="august-29-2023-feature-updates"></a>
 #### 기능 개선
 * 클러스터 및 노드 그룹 생성 시 사용하는 이미지의 배포판 버전이 변경되었습니다.
     * 변경 전
@@ -264,6 +316,7 @@
     * 변경 후
         * Rocky Linux 8.8 - Container (2023.08.22)
 
+<a id="august-29-2023-image-update"></a>
 #### 이미지 업데이트 
 * 변경 사항
     * nvidia-device-plugin 버전이 470.182.03에서 470.199.02로 변경되었습니다.
@@ -275,8 +328,10 @@
     * Ubuntu Server 20.04.6 LTS - Container (2023.08.22)
 
 
-### 2023. 07. 19.
+<a id="july-19-2023"></a>
+### 2023. 07. 19. { #july-19-2023 }
 
+<a id="july-19-2023-image-update"></a>
 #### 이미지 업데이트
 * 노드 그룹 생성 시 일부 이미지에서 iptables 커널 모듈이 정상적으로 초기화되지 않는 문제를 수정했습니다.
     * 문제 이미지: Rocky Linux 8.7 - Container (2023.05.25)
@@ -286,8 +341,10 @@
     * 해결 이미지: CentOS 7.9 - Container (2023.07.25)
 
 
-### 2023. 05. 30.
+<a id="may-30-2023"></a>
+### 2023. 05. 30. { #may-30-2023 }
 
+<a id="may-30-2023-added-features"></a>
 #### 기능 추가
 
 * Kubernetes v1.26.3을 지원합니다.
@@ -295,6 +352,7 @@
     * 자세한 내용은 [사용자 가이드](/Container/NKS/ko/user-guide/#custom-image)를 참고하세요.
 * 클러스터 서비스 네트워크, 파드 네트워크, 파드 서브넷 크기 변경 기능이 추가되었습니다.
 
+<a id="may-30-2023-feature-updates"></a>
 #### 기능 개선
 
 * 클러스터 및 노드 그룹 생성 시 사용하는 이미지의 배포판 버전이 변경되었습니다.
@@ -317,8 +375,10 @@
         * Rocky Linux 8.7 - Container (2023.05.25)
         * Ubuntu Server 20.04.6 LTS - Container (2023.05.25)
 
-### 2023. 03. 28.
+<a id="march-28-2023"></a>
+### 2023. 03. 28. { #march-28-2023 }
 
+<a id="march-28-2023-added-features"></a>
 #### 기능 추가
 
 * 클러스터 CNI 변경 기능이 추가되었습니다.
@@ -326,6 +386,7 @@
 * 노드 그룹의 인스턴스 타입을 변경할 수 있습니다.
 * 콘솔에서 Kubernetes 자원 조회 기능을 사용할 수 있습니다.
 
+<a id="march-28-2023-feature-updates"></a>
 #### 기능 변경
 
 * NKS API 주소 도메인이 변경되었습니다.
@@ -336,6 +397,7 @@
         * 기존: https://kr2-api-kubernetes.infrastructure.cloud.toast.com
         * 변경: https://kr2-api-kubernetes-infrastructure.nhncloudservice.com
 
+<a id="march-28-2023-march-28-2023-feature-updates"></a>
 #### 기능 개선
 
 * 이미지 업데이트
@@ -343,8 +405,10 @@
     * Debian 11.6 Bullseye - Container (2023.02.21)
     * Rocky Linux 8.6 - Container (2023.02.21)
 
-### 2023. 01. 31.
+<a id="january-31-2023"></a>
+### 2023. 01. 31. { #january-31-2023 }
 
+<a id="january-31-2023-added-features"></a>
 #### 기능 추가
 
 * 클러스터 OWNER 변경 기능이 추가되었습니다.
@@ -354,15 +418,19 @@
 * 로드 밸런서의 리스너에 프록시 프로토콜(Proxy Protocol)을 설정할 수 있습니다.
 * 물리 로드 밸런서를 생성할 수 있습니다.
 
-### 2022. 12. 27.
+<a id="december-27-2022"></a>
+### 2022. 12. 27. { #december-27-2022 }
 
+<a id="december-27-2022-added-features"></a>
 #### 기능 추가
 
 * 이미지 추가
     * Rocky Linux 8.6 - Container (2022.12)
 
-### 2022. 11. 29.
+<a id="november-29-2022"></a>
+### 2022. 11. 29. { #november-29-2022 }
 
+<a id="november-29-2022-feature-updates"></a>
 #### 기능 개선
 
 * 이미지 업데이트
@@ -373,6 +441,7 @@
         * Ubuntu Server 18.04.6 LTS - Container (2022.11.22)
         * CentOS 7.9 - Container (2022.11.22)
 
+<a id="november-29-2022-added-features"></a>
 #### 기능 추가
 
 * 노드 시작/중지 기능을 사용할 수 있습니다.
@@ -382,47 +451,59 @@
     * Debian 11.5 Bullseye - Container (2022.11.22)
 
 
-### 2022. 09. 27.
+<a id="september-27-2022"></a>
+### 2022. 09. 27. { #september-27-2022 }
 
+<a id="september-27-2022-added-features"></a>
 #### 기능 추가
 
 * Kubernetes v1.24.3을 지원합니다.
 * 클러스터 생성 시 Kubernetes v1.20.12는 더 이상 지원하지 않습니다. 단, 사용 중인 클러스터에는 영향이 없습니다.
 
 
-### 2022. 07. 26.
+<a id="july-26-2022"></a>
+### 2022. 07. 26. { #july-26-2022 }
 
+<a id="july-26-2022-added-features"></a>
 #### 기능 추가
 
 * 노드 그룹 생성 후에도 사용자 스크립트를 변경할 수 있습니다.
 * 사용자 스크립트 변경 API가 추가됐습니다.
 * 워커 노드 그룹 업그레이드 시 최대 노드 수와 최대 서비스 불가 노드 수를 지정할 수 있습니다.
 
-### 2022. 05. 24.
+<a id="may-24-2022"></a>
+### 2022. 05. 24. { #may-24-2022 }
 
+<a id="may-24-2022-feature-updates"></a>
 #### 기능 개선
 * 내부 구조를 개선해 서비스의 성능과 안정성을 향상했습니다.
 
 
-### 2022. 03. 29.
+<a id="march-29-2022"></a>
+### 2022. 03. 29. { #march-29-2022 }
 
+<a id="march-29-2022-added-features"></a>
 #### 기능 추가
 
 * Kubernetes v1.23.3을 지원합니다.
 * 클러스터 생성 시 Kubernetes v1.19.13은 더 이상 지원하지 않습니다. 단, 사용 중인 클러스터에는 영향이 없습니다.
 * 로드 밸런서의 리스너 프로토콜을 TERMINATED_HTTPS로 설정할 때 SSL 버전을 TLSv1.3으로 설정할 수 있습니다.
 
+<a id="march-29-2022-feature-updates"></a>
 #### 기능 변경
 
 * 기능 이름이 변경되었습니다.
     * 변경 전: 예약 스크립트
     * 변경 후: 사용자 스크립트
 
-### 2022. 01. 25.
+<a id="january-25-2022"></a>
+### 2022. 01. 25. { #january-25-2022 }
 
+<a id="january-25-2022-feature-updates"></a>
 #### 기능 개선
 * Kubernetes 서비스의 이름이 NHN Kubernetes Service(NKS)로 변경되었습니다.
 
+<a id="january-25-2022-added-features"></a>
 #### 기능 추가
 
 * 아래 Kubernetes 버전을 지원합니다.
@@ -441,8 +522,10 @@
     * Ubuntu Server 18.04.6 LTS - Container (2022.01.20)
         * 클러스터 생성 및 노드 그룹 생성 시 Ubuntu 워커 이미지를 사용할 수 있습니다.
 
-### 2021. 12. 28.
+<a id="december-28-2021"></a>
+### 2021. 12. 28. { #december-28-2021 }
 
+<a id="december-28-2021-feature-updates"></a>
 #### 기능 개선
 
 * GPU 워커 노드에서 사용하는 NVIDIA 드라이버가 업데이트되었습니다.
@@ -452,14 +535,18 @@
 * 이미지 업데이트
     * CentOS 7.8 - Container (2021.12.21)
 
-### 2021. 11. 23.
+<a id="november-23-2021"></a>
+### 2021. 11. 23. { #november-23-2021 }
 
+<a id="november-23-2021-added-features"></a>
 #### 기능 추가
 * Kubernetes 서비스를 위한 Public API가 공개되었습니다.
     * Public API에 대한 내용은 [API 가이드](/Container/NKS/ko/public-api)를 참고하세요.
 
-### 2021. 10. 26.
+<a id="october-26-2021"></a>
+### 2021. 10. 26. { #october-26-2021 }
 
+<a id="october-26-2021-added-features"></a>
 #### 기능 추가
 
 * Kubernetes v1.19.13을 지원합니다.
@@ -467,8 +554,10 @@
 * 오토스케일러의 '증설 후 감축 지연 시간' 설정 최솟값이 10분으로 변경되었습니다.
 * 새로운 클러스터에서는 워커 노드 그룹이 2개 이상인 경우 기본 워커 노드 그룹을 삭제할 수 있습니다.
 
-### 2021. 07. 27.
+<a id="july-27-2021"></a>
+### 2021. 07. 27. { #july-27-2021 }
 
+<a id="july-27-2021-added-features"></a>
 #### 기능 추가
 
 * 노드 그룹 생성 시 사용자 스크립트 기능을 사용할 수 있습니다.
@@ -477,64 +566,87 @@
         * CentOS 7.8 - Container (2021.07.27)
     * 컨테이너 로그 관리에 대한 내용은 [문제 해결 가이드](/Container/NKS/ko/troubleshooting-guide)를 참고하세요.
 
-### 2021. 06. 29.
+<a id="june-29-2021"></a>
+### 2021. 06. 29. { #june-29-2021 }
 
+<a id="june-29-2021-added-features"></a>
 #### 기능 추가
 
 * Kubernetes v1.18.19를 지원합니다.
 * 클러스터 버전을 업그레이드할 수 있습니다.
 
-### 2021. 03. 23.
+<a id="march-23-2021"></a>
+### 2021. 03. 23. { #march-23-2021 }
 
+<a id="march-23-2021-added-features"></a>
 #### 기능 추가
 
 * 사용자 클러스터에서 발생한 이벤트를 NHN CloudTrail에서 확인할 수 있습니다.
 
+<a id="march-23-2021-bug-fixes"></a>
 #### 버그 수정
 * 그래픽 최적화된 인스턴스 타입(g2)으로 노드 그룹 생성 시 정상 초기화되지 않는 문제가 수정되었습니다.
 
-### 2021. 02. 23.
+<a id="february-23-2021"></a>
+### 2021. 02. 23. { #february-23-2021 }
 
+<a id="february-23-2021-feature-updates"></a>
 #### 기능 개선
 * Kubernetes 승인 컨트롤러(admission controller)에 PodSecurityPolicy 플러그인이 추가되었습니다.
 * 클러스터 및 노드 그룹 생성 시 사용하는 이미지의 배포판 버전이 변경되었습니다.
     * 이미지 업데이트
         * CentOS 7.8 - Container (2021.02.23)
 
-### 2021. 01. 26.
+<a id="january-26-2021"></a>
+### 2021. 01. 26. { #january-26-2021 }
+<a id="january-26-2021-bug-fixes"></a>
 #### 버그 수정
 * 인터넷 게이트웨이가 연결되지 않은 환경에서 오토스케일러 기능이 동작하지 않는 문제가 수정되었습니다.
     * 이미지 업데이트
         * CentOS 7.5 - Container (2021.01.26)
 
-### 2020. 12. 29.
+<a id="december-29-2020"></a>
+### 2020. 12. 29. { #december-29-2020 }
+<a id="december-29-2020-feature-updates"></a>
 #### 기능 개선
 * Kubernetes CSR(Certificate Signing Request) 기능을 사용할 수 있습니다.
 
-### 2020. 11. 24.
+<a id="november-24-2020"></a>
+### 2020. 11. 24. { #november-24-2020 }
+<a id="november-24-2020-added-features"></a>
 #### 기능 추가
 * 오토스케일러 기능을 사용할 수 있습니다.
 
+<a id="november-24-2020-feature-updates"></a>
 #### 기능 개선
 * 클러스터를 삭제할 때 남아있는 로드 밸런서와 플로팅 IP를 삭제합니다.
 
-### 2020. 10. 27.
+<a id="october-27-2020"></a>
+### 2020. 10. 27. { #october-27-2020 }
+<a id="october-27-2020-more-feature"></a>
 #### 기능 추가
 * Kubernetes 클러스터에서 GPU 기반의 노드 그룹을 사용할 수 있습니다.
     * 이미지 업데이트
         * CentOS 7.5 - Container (2020.10.27)
 
-### 2020. 09. 22.
+<a id="09-22"></a>
+### 2020. 09. 22. { #09-22 }
+<a id="09-22-feature-updates"></a>
 #### 기능 개선
 * 동작 중인 노드 그룹에 노드를 추가하거나 삭제할 수 있습니다. 
 
+<a id="09-22-release-of-new-service"></a>
 #### 신규 서비스 출시
 * 한국(평촌) 리전에서도 Kubernetes 서비스를 사용할 수 있습니다.
 
-### 2020. 08. 25.
+<a id="august-25-2020"></a>
+### 2020. 08. 25. { #august-25-2020 }
+<a id="august-25-2020-feature-updates"></a>
 #### 기능 개선
 * 콘솔에서 Kubernetes 클러스터를 생성할 때, 임의의 영역(zone)을 선택할 수 있습니다.
 
-### 2020. 06. 23.
+<a id="june-23-2020"></a>
+### 2020. 06. 23. { #june-23-2020 }
+<a id="june-23-2020-release-of-new-service"></a>
 #### 신규 서비스 출시
 * 콘솔에서 Kubernetes 클러스터를 생성하고 관리할 수 있습니다.

--- a/ko/troubleshooting-guide.md
+++ b/ko/troubleshooting-guide.md
@@ -1,9 +1,14 @@
-## Container > NHN Kubernetes Service(NKS) > 문제 해결 가이드
+<!-- pre-align:aligned sig=d435f80f360f -->
+
+<a id="container-nhn-kubernetes-service-nks-troubleshooting-guide"></a>
+## Container > NHN Kubernetes Service(NKS) > 문제 해결 가이드 { #container-nhn-kubernetes-service-nks-troubleshooting-guide }
 
 NHN Kubernetes Service(NKS)를 사용하면서 겪을 수 있는 다양한 문제들에 대한 해결 방법을 설명합니다.
 
-### > 워커 노드의 컨테이너 로그 파일 크기가 커지면서 디스크 공간이 줄어듭니다.
+<a id="disk-space-is-reduced-as-the-size-of-the-worker-nodes-container-log-file-increases"></a>
+### > 워커 노드의 컨테이너 로그 파일 크기가 커지면서 디스크 공간이 줄어듭니다. { #disk-space-is-reduced-as-the-size-of-the-worker-nodes-container-log-file-increases }
 
+<a id="disk-space-is-reduced-as-the-size-of-the-worker-nodes-container-log-file-increases-set-log-rotation"></a>
 #### 로그 로테이션 설정하기
 컨테이너 로그 파일 관리(최대 파일 크기, 로그 파일 개수 설정 등)를 위해 워커 노드에 아래와 같은 설정을 추가합니다.
 
@@ -29,6 +34,7 @@ EOF
 > [참고] `CentOS 7.8 - Container (2021.07.27)` 이후의 인스턴스 이미지에는 위와 같은 로그 로테이션 설정이 기본으로 제공됩니다.
 <br>
 
+<a id="disk-space-is-reduced-as-the-size-of-the-worker-nodes-container-log-file-increases-synchronize-log-rotation-setting"></a>
 #### 로그 로테이션 설정 동기화하기
 
 클러스터 운용 과정에서 다음과 같은 경우 일부 워커 노드의 로그 로테이션 설정이 달라지는 상황이 발생할 수도 있습니다.
@@ -127,7 +133,8 @@ $
 > [참고] 상기 내용은 동기화를 위한 하나의 방법일 뿐이며, 사용자 환경에 더 적절한 방법이 있다면 그것을 통해 동기화 작업이 수행되도록 하면 됩니다.
 
 
-### > 파드의 상태가 ImagePullBackOff로 나타납니다.
+<a id="the-status-of-the-pod-appears-as-imagepullbackoff"></a>
+### > 파드의 상태가 ImagePullBackOff로 나타납니다. { #the-status-of-the-pod-appears-as-imagepullbackoff }
 
 2020년 11월 20일부터 dockerhub는 컨테이너 이미지 pull 요청 횟수에 다음과 같은 제한을 두는 정책을 시행하였습니다. 제한과 관련된 자세한 사항은 [Understanding Docker Hub Rate Limiting](https://www.docker.com/increase-rate-limits)과 [Pricing & Subscriptions](https://www.docker.com/pricing)을 참고하세요.
 
@@ -146,7 +153,8 @@ NKS의 워커 노드에서 dockerhub로부터 컨테이너 이미지를 내려�
 * dockerhub에 로그인하지 않은 상황에서 독립적인 퍼블릭 IP에 의한 제약을 받고 싶은 경우, 워커 노드에 플로팅 IP를 할당합니다. 
 
 
-### > 폐쇄망 환경에서 failed to pull image `k8s.gcr.io/pause:3.2`가 발생합니다.
+<a id="failed-to-pull-image-k8sgcriopause32-in-a-closed-network-environment"></a>
+### > 폐쇄망 환경에서 failed to pull image `k8s.gcr.io/pause:3.2`가 발생합니다. { #failed-to-pull-image-k8sgcriopause32-in-a-closed-network-environment }
 폐쇄망 환경의 클러스터가 퍼블릭 레지스트리로부터 이미지를 받아 오지 못하기 때문에 발생하는 문제로, 2024년 8월 이전에 생성된 클러스터에서 발생할 수 있습니다. `k8s.gcr.io/pause:3.2` 이미지처럼 기본으로 배포되어 있는 이미지는 워커 노드 생성 시 NHN Cloud 내부 레지스트리로부터 pull 받습니다. 하지만, 최초 이미지를 pull 받은 이후 이미지가 삭제되는 경우 문제가 발생할 수 있습니다. 클러스터 생성 시 기본으로 배포되는 이미지 목록은 아래와 같습니다.
 
 * kubernetesui/dashboard
@@ -186,11 +194,13 @@ imageGCHighThresholdPercent=85 : 디스크 사용률이 85%를 초과하는 경�
 imageGCLowThresholdPercent=80 : 디스크 사용률이 80% 이하일 경우 이미지 Garbage Collection을 실행하지 않습니다.
 ```
 
+<a id="failed-to-pull-image-k8sgcriopause32-in-a-closed-network-environment-workaround"></a>
 #### 해결 방안
 NKS 레지스트리를 활성화하면 폐쇄망 환경에서 컨테이너 이미지를 퍼블릭 레지스트리로부터 받아 오지 않고, NHN Cloud 내부 레지스트리에서 받아 오도록 클러스터 설정을 변경할 수 있습니다. NKS 레지스트리는 클러스터 조회 화면에서 활성화할 수 있습니다.
 
 
-### > `quay.io`로부터 Flannel CNI 관련 이미지 pull이 실패합니다.
+<a id="image-pull-for-flannel-cni-related-images-from-quayio-fails"></a>
+### > `quay.io`로부터 Flannel CNI 관련 이미지 pull이 실패합니다. { #image-pull-for-flannel-cni-related-images-from-quayio-fails }
 
 Flannel 관련 컨테이너 이미지의 리포지터리 주소는 `quay.io`를 기반으로 설정되어 있습니다. `quay.io`에서 해당 이미지에 대한 pull 서비스가 종료되어 이제 해당 이미지를 pull할 수 없습니다.
 
@@ -204,7 +214,8 @@ Flannel 관련 컨테이너 이미지의 리포지터리 주소는 `quay.io`를 
     * 변경 전: `quay.io/coreos/flannel*`
     * 변경 후: `ghcr.io/flannel-io/flannel*`
 
-### > k8s v1.24 이상의 버전에서 `pulling from host docker.pkg.github.com failed` 오류가 발생하며 이미지 pull이 실패합니다. 
+<a id="in-k8s-v124-and-later-the-pull-from-host-dockerpkggithubcom-failed-error-occurs-and-the-image-pull-fails"></a>
+### > k8s v1.24 이상의 버전에서 `pulling from host docker.pkg.github.com failed` 오류가 발생하며 이미지 pull이 실패합니다. { #in-k8s-v124-and-later-the-pull-from-host-dockerpkggithubcom-failed-error-occurs-and-the-image-pull-fails }
 
 github의 패키지 레지스트리가 Docker 레지스트리에서 Container 레지스트리로 변경되었기 때문에 발생한 문제입니다. v1.24 이전 버전의 클러스터는 컨테이너 런타임으로 Docker를 사용하여 `docker.pkg.github.com` 레지스트리에서 이미지 pull이 가능했지만, v1.24 이상 버전의 NKS 클러스터는 컨테이너 런타임으로 cotainerd를 사용하기 때문에 더 이상 `docker.pkg.github.com` 레지스트리에서 이미지 pull이 불가능합니다. 패키지 레지스트리 이전에 관한 자세한 사항은 [Migration to Container registry from the Docker registry](https://docs.github.com/en/packages/working-with-a-github-packages-registry/migrating-to-the-container-registry-from-the-docker-registry)를 참고하세요.
 
@@ -212,10 +223,12 @@ github의 패키지 레지스트리가 Docker 레지스트리에서 Container �
 해결 방안은 다음과 같습니다.
 파드 매니페스트에 정의된 image URL의 base를 `docker.pkg.github.com`에서 `gchr.io`로 변경합니다.
 
-### > `cannot allocate memory` 오류가 발생하며 파드의 상태가 `FailedCreatePodContainer`로 나타납니다.
+<a id="cannot-allocate-memory-error-occurs-and-the-pods-status-appears-as-failedcreatepodcontainer"></a>
+### > `cannot allocate memory` 오류가 발생하며 파드의 상태가 `FailedCreatePodContainer`로 나타납니다. { #cannot-allocate-memory-error-occurs-and-the-pods-status-appears-as-failedcreatepodcontainer }
 
 리눅스 커널의 기능 중 memory cgroup에 대한 kernel object accounting 기능의 버그로 발생하는 현상입니다. 주로 리눅스 커널 3.x, 4.x 버전에서 발생하며, dying memory cgroup problem 이슈로 알려져 있습니다. 사용자가 이미지 수준에서 memory cgroup에 대한 kernel object accounting 기능을 비활성화해 이 문제를 우회할 수 있습니다. 
 
+<a id="cannot-allocate-memory-error-occurs-and-the-pods-status-appears-as-failedcreatepodcontainer-apply-the-workaround-to-existing-clusters"></a>
 #### 기존에 생성된 클러스터에 해결 방안 적용
 워커 노드에 접속하여 부팅 옵션을 변경한 후 재시작합니다.
 
@@ -239,6 +252,7 @@ $ reboot
 
 해당 이슈는 항상 발생하는 것은 아니며, 사용자의 애플리케이션 특성에 따라 발생할 수 있습니다. 만약 이슈 발생이 우려될 경우 NKS의 커스텀 이미지 기능을 이용해 처음부터 위와 같은 해결 방안이 적용된 워커 노드 이미지를 사용할 수 있습니다.
 
+<a id="cannot-allocate-memory-error-occurs-and-the-pods-status-appears-as-failedcreatepodcontainer-apply-the-workaround-to-newly-created-clusters-using-the-nks-custom-image-feature"></a>
 #### NKS 커스텀 이미지 기능을 사용하여 새로 생성한 클러스터에 해결 방안 적용
 NKS에서는 사용자의 커스텀 이미지를 기반으로 한 워커 노드 그룹을 생성하는 기능을 제공하고 있습니다. NKS 커스텀 이미지 기능을 사용하여 memory cgroup에 대한 kernel object accounting 기능이 비활성화된 이미지를 만들고 클러스터 생성 시 활용할 수 있습니다. 커스텀 이미지 사용 기능에 대한 자세한 내용은 [커스텀 이미지를 워커 이미지로 활용](/Container/NKS/ko/user-guide/#custom-image)을 참고하세요.
 
@@ -252,7 +266,8 @@ sudo sed -i "s/GRUB_CMDLINE_LINUX=\"\(.*\)\"/GRUB_CMDLINE_LINUX=\"\1 $args\"/" "
 sudo grub2-mkconfig -o /boot/grub2/grub.cfg
 ```
 
-### > rpc.statd is not running but is required for remote locking 오류가 발생하며 파드에서 NAS 볼륨 마운트가 실패합니다.
+<a id="rpcstatd-is-not-running-but-is-required-for-remote-locking-error-occurs-and-the-pod-fails-to-mount-the-nas-volume"></a>
+### > rpc.statd is not running but is required for remote locking 오류가 발생하며 파드에서 NAS 볼륨 마운트가 실패합니다. { #rpcstatd-is-not-running-but-is-required-for-remote-locking-error-occurs-and-the-pod-fails-to-mount-the-nas-volume }
 
 워커 노드의 rpc.statd 프로세스가 좀비 프로세스가 되거나 관리자의 명령에 의해 정지되어 발생하는 문제입니다. 볼륨을 마운트하기 위해서는 워커 노드에 rpcbind 및 rpc.statd 프로세스가 정상적으로 실행되고 있어야 합니다. 해결 방안은 다음과 같습니다.
 ```
@@ -260,7 +275,8 @@ systemctl restart rpc-statd
 systemctl restart rpcbind
 ```
 
-### > PV 용량 증설 후에도 파드의 파일 시스템에 증설된 용량이 반영되지 않습니다.
+<a id="the-pods-file-system-does-not-reflect-the-increased-capacity-after-the-pv-capacity-is-increased"></a>
+### > PV 용량 증설 후에도 파드의 파일 시스템에 증설된 용량이 반영되지 않습니다. { #the-pods-file-system-does-not-reflect-the-increased-capacity-after-the-pv-capacity-is-increased }
 2024년 8월 이전에 생성된 1.20 이상 버전의 클러스터에서 발생할 수 있는 문제입니다. 아래 스크립트 실행을 통해 클러스터에 배포된 cinder-csi-driver를 업데이트하여 문제를 해결할 수 있습니다. 스크립트 실행 이후 새로 생성하거나 용량 증설된 PV에만 설정 업데이트가 반영됩니다.
 
 kubeconfig_file_path 변수에 클러스터의 kubeconfig 파일이 위치한 절대경로 값을 정의한 후 스크립트를 실행합니다.
@@ -296,12 +312,14 @@ kubectl -n kube-system rollout restart daemonet cinder-csi-nodeplugin
 kubectl -n kube-system rollout restart statefulset cinder-csi-controllerplugin
 ```
 
-### > timed out waiting for condition 오류가 발생하며 파드에 볼륨 마운트가 실패합니다.
+<a id="error-of-timed-out-waiting-for-condition-occurs-and-the-volume-mount-to-the-pod-fails"></a>
+### > timed out waiting for condition 오류가 발생하며 파드에 볼륨 마운트가 실패합니다. { #error-of-timed-out-waiting-for-condition-occurs-and-the-volume-mount-to-the-pod-fails }
 파드에 큰 사이즈의 볼륨을 마운트하는 경우 발생할 수 있는 문제입니다. 기본적으로 Kubernetes는 볼륨을 마운트할 때 파드의 SecurityContext에 지정된 fsGroup과 일치하도록 각 볼륨의 내용에 대한 소유 및 권한을 변경합니다. 볼륨이 큰 경우 소유 및 권한을 확인하고 변경하는 데 많은 시간이 소요되어 타임아웃이 발생할 수 있습니다. 
 
 타임아웃이 발생하는 것을 막기 위해 securityContext의 fsGroupChangePolicy 필드를 사용하여 Kubernetes가 볼륨에 대한 소유 및 권한을 확인하고 관리하는 방식을 변경할 수 있습니다. 자세한 내용은 [Configure volume permission and ownership change policy for pods](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#configure-volume-permission-and-ownership-change-policy-for-pods)를 참고하세요.
 
-### > Calico-eBPF CNI를 사용하는 클러스터의 파드에 hostnetwork: true, dnsPolicy: ClusterFirstWithHostNet 옵션을 설정하면 UDP 통신 문제가 발생합니다.
+<a id="setting-the-hostnetwork-true-dnspolicy-clusterfirstwithhostnet-option-on-a-pod-in-a-cluster-with-calico-ebpf-cni-causes-udp-communication-issues"></a>
+### > Calico-eBPF CNI를 사용하는 클러스터의 파드에 hostnetwork: true, dnsPolicy: ClusterFirstWithHostNet 옵션을 설정하면 UDP 통신 문제가 발생합니다. { #setting-the-hostnetwork-true-dnspolicy-clusterfirstwithhostnet-option-on-a-pod-in-a-cluster-with-calico-ebpf-cni-causes-udp-communication-issues }
 Calico v3.28.0에서 UDP 통신 중 BPF NAT 테이블이 네트워크 패킷을 올바르게 처리하지 못하여 발생하는 문제입니다. eBPF를 사용하는 경우 TCP는 `CTLB(connect-time load balancing)` 방식으로 통신하며 UDP는 BPF가 관리하는 `NAT 테이블`을 통해 통신합니다. 이 문제는 UDP 통신도 CTLB 방식으로 변경하면 해결할 수 있습니다.
 
 `CTLB(connect-time load balancing)`는 네트워크 로드 밸런싱 기술의 하나로 클라이언트가 서버에 처음 연결할 때 첫 번째 패킷에서 백엔드 서버를 선택하고 이후의 모든 트래픽은 선택된 백엔드 서버로 직접 전달됩니다. 이를 통해 세션 지속성이 보장되며, 매번 로드 밸런싱을 수행하는 오버헤드를 줄일 수 있습니다.
@@ -320,23 +338,28 @@ spec.template.spec.containers.env 항목에 아래와 같은 설정 추가가 �
     value: "Disabled"
 ```
 
+<a id="setting-the-hostnetwork-true-dnspolicy-clusterfirstwithhostnet-option-on-a-pod-in-a-cluster-with-calico-ebpf-cni-causes-udp-communication-issues-cautions-for-setting-up-udp-communication-after-applying-the-workaround"></a>
 #### 해결 방안 적용 후 UDP 통신 설정 시 주의 사항
 UDP는 비연결형 프로토콜로 서버/클라이언트 통신 시 별도 세션을 설정하거나 연결을 유지하지 않고 데이터를 전송합니다. 그러나 Golang `net.DialUDP()` 함수와 같은 UDP의 `connect()` 함수를 사용하면 UDP 소켓을 특정 주소와 연결해 지정된 주소로만 데이터를 전송하고 수신할 수 있습니다. 
 Calico의 eBPF를 사용하면 UDP에 CTLB(connect-time load balancing)가 활성화된 클러스터에 UD `connect()` 함수를 사용하는 파드를 배포한 경우 서버 역할을 하는 파드가 재배포되면 통신 문제가 발생할 수 있습니다. 이는 UDP 소켓이 초기 연결된 서버 주소에만 데이터 전송을 시도하기 때문입니다. 서버 파드가 재배포되면 IP 주소나 네트워크 경로가 변경될 수 있는데 UDP connect() 소켓은 이전 서버 주소에만 데이터를 보내므로 통신에 실패할 가능성이 있습니다.
 이 문제는 UDP connect()의 동작 방식과 CTLB 환경에서 발생하는 알려진 문제이므로 Calico eBPF와 UDP CTLB를 사용하는 클러스터에서 UDP의 connect() 함수를 사용할 경우 이러한 통신 문제가 발생할 수 있음을 인지하고 주의가 필요합니다.
 
-### > Calico-eBPF 클러스터에서 istio가 오동작합니다.
+<a id="istio-is-not-working-properly-in-a-calico-ebpf-cluster"></a>
+### > Calico-eBPF 클러스터에서 istio가 오동작합니다. { #istio-is-not-working-properly-in-a-calico-ebpf-cluster }
 eBPF가 활성화되면 `CTLB(connect-time load balancing)` 방식으로 연결 시점에 로드 밸런싱을 수행하여 클라이언트가 서비스에 연결을 시도할 때 첫 번째 패킷에서 백엔드 파드를 선택하고 이후의 모든 패킷은 해당 백엔드로 직접 전달됩니다. 한편, Istio는 서비스 메시를 구성하기 위해 사이드카 프록시를 배포하고 프록시는 애플리케이션 트래픽을 가로채 제어 및 모니터링 역할을 합니다. 
 CTLB가 활성화된 경우 패킷은 BPF MAP에서 목적지 Pod로 직접 전달되며 이 과정에서 패킷이 변조됩니다. 따라서 Istio의 프록시를 거치지 않고, 패킷이 바로 목적지 Pod로 전달됩니다. 이와 같은 eBPF 네트워킹 구조로 인해 Istio 기능이 정상적으로 동작하지 않을 수 있습니다. istio를 사용한 클러스터 관리가 필요한 경우 Calico-VXLAN 클러스터 사용을 고려해야 합니다.
 
 
-### > Calico-eBPF CNI를 사용하는 클러스터에서 노드 감축 후 증설 시 네트워크 장애가 발생합니다.
+<a id="in-a-cluster-using-calico-ebpf-cni-network-failures-occur-when-scaling-up-after-node-reduction"></a>
+### > Calico-eBPF CNI를 사용하는 클러스터에서 노드 감축 후 증설 시 네트워크 장애가 발생합니다. { #in-a-cluster-using-calico-ebpf-cni-network-failures-occur-when-scaling-up-after-node-reduction }
 Calico v3.28.0의 calico/kube-controllers에서 발견된 버그로 인해 발생하는 문제입니다. 노드 감축 진행 시 calico/kube-controllers 파드가 배포된 노드가 제거되면 해당 파드는 다른 노드로 스케줄링되어 실행됩니다. calico/kube-controllers가 재실행되는 동안 노드 정보가 동기화되지 않습니다. 이 상태에서 제거했던 노드와 동일한 이름의 노드가 추가되면 네트워크 장애가 발생할 수 있습니다.
 
 이 문제는 Calico v3.28.2에서 해결되었습니다. Calico v3.28.2를 사용하기 위해서는 Kubernetes 버전을 업그레이드하거나 클러스터를 다시 생성해야 합니다. 
 
-### > 클러스터 업그레이드에 실패합니다.
+<a id="failed-to-upgrade-clusters"></a>
+### > 클러스터 업그레이드에 실패합니다. { #failed-to-upgrade-clusters }
 
+<a id="failed-to-upgrade-clusters-when-creating-an-nks-check-whether-finalizers-are-set-on-the-resources-that-are-deployed-by-default"></a>
 #### NKS 생성 시 기본으로 배포되는 리소스에 finalizers 설정 여부를 확인해야 합니다.
 NKS 생성 시 배포된 리소스에 finalizers가 설정되어 있는 경우, 리소스가 제거되지 못하여 업그레이드에 실패합니다. 모든 워커 노드 그룹의 업그레이드가 완료되면 NKS 초기 배포 리소스가 재배포됩니다. 이 과정에서 NKS 초기 배포 리소스에 finalizers가 설정되어 있으면 리소스 재배포에 실패해 업그레이드가 중단됩니다. 이 문제를 해결하기 위해서는 업그레이드 전 NKS 초기 배포 리소스에 finalizers 설정을 제거해야 합니다.
 
@@ -350,17 +373,20 @@ kubectl patch clusterrole calico-kube-controllers --type=json -p='[{"op": "remov
 ```
 
 
-### > NKS 레지스트리가 비활성 상태인 v1.29.3 이하 버전 클러스터에서 노드 증설 혹은 노드 그룹 추가 시 calico-node 파드 배포에 실패하여 노드 초기화 작업에 실패합니다.
+<a id="when-scaling-out-nodes-or-adding-node-groups-in-a-cluster-running-v1293-or-earlier-with-an-inactive-nks-registry-the-calico-node-pod-deployment-fails-causing-the-node-initialization-task-to-fail"></a>
+### > NKS 레지스트리가 비활성 상태인 v1.29.3 이하 버전 클러스터에서 노드 증설 혹은 노드 그룹 추가 시 calico-node 파드 배포에 실패하여 노드 초기화 작업에 실패합니다. { #when-scaling-out-nodes-or-adding-node-groups-in-a-cluster-running-v1293-or-earlier-with-an-inactive-nks-registry-the-calico-node-pod-deployment-fails-causing-the-node-initialization-task-to-fail }
 잘못된 이미지 리포지터리 설정으로 인해 노드 증설 혹은 노드 그룹 추가 시 calico 관련 파드(calico-node, calico-kube-controllers, calico-typha)가 배포되지 않아 발생하는 문제입니다.
 
 이 문제는 주로 2024년 5월 이전에 생성된 클러스터에서 발생할 수 있습니다. 당시 생성된 클러스터는 NKS 전용 이미지 레지스트리가 기본적으로 비활성 상태이고, Calico 컨테이너 이미지의 리포지토리 경로가 올바르지 않아 이미지 다운로드가 불가능한 것이 원인입니다.
 
+<a id="when-scaling-out-nodes-or-adding-node-groups-in-a-cluster-running-v1293-or-earlier-with-an-inactive-nks-registry-the-calico-node-pod-deployment-fails-causing-the-node-initialization-task-to-fail-how-to-check-if-the-symptom-occurs"></a>
 #### 증상 발생 시 확인 방법
 `kubectl get all -n kube-system` 명령 확인 시 증설 작업에 실패한 노드에 배포되어 있는 아래 파드의 상태가 **ImagePullBackOff** 또는 **ErrImagePull**로 유지됩니다.
 - calico-node
 - calico-kube-controllers
 - calico-typha
 
+<a id="when-scaling-out-nodes-or-adding-node-groups-in-a-cluster-running-v1293-or-earlier-with-an-inactive-nks-registry-the-calico-node-pod-deployment-fails-causing-the-node-initialization-task-to-fail-solution"></a>
 #### 해결 방안
 calico 관련 image 리포지터리 url을 public 리포지터리로 변경하여 문제를 해결할 수 있습니다. 단, 인터넷에 연결 가능한 클러스터에만 적용 가능합니다. 작업 진행 중 일시적으로 클러스터 파드 네트워킹이 단절될 수 있으므로 작업 진행 시 주의가 필요합니다. 작업 단계는 아래와 같습니다.
 

--- a/ko/user-guide.md
+++ b/ko/user-guide.md
@@ -1,11 +1,12 @@
-## Container > NHN Kubernetes Service(NKS) > 사용 가이드
+<a id="container-nhn-kubernetes-service-nks-user-guide"></a>
+## Container > NHN Kubernetes Service(NKS) > 사용 가이드 { #container-nhn-kubernetes-service-nks-user-guide }
 
 <a id="cluster-headings"></a>
-## 클러스터
+## 클러스터 { #cluster-headings }
 클러스터는 사용자의 Kubernetes를 구성하는 인스턴스들의 그룹입니다.
 
 <a id="cluster-create"></a>
-### 클러스터 생성
+### 클러스터 생성 { #cluster-create }
 NHN Kubernetes Service(NKS)를 사용하려면 먼저 클러스터를 생성해야 합니다.
 
 > [주의] 클러스터 사용을 위한 권한 설정<br>
@@ -81,7 +82,7 @@ NHN Kubernetes Service(NKS)를 사용하려면 먼저 클러스터를 생성해�
 >  - 계산 : 254(각 노드당 파드에 할당 가능한 최대 IP 수) * 253(최대 생성 가능한 노드 수) = 최대 64,262개 IP 사용 가능
 
 <a id="cluster-show"></a>
-### 클러스터 조회
+### 클러스터 조회 { #cluster-show }
 생성한 클러스터는 **Container > NHN Kubernetes Service(NKS)** 페이지에서 확인할 수 있습니다. 클러스터 목록에는 각 클러스터에 대한 간략한 정보가 나타납니다.
 
 | 항목 | 설명 |
@@ -137,11 +138,11 @@ k8s Node 상태의 아이콘별 의미는 다음과 같습니다.
 | 설정 파일 | 클러스터에 접근해 조작하기 위해 필요한 설정 파일 다운로드 버튼 |
 
 <a id="cluster-delete"></a>
-### 클러스터 삭제
+### 클러스터 삭제 { #cluster-delete }
 삭제할 클러스터를 선택하고 **클러스터 삭제**를 클릭하면 삭제가 진행됩니다. 삭제하는 데는 약 5분 정도 걸립니다. 클러스터의 상태에 따라 더 오래 걸릴 수도 있습니다.
 
 <a id="change-keypair"></a>
-### 클러스터 키페어 변경
+### 클러스터 키페어 변경 { #change-keypair }
 
 클러스터에 속한 모든 워커 노드의 키페어를 변경합니다. 설정할 키페어는 로그인한 사용자의 키페어 중 하나를 선택합니다. 키페어를 변경하면 아래 내용이 적용됩니다.
 
@@ -156,11 +157,11 @@ k8s Node 상태의 아이콘별 의미는 다음과 같습니다.
 > * 클러스터 오너 변경 기능은 더 이상 제공되지 않습니다. 클러스터가 서비스 사용자의 권한으로 동작할 수 있도록 하려면 키페어 변경 기능을 이용하세요.
 
 <a id="nodegroup-headings"></a>
-## 노드 그룹
+## 노드 그룹 { #nodegroup-headings }
 노드 그룹은 Kubernetes를 구성하는 워커 노드 인스턴스들의 그룹입니다.
 
 <a id="nodegroup-show"></a>
-### 노드 그룹 조회
+### 노드 그룹 조회 { #nodegroup-show }
 클러스터 목록에서 클러스터 이름을 클릭하면 노드 그룹 목록을 확인할 수 있습니다. 노드 그룹 목록에는 각 노드 그룹에 대한 간략한 정보가 나타납니다.
 
 | 항목 | 설명 |
@@ -212,7 +213,7 @@ k8s Node 상태의 아이콘별 의미는 다음과 같습니다.
 **노드 목록** 탭에서는 노드 그룹을 구성하는 인스턴스의 목록을 확인할 수 있습니다.
 
 <a id="nodegroup-create"></a>
-### 노드 그룹 생성
+### 노드 그룹 생성 { #nodegroup-create }
 클러스터를 생성하면 기본 노드 그룹이 생성되지만, 필요에 따라 추가 노드 그룹을 만들 수 있습니다. 기본 노드 그룹의 인스턴스보다 높은 사양의 컨테이너 구동 환경이 필요하거나, 스케일 아웃(scale out, 확장)을 위해 더 많은 워커 노드 인스턴스가 필요한 경우 추가 노드 그룹을 생성해 사용할 수 있습니다. 노드 그룹 목록 페이지에서 **노드 그룹 생성** 버튼을 클릭하면 노드 그룹 생성 페이지가 나타납니다. 노드 그룹 생성에 필요한 항목은 다음과 같습니다.
 
 | 항목 | 설명 |
@@ -232,7 +233,7 @@ k8s Node 상태의 아이콘별 의미는 다음과 같습니다.
 >해당 클러스터를 생성한 사용자만 노드 그룹 생성이 가능합니다.
 
 <a id="nodegroup-delete"></a>
-### 노드 그룹 삭제
+### 노드 그룹 삭제 { #nodegroup-delete }
 노드 그룹 목록에서 삭제하려는 노드 그룹을 선택하고 **노드 그룹 삭제** 버튼을 클릭하면 삭제가 진행됩니다. 노드 그룹 삭제하는 데는 약 5분 정도 걸립니다. 노드 그룹의 상태에 따라 더 오래 걸릴 수도 있습니다.
 
 노드 그룹에 포함되는 모든 노드는 다음의 순서로 삭제됩니다.
@@ -242,14 +243,14 @@ k8s Node 상태의 아이콘별 의미는 다음과 같습니다.
 * 해당 노드가 인스턴스 수준에서 삭제됩니다.
 
 <a id="nodegroup-scale-out"></a>
-### 노드 그룹에 노드 추가
+### 노드 그룹에 노드 추가 { #nodegroup-scale-out }
 동작 중인 노드 그룹에 노드를 추가할 수 있습니다. 노드 그룹 정보 조회 페이지의 노드 목록 탭을 클릭하면 현재 노드 목록이 나타납니다. 노드 추가 버튼을 클릭하고 노드 수를 입력하면 노드가 추가됩니다.
 
 >[주의]
 >오토스케일러가 활성화된 노드 그룹은 수동으로 노드를 추가할 수 없습니다.
 
 <a id="nodegroup-scale-in"></a>
-### 노드 그룹에서 노드 삭제
+### 노드 그룹에서 노드 삭제 { #nodegroup-scale-in }
 동작 중인 노드 그룹에서 노드를 삭제할 수 있습니다. 노드 그룹 정보 조회 페이지의 노드 목록 탭을 클릭하면 현재 노드 목록이 나타납니다. 노드 목록 중 삭제할 노드를 선택하고 노드 삭제 버튼을 클릭하면 확인 대화 상자가 나타납니다. 삭제할 노드 이름을 다시 한번 확인하고 확인 버튼을 클릭하면 노드가 삭제됩니다.
 
 노드 그룹에 포함되는 모든 노드는 다음의 순서로 삭제됩니다.
@@ -262,9 +263,10 @@ k8s Node 상태의 아이콘별 의미는 다음과 같습니다.
 >오토스케일러가 활성화된 노드 그룹은 수동으로 노드를 삭제할 수 없습니다.
 
 <a id="node-start-stop"></a>
-### 노드 중지와 시작
+### 노드 중지와 시작 { #node-start-stop }
 노드 그룹에 속한 노드 중 일부를 중지시키고, 중지된 노드를 다시 시작할 수 있습니다. 노드 그룹 정보 조회 페이지의 노드 목록 탭을 클릭하면 현재 노드 목록이 나타납니다. 중지할 노드를 선택하고 노드 중지 버튼을 클릭하면 노드가 중지됩니다. 중지된 노드를 선택하고 노드 시작 버튼을 클릭하면 노드가 다시 시작됩니다.
 
+<a id="node-start-stop-action-process"></a>
 #### 동작 과정
 
 시작 상태의 노드를 중지하면 다음의 순서로 동작합니다.
@@ -280,6 +282,7 @@ k8s Node 상태의 아이콘별 의미는 다음과 같습니다.
 * 해당 노드가 Kubernetes 노드 자원에 다시 추가됩니다.
 
 
+<a id="node-start-stop-constraints"></a>
 #### 제약 사항
 
 노드 중지와 시작 기능은 다음의 제약 사항이 있습니다.
@@ -291,6 +294,7 @@ k8s Node 상태의 아이콘별 의미는 다음과 같습니다.
 * 중지된 노드가 존재하는 노드 그룹은 업그레이드를 할 수 없습니다.
 
 
+<a id="node-start-stop-display-status"></a>
 #### 상태 표시
 
 노드의 상태에 따라 노드 목록 탭의 상태 아이콘이 표시됩니다. 아이콘 색상별 상태는 다음과 같습니다.
@@ -300,7 +304,7 @@ k8s Node 상태의 아이콘별 의미는 다음과 같습니다.
 * 빨간색: 비정상 상태의 노드
 
 <a id="use-gpu-nodegroup"></a>
-### GPU 노드 그룹 사용 
+### GPU 노드 그룹 사용 { #use-gpu-nodegroup }
 Kubernetes를 통한 GPU 기반 워크로드 실행이 필요한 경우, GPU 인스턴스로 구성된 노드 그룹을 생성할 수 있습니다.
 클러스터 혹은 노드 그룹 생성 과정에서 인스턴스 타입 선택 시, `g2` 타입을 선택하면 GPU 노드 그룹을 만들 수 있습니다.
 
@@ -310,6 +314,7 @@ Kubernetes를 통한 GPU 기반 워크로드 실행이 필요한 경우, GPU 인
 
 생성된 GPU 노드에 대한 기본적인 설정 상태 확인 및 간단한 동작 테스트는 다음과 같은 방법을 이용하면 됩니다.
 
+<a id="use-gpu-nodegroup-node-level-status-check"></a>
 #### 노드 수준의 상태 확인
 GPU 노드에 접속한 후, `nvidia-smi` 명령을 실행합니다.
 다음과 같은 내용이 출력되면 GPU driver가 정상적으로 동작하는 것입니다.
@@ -335,6 +340,7 @@ Mon Jul 27 14:38:07 2020
 +-----------------------------------------------------------------------------+ 
 ```
 
+<a id="use-gpu-nodegroup-kubernetes-level-status-check"></a>
 #### Kubernetes 수준의 상태 확인
 `kubectl` 명령을 사용해 클러스터 수준에서 사용 가능한 GPU 리소스 정보를 확인합니다.
 아래는 각 노드에서 사용 가능한 GPU 코어의 개수를 출력하도록 하는 명령 및 수행 결과입니다.
@@ -345,6 +351,7 @@ NAME                                       GPU Allocatable   GPU Capacity
 my-cluster-default-w-vdqxpwisjjsk-node-1   1                 1
 ```
 
+<a id="use-gpu-nodegroup-sample-workload-execution-for-gpu-testing"></a>
 #### GPU 테스트를 위한 샘플 워크로드 실행
 Kubernetes 클러스터에 속한 GPU 노드들은 CPU와 메모리 이외에 `nvidia.com/gpu`와 같은 이름의 리소스를 제공합니다.
 GPU를 사용하고 싶다면 `nvidia.com/gpu` 리소스를 할당받도록 아래의 샘플 파일처럼 입력하면 됩니다.
@@ -419,7 +426,7 @@ totalMemory: 14.73GiB freeMemory: 14.62GiB
 > GPU가 필요없는 워크로드가 GPU 노드에 할당되는 것을 막고 싶다면 [Taint 및 Toleration 개요](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/)를 참고하세요.
 
 <a id="autoscaler"></a>
-### 오토스케일러
+### 오토스케일러 { #autoscaler }
 오토스케일러는 노드 그룹의 가용 리소스가 부족하거나 노드의 사용률이 일정 수준 이하로 유지되는 경우 노드의 수를 자동으로 조정하는 기능입니다. 이 기능은 노드 그룹별로 설정할 수 있고, 서로 독립적으로 동작합니다. NKS에서는 두 가지 방식의 오토스케일러를 지원합니다.
 
 * 지표 기반 오토스케일러
@@ -1019,7 +1026,7 @@ autoscaler-test-default-w-ohw5ab5wpzug-node-0   Ready    <none>   22d   v1.28.3
 ```
 
 <a id="user-script-old"></a>
-### 사용자 스크립트(old)
+### 사용자 스크립트(old) { #user-script-old }
 클러스터를 생성할 때와 추가 노드 그룹을 생성할 때, 사용자 스크립트를 등록할 수 있습니다. 사용자 스크립트 기능에는 다음과 같은 특징이 있습니다.
 
 * 기능 설정
@@ -1039,7 +1046,7 @@ autoscaler-test-default-w-ohw5ab5wpzug-node-0   Ready    <none>   22d   v1.28.3
         * 스크립트 표준 출력 및 표준 에러 스트림: `/var/log/userscript.output`
 
 <a id="user-script"></a>
-### 사용자 스크립트
+### 사용자 스크립트 { #user-script }
 2022년 7월 26일 이후에 생성되는 노드 그룹에는 새로운 버전의 사용자 스크립트 기능이 탑재됩니다. 이전 버전의 기능에 비해 다음과 같은 특징이 있습니다.
 
 * **워커 노드 그룹이 생성된 후에도 사용자 스크립트의 내용을 변경할 수 있습니다.**
@@ -1059,10 +1066,11 @@ autoscaler-test-default-w-ohw5ab5wpzug-node-0   Ready    <none>   22d   v1.28.3
         2. 신규 버전의 사용자 스크립트
 
 <a id="instance-flavor-update"></a>
-### 인스턴스 타입 변경
+### 인스턴스 타입 변경 { #instance-flavor-update }
 워커 노드 그룹의 인스턴스 타입을 변경합니다. 워커 노드 그룹에 속한 모든 워커 노드의 인스턴스 타입이 변경됩니다.
 
 
+<a id="instance-flavor-update-process"></a>
 #### 진행 과정
 
 인스턴스 타입 변경은 다음 순서로 진행됩니다.
@@ -1079,6 +1087,7 @@ autoscaler-test-default-w-ohw5ab5wpzug-node-0   Ready    <none>   22d   v1.28.3
 인스턴스 타입 변경은 워커 구성 요소 업그레이드와 유사한 방법으로 진행됩니다. 버퍼 노드의 생성과 삭제, 파드의 축출에 대해서는 [클러스터 업그레이드](/Container/NKS/ko/user-guide/#cluster-upgrade)를 참고하세요.
 
 
+<a id="instance-flavor-update-constraints"></a>
 #### 제약 사항
 
 인스턴스의 현재 타입에 따라 변경할 수 있는 타입이 다릅니다.
@@ -1088,7 +1097,7 @@ autoscaler-test-default-w-ohw5ab5wpzug-node-0   Ready    <none>   22d   v1.28.3
 * u2 타입의 인스턴스는 생성 이후에 타입을 변경할 수 없습니다. 같은 u2 타입으로의 변경도 불가합니다.
 
 <a id="custom-image"></a>
-### 커스텀 이미지를 워커 이미지로 활용
+### 커스텀 이미지를 워커 이미지로 활용 { #custom-image }
 
 사용자의 커스텀 이미지를 기반으로 한 워커 노드 그룹을 생성할 수 있습니다. 커스텀 이미지가 워커 노드 이미지로 활용될 수 있도록 NHN Cloud Image Builder 서비스에서 추가적인 작업(NKS 워커 노드화)이 필요합니다. Image Builder 서비스에서 NHN Kubernetes Service(NKS) 워커 노드 애플리케이션으로 이미지 템플릿을 생성하여 커스텀 워커 노드 이미지를 생성할 수 있습니다. Image Builder 서비스에 대한 자세한 내용은 [Image Builder 사용자 가이드](/Compute/Image%20Builder/ko/console-guide/#_1)를 참고하세요.
 
@@ -1096,6 +1105,7 @@ autoscaler-test-default-w-ohw5ab5wpzug-node-0   Ready    <none>   22d   v1.28.3
 > NKS 워커 노드화 작업에는 패키지 설치 및 설정 변경 등이 포함되어 있어 정상적으로 동작하지 않는 이미지로 작업을 진행하는 경우 실패할 수 있습니다.
 > Image Builder 서비스 사용에 대해 과금될 수 있습니다.
 
+<a id="custom-image-constraints"></a>
 #### 제약 사항
 지원되는 OS 이미지 및 OS 이미지별로 선택해야 하는 애플리케이션 버전 정보는 아래 표와 같습니다. 커스텀 이미지를 생성하는 기반 인스턴스의 이미지에 맞춰 올바른 버전의 애플리케이션을 선택해야 합니다.
 
@@ -1121,6 +1131,7 @@ autoscaler-test-default-w-ohw5ab5wpzug-node-0   Ready    <none>   22d   v1.28.3
 > 커스텀 이미지를 워커 노드 이미지로 변환하는 과정에서 선택한 옵션에 따라 GPU 드라이버가 설치됩니다.
 > 따라서 커스텀 GPU 워커 노드 이미지를 생성하는 경우에도 커스텀 이미지 생성을 GPU 인스턴스로 할 필요가 없습니다.
 
+<a id="custom-image-process"></a>
 #### 진행 과정
 
 커스텀 이미지를 워커 노드 이미지로 활용하기 위해서 Image Builder 서비스에서 아래와 같은 과정을 수행합니다.
@@ -1142,7 +1153,7 @@ autoscaler-test-default-w-ohw5ab5wpzug-node-0   Ready    <none>   22d   v1.28.3
 ![nkscustom_image_3.png](http://static.toastoven.net/prod_infrastructure/container/kubernetes/nkscustom_image_3.png)
 
 <a id="extra-volumes"></a>
-### 추가 블록 스토리지
+### 추가 블록 스토리지 { #extra-volumes }
 노드 그룹에 추가 블록 스토리지를 사용할 수 있습니다. 클러스터 및 노드 그룹 생성 시 추가 블록 스토리지를 지정하여 생성하거나, 기존의 노드 그룹에 추가 블록 스토리지를 생성하여 사용할 수 있습니다. 추가 블록 스토리지는 다음과 같은 특징을 가집니다.
 
 * 추가 블록 스토리지는 노드 그룹당 최대 3개까지 설정할 수 있으며, 블록 스토리지의 크기는 1~2048GB 범위에서 지정 가능합니다.
@@ -1160,7 +1171,7 @@ autoscaler-test-default-w-ohw5ab5wpzug-node-0   Ready    <none>   22d   v1.28.3
 > 추가 블록 스토리지의 설정 변경은 기존 볼륨의 마운트 해제를 포함하므로 사용 중인 서비스에 영향을 미칠 수 있습니다.
 
 <a id="extra-security-groups"></a>
-### 추가 보안 그룹
+### 추가 보안 그룹 { #extra-security-groups }
 노드 그룹에 추가 보안 그룹을 설정할 수 있습니다. 클러스터 및 노드 그룹 생성 시 추가 보안 그룹을 지정하여 생성하거나, 기존의 노드 그룹에 추가 보안 그룹을 설정할 수 있습니다. 추가 보안 그룹의 특징은 다음과 같습니다.
 
 * 추가 보안 그룹은 서브넷당 최대 8개까지 설정할 수 있습니다.
@@ -1176,7 +1187,7 @@ autoscaler-test-default-w-ohw5ab5wpzug-node-0   Ready    <none>   22d   v1.28.3
 > 추가 보안 그룹 변경 시 네트워크 설정이 변경되므로 설정이 적용되는 동안 일시적으로 통신에 영향이 있을 수 있습니다.
 
 <a id="fip-auto-bind"></a>
-### 플로팅 IP 자동 할당
+### 플로팅 IP 자동 할당 { #fip-auto-bind }
 노드 그룹에 플로팅 IP 자동 할당 기능을 사용할 수 있습니다. 기능이 활성화된 노드 그룹은 노드 생성 시 플로팅 IP를 자동으로 할당합니다. 클러스터 및 추가 노드 그룹 생성 시 기능 활성화 여부를 선택할 수 있으며, 설정한 옵션은 이후에 변경할 수 있습니다. 플로팅 IP 자동 할당 기능을 활성화하기 위해 필요한 항목은 다음과 같습니다.
 
 | 항목 | 설명 | 
@@ -1194,11 +1205,11 @@ autoscaler-test-default-w-ohw5ab5wpzug-node-0   Ready    <none>   22d   v1.28.3
   * 기능이 활성화된 노드 그룹에서 기능을 비활성화하더라도 기존 노드에 할당된 플로팅 IP는 해제되지 않습니다.
 
 <a id="cluster-management"></a>
-## 클러스터 관리
+## 클러스터 관리 { #cluster-management }
 원격의 호스트에서 클러스터를 조작하고 관리하려면 Kubernetes가 제공하는 명령줄 도구(CLI)인 `kubectl`이 필요합니다.
 
 <a id="kubectl-install"></a>
-### kubectl 설치
+### kubectl 설치 { #kubectl-install }
 kubectl은 특별한 설치 과정 없이 실행 파일을 다운로드해 바로 사용할 수 있습니다. 운영체제별 다운로드 경로는 다음과 같습니다.
 
 > [주의]
@@ -1212,6 +1223,7 @@ kubectl은 특별한 설치 과정 없이 실행 파일을 다운로드해 바�
 
 그 외 설치 방법과 옵션 등 자세한 사항은 [Install and Set Up kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/) 문서를 참고하세요.
 
+<a id="kubectl-install-change-permission"></a>
 #### 권한 변경
 다운로드한 파일은 기본적으로 실행 권한이 없습니다. 실행 권한을 추가해야 합니다.
 
@@ -1219,6 +1231,7 @@ kubectl은 특별한 설치 과정 없이 실행 파일을 다운로드해 바�
 $ chmod +x kubectl
 ```
 
+<a id="kubectl-install-change-the-location-or-set-the-path"></a>
 #### 위치 변경 또는 경로 지정
 어느 경로에서든 kubectl을 실행할 수 있도록 환경 변수에 지정된 경로로 옮기거나, kubectl이 있는 경로를 환경 변수에 추가합니다.
 
@@ -1234,7 +1247,7 @@ $ export PATH=$PATH:$(pwd)
 ```
 
 <a id="kubectl-set-kubeconfig"></a>
-### 설정
+### 설정 { #kubectl-set-kubeconfig }
 kubectl로 Kubernetes 클러스터에 접근하려면 클러스터 설정 파일(kubeconfig)이 필요합니다. NHN Cloud 웹 콘솔에서 **Container > NHN Kubernetes Service(NKS)** 페이지를 열고 접근할 클러스터를 선택합니다. 하단 **기본 정보** 탭에서 **설정 파일** 항목의 **다운로드** 버튼을 클릭해 설정 파일을 다운로드합니다. 다운로드한 설정 파일은 원하는 위치로 옮겨 kubectl 실행 시 참조할 수 있도록 준비합니다.
 
 > [주의]
@@ -1249,7 +1262,7 @@ $ export KUBECONFIG={클러스터 설정 파일 경로}
 클러스터 설정 파일 경로를 환경 변수에 저장하고 싶지 않다면 kubectl의 기본 설정 파일인 `$HOME/.kube/config`로 복사해 사용할 수도 있습니다. 그러나 클러스터를 여러 개 운영한다면 환경 변숫값을 변경하는 방법이 편리합니다.
 
 <a id="kubectl-check-connection"></a>
-### 연결 확인
+### 연결 확인 { #kubectl-check-connection }
 `kubectl version` 명령어로 정상 설정되었는지 확인합니다. 문제가 없다면 `Server Version`이 출력됩니다.
 
 ```
@@ -1262,9 +1275,10 @@ Server Version: version.Info{Major:"1", Minor:"15", GitVersion:"v1.15.7", GitCom
 * Server Version: 클러스터를 구성하고 있는 Kubernetes 버전 정보
 
 <a id="certificatesigningrequest"></a>
-### CSR(CertificateSigningRequest)
+### CSR(CertificateSigningRequest) { #certificatesigningrequest }
 Kubernetes의 인증 API(Certificate API)를 통해 Kubernetes API 클라이언트를 위한 X.509 인증서(certificate)를 요청하고 발급할 수 있습니다. CSR 자원은 인증서를 요청하고, 요청에 대해 승인/거부를 결정할 수 있도록 합니다. 자세한 사항은 [Certificate Signing Requests](https://kubernetes.io/docs/reference/access-authn-authz/certificate-signing-requests/) 문서를 참고하세요.
 
+<a id="certificatesigningrequest-csr-request-and-issue-approval-example"></a>
 #### CSR 요청과 발급 승인 예제
 먼저 개인 키(private key)를 생성합니다. 인증서 생성에 관한 자세한 내용은 [Certificates](https://kubernetes.io/docs/tasks/administer-cluster/certificates/) 문서를 참고하세요.
 
@@ -1365,11 +1379,12 @@ status:
 > * 평촌 리전: 2020년 12월 24일 이후에 생성한 클러스터
 
 <a id="admission-controller"></a>
-### 승인 컨트롤러(admission controller) 플러그인
+### 승인 컨트롤러(admission controller) 플러그인 { #admission-controller }
 승인 컨트롤러는 Kubernetes API 서버 요청을 가로채 객체를 변경하거나 요청을 거부할 수 있습니다. 승인 컨트롤러에 대한 자세한 설명은 [승인 컨트롤러](https://kubernetes.io/docs/reference/access-authn-authz/admission-controllers/)를 참고하세요. 그리고 승인 컨트롤러의 사용 예제는 [승인 컨트롤러 가이드](https://kubernetes.io/blog/2019/03/21/a-guide-to-kubernetes-admission-controllers/)를 참고하세요.
 
 클러스터 버전과 클러스터 생성 시점에 따라 승인 컨트롤러에 적용되는 플러그인의 종류가 다릅니다. 자세한 내용은 리전별 생성 시점에 따른 플러그인 목록을 참고하세요.
 
+<a id="admission-controller-v11913-or-earlier"></a>
 #### v1.19.13 이전 버전
 판교 리전 2021년 2월 22일 이전에 생성한 클러스터 및 평촌 리전 2021년 2월 17일 이전에 생성한 클러스터는 다음과 같이 적용됩니다.
 
@@ -1396,6 +1411,7 @@ status:
 * ServiceAccount
 * ValidatingAdmissionWebhook
 
+<a id="admission-controller-v12012-or-later"></a>
 #### v1.20.12 이후 버전
 Kubernetes 버전별 기본 활성 승인 컨트롤러는 모두 활성화됩니다. 기본 활성 승인 컨트롤러에 아래의 컨트롤러가 추가 활성화됩니다.
 
@@ -1403,9 +1419,10 @@ Kubernetes 버전별 기본 활성 승인 컨트롤러는 모두 활성화됩니
 * PodSecurityPolicy
 
 <a id="cluster-upgrade"></a>
-### 클러스터 업그레이드
+### 클러스터 업그레이드 { #cluster-upgrade }
 NHN Kubernetes Service(NKS)는 동작 중인 Kubernetes 클러스터의 Kubernetes 구성 요소 업그레이드를 지원합니다. 
 
+<a id="cluster-upgrade-policy-of-supporting-different-kubernetes-versions"></a>
 #### Kubernetes 버전 차이 지원 정책
 Kubernetes 버전은 `x.y.z`로 표현됩니다. `x`는 메이저 버전, `y`는 마이너 버전, `z`는 패치 버전입니다. 기능이 추가되면 메이저 버전 혹은 마이너 버전을 올리고, 버그 수정과 같이 이전 버전과 호환되는 기능을 제공하면 패치 버전을 올립니다. 좀 더 자세한 내용은 [Semantic Versioning 2.0.0](https://semver.org/)을 참고하세요.
 
@@ -1413,6 +1430,7 @@ Kubernetes 클러스터는 동작 중인 상태에서 Kubernetes 구성 요소�
 
 <br>
 
+<a id="cluster-upgrade-manage-nks-cluster-version"></a>
 #### NKS 클러스터의 버전 관리
 NKS 클러스터는 클러스터 컨트롤 플레인과 워커 노드 그룹별로 Kubernetes 버전과 플랫폼 버전을 관리합니다. Kubernetes 버전과 플랫폼 버전은 다음과 같은 차이가 있습니다.
 
@@ -1448,6 +1466,7 @@ NKS 클러스터는 클러스터 컨트롤 플레인과 워커 노드 그룹별�
 
 <br>
 
+<a id="cluster-upgrade-upgrade-rules"></a>
 #### 업그레이드 규칙
 NKS 클러스터 버전 관리 방식과 Kubernetes 버전 차이 지원 정책에 의해 구성 요소별로 순서에 맞게 업그레이드해야 합니다. NKS 클러스터 업그레이드 기능에 적용되는 규칙은 다음과 같습니다.
 
@@ -1484,6 +1503,7 @@ NKS 클러스터 버전 관리 방식과 Kubernetes 버전 차이 지원 정책�
 
 <br>
 
+<a id="cluster-upgrade-considerations-for-etcd-version-changes"></a>
 #### etcd 버전 변경에 따른 주의 사항
 클러스터 업그레이드 작업 진행 시, 업그레이드 대상 플랫폼 버전에 정의된 [etcd 버전](/Container/NKS/ko/user-guide/#platform-version-etcd-version)이 현재 클러스터의 etcd 버전과 다른 경우에 한해 etcd 업그레이드 작업이 함께 진행됩니다. 해당 작업을 시작하기 전에 주의 사항을 반드시 인지하고 사전 공지/점검 시간 확보 등의 조치를 권장합니다.
 
@@ -1498,6 +1518,7 @@ etcd 업그레이드가 실패하면 클러스터를 이전 상태로 되돌리�
 
 <br>
 
+<a id="cluster-upgrade-upgrade-strategy"></a>
 #### 업그레이드 전략
 NKS 클러스터는 Rolling Upgrade, Blue/Green Upgrade 2가지 방식의 업그레이드 전략을 제공합니다. 사용자는 운영 정책에 따라 적절한 전략을 선택하여 클러스터를 업그레이드할 수 있습니다.
 
@@ -1578,10 +1599,11 @@ NKS 클러스터 컨트롤 플레인은 고가용성을 보장합니다. 컨트�
 Blue 환경의 리소스를 모두 폐기하면 컨트롤 플레인과 모든 워커 노드 그룹의 버전이 모두 일치하게 됩니다.
 
 <a id="api-endpoint-ipacl"></a>
-### 클러스터 API 엔드포인트 IP 접근 제어 적용
+### 클러스터 API 엔드포인트 IP 접근 제어 적용 { #api-endpoint-ipacl }
 클러스터 API 엔드포인트에 IP 접근 제어를 적용하거나 해제할 수 있습니다.
 IP 접근 제어 기능에 대한 자세한 사항은 [IP 접근제어](/Network/Load%20Balancer/ko/overview/#ip) 문서를 참고하세요.
 
+<a id="api-endpoint-ipacl-ip-access-control-rules"></a>
 #### IP 접근 제어 대상 규칙
 클러스터 API 엔드포인트 IP 접근 제어 대상을 추가하는 경우 아래의 규칙이 적용됩니다.
 
@@ -1592,7 +1614,7 @@ IP 접근 제어 기능에 대한 자세한 사항은 [IP 접근제어](/Network
 * IP 접근 제어 대상은 1개 이상 존재해야 합니다.
 
 <a id="rotate-certificate"></a>
-### 클러스터 인증서 갱신
+### 클러스터 인증서 갱신 { #rotate-certificate }
 Kubernetes는 구성 요소 간의 TLS 인증을 위해 PKI 인증서가 필요합니다. PKI 인증서에 대한 자세한 내용은 [PKI 인증서 및 요구 사항](https://kubernetes.io/ko/docs/setup/best-practices/certificates/)을 참고하세요. NKS 클러스터를 생성하는 경우 클러스터에 필요한 인증서를 자동으로 생성하며, 이 인증서의 기본 유효기간은 5년으로 설정되어 있습니다.
 
 인증서의 유효기간이 만료되면 API 서버, 컨트롤러 매니저, etcd 등 클러스터의 주요 구성 요소들이 동작하지 않게 되어 클러스터를 사용할 수 없습니다.
@@ -1626,7 +1648,7 @@ Kubernetes는 구성 요소 간의 TLS 인증을 위해 PKI 인증서가 필요�
 > 이러한 작업 영향도를 최소화하려면 인증서 갱신 작업이 진행되는 동안에는 신규 파드 생성 등의 작업을 수행하지 않아야 합니다.
 
 <a id="k8s-component"></a>
-### Kubernetes 컴포넌트 설정 기능
+### Kubernetes 컴포넌트 설정 기능 { #k8s-component }
 
 Kubernetes 컴포넌트의 여러 가지 옵션을 설정할 수 있습니다. 클러스터 생성 시 설정할 수 있으며, 설정한 옵션은 클러스터 생성 완료 후에 변경할 수도 있습니다. 
 
@@ -1637,7 +1659,8 @@ Kubernetes 컴포넌트의 여러 가지 옵션을 설정할 수 있습니다. �
 > * 워커 노드에서 동작하는 컴포넌트의 설정을 변경한 경우 워커 노드의 컴포넌트가 재시작됩니다.
 > * 워커 노드에서 동작하는 컴포넌트의 설정은 워커 노드 그룹별로 설정할 수 있습니다.(플랫폼 버전 1.202602.0 이후 버전에 한함)
 
-### 컨트롤 플레인 옵션
+<a id="control-plain-options"></a>
+### 컨트롤 플레인 옵션 { #control-plain-options }
 
 | 컴포넌트 | 옵션 | 설명 |
 | --- | --- | --- |
@@ -1646,7 +1669,8 @@ Kubernetes 컴포넌트의 여러 가지 옵션을 설정할 수 있습니다. �
 | kube-controller-manager | node-monitor-grace-period | 노드가 비정상 상태일 때 해당 노드를 비정상으로 간주하기까지 기다리는 시간을 정의합니다.<br>(단위: 초, 기본값: 40, 최솟값: 0, 최댓값: 86400) |
 | kube-controller-manager | unhealthy-zone-threshold | 가용 영역(zone)을 비정상으로 간주하는 NotReady 노드 비율의 임계값을 정의합니다.<br>(단위: 백분율, 기본값: 55, 최솟값: 0, 최댓값: 100) |
 
-### 워커 노드 옵션
+<a id="worker-node-options"></a>
+### 워커 노드 옵션 { #worker-node-options }
 
 | 컴포넌트 | 옵션 | 설명 |
 | --- | --- | --- |
@@ -1654,12 +1678,13 @@ Kubernetes 컴포넌트의 여러 가지 옵션을 설정할 수 있습니다. �
 | kubelet | max-pods | 노드에서 실행 가능한 최대 파드 개수를 정의합니다.<br>(기본값: 110, 최솟값: 1, 최댓값: 파드 네트워크 및 서브넷 크기 설정에 따라 계산된 최대 생성 가능 파드 IP 수)<br>플랫폼 버전 1.202602.0 이후 버전에서 지원합니다. |
 
 <a id="k8s-label"></a>
-### Kubernetes 레이블 설정 기능
+### Kubernetes 레이블 설정 기능 { #k8s-label }
 노드 그룹마다 Kubernetes 레이블 설정 기능을 사용할 수 있습니다. 이 기능을 통해 레이블이 설정된 노드 그룹은 노드 생성 시 사용자가 설정한 레이블을 자동으로 추가합니다. 레이블은 파드, 노드와 같은 오브젝트에 첨부된 키와 값의 쌍으로 오브젝트의 특성을 식별하는 데 사용됩니다. 레이블에 대한 자세한 설명은 [Labels and Selectors](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/)를 참고하세요.
 
 
 Kubernetes 레이블은 키와 값의 쌍으로 이루어지며, 유효한 레이블 키와 값은 각각 다음과 같은 규칙을 준수하여야 합니다.
 
+<a id="k8s-label-label-key"></a>
 #### 레이블 키
 레이블 키는 슬래시(/)로 구분되는 접두사와 이름의 구조를 가질 수 있으며 접두사는 생략 가능합니다.
 
@@ -1673,6 +1698,7 @@ Kubernetes 레이블은 키와 값의 쌍으로 이루어지며, 유효한 레�
     * 알파벳 대소문자, 숫자, 대시(-), 밑줄(_), 점(.)만 허용되며, 영숫자로 시작하고 끝나야 합니다.
 
 
+<a id="k8s-label-label-value"></a>
 #### 레이블 값
 * 공백이거나 63자 이하여야 합니다.
 * 알파벳 대소문자, 숫자, 대시(-), 밑줄(_), 점(.)만 허용되며, 영숫자로 시작하고 끝나야 합니다.
@@ -1682,7 +1708,7 @@ Kubernetes 레이블은 키와 값의 쌍으로 이루어지며, 유효한 레�
 > * Kubernetes 레이블 설정을 변경하면, 이후에 신규로 생성되는 노드부터 변경된 설정이 적용됩니다.
 
 <a id="oidc-auth"></a>
-### OIDC 인증 설정 기능
+### OIDC 인증 설정 기능 { #oidc-auth }
 
 OIDC(OpenID Connect)는 OAuth 2.0 프레임워크를 기반으로 한 상호 운용 가능한 인증 프로토콜입니다. OIDC를 이용하면 외부 인증 서비스를 통해 사용자를 인증할 수 있습니다. OIDC의 자세한 동작 방식은 [What is OpenID Connect](https://openid.net/developers/how-connect-works/)를 참고하세요.
 
@@ -1701,7 +1727,7 @@ NKS 클러스터는 OIDC를 이용한 인증을 처리하도록 설정할 수 �
 | Signing Algs| X | 허용된 JOSE 비대칭 서명 알고리즘 목록. 기본값: 'RS256' |
 
 <a id="control-plane-k8s-log"></a>
-### 컨트롤 플레인 Kubernetes 컴포넌트 로그 저장
+### 컨트롤 플레인 Kubernetes 컴포넌트 로그 저장 { #control-plane-k8s-log }
 NHN Kubernetes Service(NKS)는 컨트롤 플레인에서 실행 중인 주요 Kubernetes 컴포넌트들의 로그를 제공합니다. 이를 통해 클러스터 내에서 발생하는 다양한 이벤트와 동작을 보다 명확하게 파악할 수 있으며, 서비스 상태 진단 및 문제 해결에 유용하게 활용할 수 있습니다.
 
 컨트롤 플레인 Kubernetes 컴포넌트 로그 저장 기능의 특징은 다음과 같습니다.
@@ -1819,11 +1845,12 @@ OBS 컨테이너에 로그가 생성되는 경로는 다음과 같습니다.
   nks-test-master-0/kube-apiserver/2025/04/20250428-101500-index0.gz
 
 <a id="k8s-taint"></a>
-### Kubernetes 테인트 설정 기능
+### Kubernetes 테인트 설정 기능 { #k8s-taint }
 노드 그룹마다 Kubernetes 테인트(taint) 설정 기능을 사용할 수 있습니다. 이 기능을 통해 생성된 노드 그룹은 사용자가 설정한 테인트를 설정한 상태로 초기화됩니다. Taint에 대한 자세한 설명은 [Taints and Tolerations](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/)을 참고하세요.
 
 Kubernetes 테인트는 키, 값, 효과(effect)로 이루어지며, 각 항목은 다음과 같은 규칙을 준수하여야 합니다.
 
+<a id="k8s-taint-taint-key"></a>
 #### 테인트 키
 
 테인트 키는 슬래시(/)로 구분되는 접두사와 이름의 구조를 가질 수 있으며 접두사는 생략 가능합니다.
@@ -1837,11 +1864,13 @@ Kubernetes 테인트는 키, 값, 효과(effect)로 이루어지며, 각 항목�
     * 63자 이하여야 합니다.
     * 알파벳 대소문자, 숫자, 대시(-), 밑줄(_), 점(.)만 허용되며, 영숫자로 시작하고 끝나야 합니다.
 
+<a id="k8s-taint-taint-value"></a>
 #### 테인트 값
 
 * 공백이거나 63자 이하여야 합니다.
 * 알파벳 대소문자, 숫자, 대시(-), 밑줄(_), 점(.)만 허용되며, 영숫자로 시작하고 끝나야 합니다.
 
+<a id="k8s-taint-taint-effect"></a>
 #### 테인트 효과(Effect)
 
 다음 세 가지 값 중 하나를 지정해야 합니다.
@@ -1859,7 +1888,7 @@ Kubernetes 테인트는 키, 값, 효과(effect)로 이루어지며, 각 항목�
 * Kubernetes 테인트 설정을 변경하면, 이후에 신규로 생성되는 노드부터 변경된 설정이 적용됩니다.
 
 <a id="konnectivity-description"></a>
-### konnectivity
+### konnectivity { #konnectivity-description }
 
 Konnectivity는 Kubernetes에서 컨트롤 플레인(API 서버)과 워커 노드 간의 네트워크 통신을 안전하게 프록시해 주는 컴포넌트입니다. 기존에는 API 서버가 노드의 kubelet이나 파드에 직접 접근해야 하여 네트워크 구성이 복잡한 문제가 있었습니다.
 
@@ -1882,27 +1911,32 @@ Konnectivity Server와 Konnectivity Agent가 먼저 연결을 맺어 터널을 �
 > Konnectivity는 플랫폼 버전 1.202605.0 이상에서 제공됩니다.
 
 <a id="worker-node-management"></a>
-## 워커 노드 관리
+## 워커 노드 관리 { #worker-node-management }
 
 <a id="container-management"></a>
-### 컨테이너 관리
+### 컨테이너 관리 { #container-management }
 
+<a id="container-management-clusters-of-kubernetes-v1243-or-older"></a>
 #### Kubernetes v1.24.3 이전 버전의 클러스터
 Kubernetes v1.24.3 이전 버전의 클러스터는 Docker를 이용해 컨테이너 런타임을 구성합니다. 워커 노드에서 docker CLI를 이용해 컨테이너 상태 조회, 컨테이너 이미지 조회 등의 작업을 할 수 있습니다. docker CLI에 대한 자세한 설명과 사용법은 [Use the Docker command line](https://docs.docker.com/engine/reference/commandline/cli/)을 참고하세요.
 
+<a id="container-management-clusters-of-kubernetes-v1243-and-later"></a>
 #### Kubernetes v1.24.3 이후 버전의 클러스터
 
 Kubernetes v1.24.3 이후 버전의 클러스터는 containerd를 이용해 컨테이너 런타임을 구성합니다. 워커 노드에서 docker CLI 대신 nerdctl을 이용해 컨테이너 상태 조회, 컨테이너 이미지 조회 등의 작업을 할 수 있습니다. nerdctl에 대한 자세한 설명과 사용법은 [nerdctl: Docker-compatible CLI for containerd](https://github.com/containerd/nerdctl#nerdctl-docker-compatible-cli-for-containerd)를 참고하세요.
 
 <a id="network-management"></a>
-### 네트워크 관리
+### 네트워크 관리 { #network-management }
 
+<a id="network-management-default-network-interface"></a>
 #### 기본 네트워크 인터페이스
 모든 워커 노드는 클러스터 생성 시 입력한 VPC/서브넷에 연결되는 네트워크 인터페이스를 가지고 있습니다. 이 기본 네트워크 인터페이스의 이름은 "eth0"이며, 워커 노드는 이 네트워크 인터페이스를 통해 컨트롤 플레인과 연결됩니다.
 
+<a id="network-management-additional-network-interface"></a>
 #### 추가 네트워크 인터페이스
 클러스터 또는 워커 노드 그룹 생성 시 추가 네트워크를 설정하면 해당 워커 노드 그룹의 워커 노드에 추가 네트워크 인터페이스가 생성됩니다. 추가 네트워크 인터페이스는 추가 네트워크 설정에 입력한 순서대로 인터페이스 이름이 설정됩니다(eth1, eth2, ...).
 
+<a id="network-management-default-route-settings"></a>
 #### 기본 경로(default route) 설정
 워커 노드에 여러 네트워크 인터페이스가 존재하는 경우, 각 네트워크 인터페이스별로 기본 경로가 설정됩니다. 한 시스템에 여러 기본 경로가 설정된 경우, 메트릭(metric) 값이 가장 낮은 기본 경로가 시스템 기본 경로로 동작합니다. 네트워크 인터페이스별 기본 경로는 인터페이스 번호가 작을수록 낮은 메트릭 값이 설정되어 있습니다. 이로 인해 동작 중인 네트워크 인터페이스 중 가장 작은 번호의 네트워크 인터페이스가 시스템 기본 경로로 동작합니다.
 
@@ -1962,6 +1996,7 @@ Destination     Gateway         Genmask         Flags Metric Ref    Use Iface
 ...
 ```
 
+<a id="network-management-change-default-route-settings-using-user-script"></a>
 #### 사용자 스크립트 기능을 이용한 기본 경로 설정 변경
 사용자 스크립트 기능을 이용하면 노드 증설 등으로 노드가 새롭게 초기화될 때도 위와 같은 설정을 유지할 수 있습니다. 다음 사용자 스크립트는 CentOS를 사용하는 워커 노드에서 eth0의 메트릭 값을 100으로, eth1의 메트릭 값을 0으로 설정하는 예제입니다. 이렇게 하면 현재 시스템에 적용되어 있는 기본 경로별 메트릭 값도 변경되며, 이는 워커 노드 재시작 후에도 유지됩니다.
 ```
@@ -1975,7 +2010,7 @@ route add -net 0.0.0.0/0 gw 192.168.0.1 dev eth1 metric 0
 ```
 
 <a id="kubelet-argument"></a>
-### kubelet 사용자 정의 아규먼트 설정 기능
+### kubelet 사용자 정의 아규먼트 설정 기능 { #kubelet-argument }
 kubelet은 모든 워커 노드에서 동작하는 노드 에이전트입니다. kubelet은 커맨드라인 아규먼트를 이용해 여러 설정을 입력 받습니다. NKS에서 제공하는 kubelet 사용자 정의 아규먼트 설정 기능을 이용하면 kubelet 시작 시 입력되는 아규먼트를 추가할 수 있습니다. kubelet 사용자 정의 아규먼트는 다음과 같이 설정하고 시스템에 적용할 수 있습니다.
 
 * 워커 노드의 `/etc/kubernetes/kubelet-user-args` 파일에 `KUBELET_USER_ARGS="사용자 정의 아규먼트"` 형식으로 사용자 정의 아규먼트를 입력합니다.
@@ -1990,7 +2025,7 @@ kubelet은 모든 워커 노드에서 동작하는 노드 에이전트입니다.
 > * 설정된 사용자 정의 아규먼트는 시스템 재시작 시에도 그대로 적용됩니다.
 
 <a id="containerd-registry-config"></a>
-### 사용자 정의 containerd 레지스트리 설정 기능(deprecated)
+### 사용자 정의 containerd 레지스트리 설정 기능(deprecated) { #containerd-registry-config }
 
 > [주의]
 > 이 기능은 Kubernetes v1.34 이상에서 동작하지 않습니다.
@@ -2036,6 +2071,7 @@ v1.24.3 이상의 NKS 클러스터는 컨테이너 런타임으로 containerd v1
 }
 ```
 
+<a id="containerd-registry-config-example-1"></a>
 #### 예시1 
 
 `docker.io` 이외에 추가 레지스트리를 등록하려면 다음과 같이 설정할 수 있습니다.
@@ -2057,6 +2093,7 @@ v1.24.3 이상의 NKS 클러스터는 컨테이너 런타임으로 containerd v1
 ]
 ```
 
+<a id="containerd-registry-config-example-2"></a>
 #### 예시2 
 
 `docker.io` 레지스트리를 제거하고 HTTP를 지원하는 레지스트리만 등록하려면 다음과 같이 설정할 수 있습니다.
@@ -2074,6 +2111,7 @@ v1.24.3 이상의 NKS 클러스터는 컨테이너 런타임으로 containerd v1
 ]
 ```
 
+<a id="containerd-registry-config-example-3"></a>
 #### 예시3
 
 노드 생성 시 사용자 정의 containerd 레지스트리 설정 파일을 예시2의 내용으로 생성하기 위해서 사용자 스크립트를 다음과 같이 설정할 수 있습니다.
@@ -2094,7 +2132,7 @@ echo '[ { "registry": "user-defined.registry.io", "endpoint_list": [ "http://use
 >     * `docker.io` 레지스트리를 사용하지 않으려면 `docker.io` 레지스트리에 대한 설정을 포함하지 않으면 됩니다. 단, 하나 이상의 레지스트리 설정이 존재해야 합니다.
 
 <a id="constraints-on-cgroup"></a>
-### Kubernetes 버전과 CGroup 버전에 따른 제약 사항
+### Kubernetes 버전과 CGroup 버전에 따른 제약 사항 { #constraints-on-cgroup }
 CGroup(Control Group)은 Linux 커널 기능으로, 프로세스 그룹의 CPU, 메모리, 디스크 I/O, 네트워크 등 시스템 리소스 사용량을 제한하고 격리하며 모니터링할 수 있게 해 줍니다. Kubernetes를 포함한 컨테이너 기술의 핵심 기반 중 하나입니다. CGroup은 최초 버전1(v1)부터 시작했으며 메모리·I/O 제어 기능을 강화하며 버전2(v2)로 발전하게 되었습니다. Linux 커널의 기능이므로 CGroup v2는 Linux 커널에 의존성을 가집니다. 따라서 비교적 최신의 배포판/버전에서만 CGroup v2가 지원됩니다.
 
 NKS 클러스터 v1.34부터는 워커 노드가 CGroup v2로 동작해야 합니다. 이는 Kubernetes 진영에서 앞으로 containerd 1.x 대신 containerd 2.x를 사용하도록 하고, CGroup v1 대신 v2를 기반으로 동작하겠다는 의미로 나온 제약 사항입니다. 
@@ -2123,13 +2161,13 @@ CGroup 버전을 v1에서 v2로 변경할 수 있는 OS 이미지 배포판의 �
 기본 CGroup 버전이 v1이고 CGroup 버전을 v2로 변경하지 못하는 OS 이미지로 생성한 워커 노드 그룹은 롤링 업그레이드 방식으로 Kubernetes v1.34로 업그레이드할 수 없습니다. 이 경우 Blue-Green 방식으로 워커 노드 그룹을 업그레이드할 수 있습니다.
 
 <a id="worker-management-caution"></a>
-### 워커 노드 관리 주의 사항
+### 워커 노드 관리 주의 사항 { #worker-management-caution }
 * 워커 노드에 pull되어 있는 container image를 임의로 삭제하면 안 됩니다. NKS 클러스터에 필요한 파드가 동작하지 않을 수도 있습니다. 
 * `shutdown`, `halt`, `poweroff` 등의 명령으로 시스템을 임의 중지하면 콘솔에서 다시 시작할 수 없습니다. 워커 노드 시작/중지 기능을 사용하세요.
 * 워커 노드 내의 여러 가지 설정 파일을 임의 수정하거나 시스템 서비스를 임의 조작하면 안 됩니다. NKS 클러스터에 치명적인 문제가 발생할 수 있습니다.
 
 <a id="cni"></a>
-## CNI(Container Network Interface)
+## CNI(Container Network Interface) { #cni }
 NHN Kubernetes Service(NKS)는 Addon 기능을 통해 다른 종류의 Container Network Interface(CNI)를 제공합니다. 클러스터 생성 시 Calico-VXLAN, Calico-eBPF, Cilium 중 하나의 CNI를 선택할 수 있으며, 기본 설정은 Calico-VXLAN입니다. Calico-eBPF는 컨테이너 워크로드를 BGP 라우팅 프로토콜로 구성하고, eBPF 기술을 기반으로 직접 통신하며 일부 구간(NodePort 등)은 VXLAN을 이용해 통신합니다. Calico의 eBPF 관련 내용은 [about eBPF](https://docs.tigera.io/calico/latest/about/kubernetes-training/about-ebpf)를 참고하세요. Cilium은 VXLAN 오버레이 네트워크를 기반으로 하며, eBPF 기술을 활용하여 높은 네트워크 성능을 제공합니다. Cilium의 eBPF 관련 내용은 [eBPF Datapath](https://docs.cilium.io/en/stable/network/ebpf/)를 참고하세요.
 
 CNI별로 선택할 수 있는 OS의 제약 사항은 아래와 같습니다.
@@ -2142,7 +2180,7 @@ CNI별로 선택할 수 있는 OS의 제약 사항은 아래와 같습니다.
 | Cilium | Rocky, Ubuntu |
 
 <a id="calico-cni-types"></a>
-### Calico CNI 종류
+### Calico CNI 종류 { #calico-cni-types }
 NHN Kubernetes Service(NKS)가 제공하는 Calico-VXLAN, Calic-eBPF는 아래와 같은 차이점이 있습니다.
 
 |  | Calico-VXLAN | Calico-eBPF |
@@ -2165,11 +2203,11 @@ NHN Kubernetes Service(NKS)가 제공하는 Calico-VXLAN, Calic-eBPF는 아래�
 > 해당 이미지를 사용하려면 애드온 관리 기능을 통해 Calico를 v3.28.2 이상으로 업데이트해야 합니다. 
 
 <a id="security-group"></a>
-## 보안 그룹
+## 보안 그룹 { #security-group }
 클러스터 생성 시 강화된 보안 규칙을 True로 설정하면 워커 노드 보안 그룹 생성 시 필수 보안 규칙만 생성됩니다.
 
 <a id="mandatory-sg-rules"></a>
-### 클러스터 워커 노드 필수 보안 규칙
+### 클러스터 워커 노드 필수 보안 규칙 { #mandatory-sg-rules }
 
 | 방향 | IP 프로토콜 | 포트 범위 | Ether | 원격 | 설명 | 특이 사항 |
 | :-: | :-: | :-: | :-: | :-: | :-: | :-: |
@@ -2219,7 +2257,7 @@ NHN Kubernetes Service(NKS)가 제공하는 Calico-VXLAN, Calic-eBPF는 아래�
 > 강화된 보안 규칙을 사용하는 경우 해당 파드 포트에 대한 ingress, egress 보안 규칙을 수동으로 추가해야 합니다.
 
 <a id="cilium-optional-security-group-rules"></a>
-### Cilium CNI 선택적 기능 사용 시 추가 보안 그룹 규칙
+### Cilium CNI 선택적 기능 사용 시 추가 보안 그룹 규칙 { #cilium-optional-security-group-rules }
 
 Cilium CNI를 사용하는 클러스터에서 Hubble, Envoy, Prometheus 같은 선택적 기능을 활성화하려면 해당 기능에 필요한 보안 그룹 규칙을 추가로 설정해야 합니다.
 
@@ -2242,7 +2280,7 @@ Cilium CNI를 사용하는 클러스터에서 Hubble, Envoy, Prometheus 같은 �
 > 선택적 기능을 사용하려면 Cilium 설정 변경 및 해당 기능에 필요한 보안 그룹 규칙을 수동으로 추가해야 합니다.
 
 <a id="relaxd-sg-rules"></a>
-### 강화된 보안 규칙을 사용하지 않는 경우 생성되는 규칙
+### 강화된 보안 규칙을 사용하지 않는 경우 생성되는 규칙 { #relaxd-sg-rules }
 
 강화된 보안 규칙을 사용하지 않는 경우 NodePort 타입의 서비스와 외부 네트워크 통신에 필요한 보안 규칙이 추가로 생성됩니다.
 
@@ -2258,20 +2296,22 @@ Cilium CNI를 사용하는 클러스터에서 Hubble, Envoy, Prometheus 같은 �
 
 
 <a id="addon-mgmt"></a>
-## 애드온 관리 기능
+## 애드온 관리 기능 { #addon-mgmt }
 애드온은 Kubernetes 클러스터의 필수 구성 요소는 아니지만 NKS 클러스터의 기능을 확장하거나 특화된 기능을 제공하기 위해 제공되는 구성 요소를 말합니다. 애드온은 네트워킹, 서비스 디스커버리, 모니터링, 스토리지 프로비저닝 등의 기능을 하는 구성 요소가 포함될 수 있습니다. 사용자는 애드온 관리 기능을 통해 NHN Cloud에서 제공하는 애드온을 클러스터에 설치/변경/제거할 수 있습니다.
 
 > [주의]
 > NKS 레지스트리가 활성화되지 않은 클러스터는 애드온 관리 기능을 사용할 수 없습니다.
 
 <a id="addon-mgmt-operation"></a>
-### 동작 방식
+### 동작 방식 { #addon-mgmt-operation }
 애드온 관리 기능의 동작 방식에 대해 설명합니다.
 
+<a id="addon-mgmt-operation-server-side-apply"></a>
 #### Server-side apply
 애드온 관리 기능을 이용해 클러스터에 애드온을 설치/변경할 때 Kubernetes의 Server-side apply를 이용합니다. Client-side apply는 클라이언트가 로컬에서 리소스 상태를 계산해 전체 리소스를 API 서버에 보내는 방식입니다. 반면 Server-side apply는 API 서버가 리소스 병합 및 필드 소유권 관리를 수행하여 API 서버가 리소스 병합과 충돌 감지를 수행할 수 있습니다. Server-side apply에 대한 자세한 내용은 [Server-Side Apply](https://kubernetes.io/docs/reference/using-api/server-side-apply/)를 참고하세요.
 
 
+<a id="addon-mgmt-operation-conflict-resolution-options"></a>
 #### 충돌 처리 옵션
 사용자가 애드온이 관리하는 필드를 변경해 사용하는 경우 애드온 설치/변경 시 충돌이 발생할 수 있습니다. 사용자는 애드온의 설치/변경 시 적절한 충돌 처리 옵션(resolve-conflicts)을 선택해 충돌 상황을 관리할 수 있습니다. 애드온 관리 기능에서 제공하는 충돌 처리 옵션은 다음과 같습니다.
 
@@ -2286,6 +2326,7 @@ Cilium CNI를 사용하는 클러스터에서 Hubble, Envoy, Prometheus 같은 �
 > 애드온을 구성하는 리소스의 모든 변경 사항을 보존할 수는 없습니다.
 > 보존 불가능한 필드에서 충돌 발생 시 설치/변경 작업은 실패로 처리됩니다.
 
+<a id="addon-mgmt-operation-main-features"></a>
 #### 제공 기능
 애드온 관리 기능을 이용해 애드온을 클러스터에 설치/변경/제거할 수 있습니다.
 
@@ -2306,11 +2347,12 @@ Cilium CNI를 사용하는 클러스터에서 Hubble, Envoy, Prometheus 같은 �
 > Kubernetes 버전 업그레이드 기능을 통한 CNI, coredns 등의 업그레이드는 더 이상 제공되지 않습니다.
 > 대신 애드온 변경 기능을 통해 각 애드온의 버전을 변경할 수 있습니다.
 
+<a id="addon-mgmt-operation-enable-add-on-management"></a>
 #### 애드온 관리 기능 활성화
 애드온 관리 기능이 활성화되지 않은 기존 클러스터도 애드온 관리 기능을 사용할 수 있습니다. 애드온이 설정되지 않은 클러스터는 calico, coredns 등이 동작하고 있음에도 애드온이 설치되지 않은 것으로 표시됩니다. 이 상태에서 각 애드온을 설치하면 이후 애드온 관리 기능을 통해 애드온을 관리할 수 있습니다. 애드온을 구성하는 리소스의 설정을 변경해 사용하는 경우 충돌 처리 옵션을 '보존'으로 선택해 설치하면 기존 리소스의 설정을 유지할 수 있습니다.
 
 <a id="addon-mgmt-types"></a>
-### 애드온 유형
+### 애드온 유형 { #addon-mgmt-types }
 애드온 유형은 클러스터에 설치되는 애드온을 특성에 따라 구분한 것입니다.
 
 | 유형 | 필수 여부 | 설명|
@@ -2323,7 +2365,7 @@ Cilium CNI를 사용하는 클러스터에서 Hubble, Envoy, Prometheus 같은 �
 | nfs-csi-plugin | X | NHN Cloud의 NFS를 프로비저닝하고 관리할 수 있는 CSI 드라이버입니다. |
 
 <a id="addon-mgmt-addon-list"></a>
-### 애드온 목록
+### 애드온 목록 { #addon-mgmt-addon-list }
 
 <a id="addon-mgmt-addon-calico"></a>
 #### Calico
@@ -2410,6 +2452,7 @@ CoreDNS는 Kubernetes 클러스터의 기본 DNS 서버입니다.
 
 
 <a id="addon-mgmt-addon-cinder-csi-plugin">
+<a id="addon-mgmt-addon-list-cinder-csi-plugin"></a>
 #### Cinder CSI Plugin
 Cinder CSI Plugin은 NHN Cloud에서 블록 스토리지를 프로비저닝하고 관리할 수 있는 CSI 드라이버입니다.
 
@@ -2441,6 +2484,7 @@ Cinder CSI Plugin은 NHN Cloud에서 블록 스토리지를 프로비저닝하�
     * v1.27.102-nks3: 애드온 관리 기능의 안정성을 강화했습니다.
 
 <a id="adoon-mgmt-addon-metrics-server">
+<a id="addon-mgmt-addon-list-metrics-server"></a>
 #### Metrics Server
 Metrics Server는 오토 스케일링과 모니터링을 위해 노드와 파드로부터 리소스 사용 지표를 수집하는 Kubernetes의 구성 요소입니다.
 
@@ -2454,6 +2498,7 @@ Metrics Server는 오토 스케일링과 모니터링을 위해 노드와 파드
     * v0.4.4-nks2: 애드온 관리 기능의 안정성을 강화했습니다.
 
 <a id="addon-mgmt-addon-snapshot-controller">
+<a id="addon-mgmt-addon-list-snapshot-controller"></a>
 #### Snapshot Controller
 Snapshot Controller는 볼륨 스냅숏의 생성, 삭제, PVC 연동을 포함한 라이프 사이클을 관리하는 Kubernetes의 구성 요소입니다.
 
@@ -2467,6 +2512,7 @@ Snapshot Controller는 볼륨 스냅숏의 생성, 삭제, PVC 연동을 포함�
     * v4.1.1-nks2: 애드온 관리 기능의 안정성을 강화했습니다.
 
 <a id="addon-mgmt-addon-nfs-csi-plugin">
+<a id="addon-mgmt-addon-list-nfs-csi-plugin"></a>
 #### NFS CSI Plugin
 NFS CSI Plugin은 NHN Cloud의 NFS를 프로비저닝하고 관리할 수 있는 CSI 드라이버입니다.
 
@@ -2491,11 +2537,11 @@ NFS CSI Plugin은 NHN Cloud의 NFS를 프로비저닝하고 관리할 수 있는
         * 선택 항목인 snapshot 설정이 필수로 요구되던 문제를 해결했습니다.
 
 <a id="loadbalancer-service"></a>
-## LoadBalancer 서비스
+## LoadBalancer 서비스 { #loadbalancer-service }
 Kubernetes 애플리케이션의 기본 실행 단위인 파드(pod)는 CNI(container network interface)로 클러스터 네트워크에 연결됩니다. 기본적으로 클러스터 외부에서 파드로는 접근할 수 없습니다. 파드의 서비스를 클러스터 외부에 공개하려면 Kubernetes의 `LoadBalancer` 서비스(Service) 객체(object)를 이용해 외부에 공개할 경로를 만들어야 합니다. LoadBalancer 서비스 객체를 만들면 클러스터 외부에 NHN Cloud Load Balancer가 생성되어 서비스 객체와 연결됩니다.
 
 <a id="create-webserver-pod"></a>
-### 웹 서버 파드 생성
+### 웹 서버 파드 생성 { #create-webserver-pod }
 다음과 같이 2개의 nginx 파드를 실행하는 디플로이먼트(deployment) 객체 매니페스트 파일을 작성하고 객체를 생성합니다.
 
 ```yaml
@@ -2536,7 +2582,7 @@ nginx-deployment-7fd6966748-wv7rd   1/1     Running   0          4m13s
 ```
 
 <a id="create-lb-service"></a>
-### LoadBalancer 서비스 생성
+### LoadBalancer 서비스 생성 { #create-lb-service }
 Kubernetes의 서비스 객체를 정의하려면 다음과 같은 항목으로 구성된 매니페스트가 필요합니다.
 
 | 항목 | 설명 |
@@ -2594,7 +2640,7 @@ nginx-svc    LoadBalancer   10.254.134.18   123.123.123.30   8080:30013/TCP   3m
 > 로드 밸런서의 IP는 외부에서 접근할 수 있는 플로팅 IP입니다. **Network > Floating IP** 페이지에서 확인할 수 있습니다.
 
 <a id="internet-test-via-service"></a>
-### 인터넷을 통한 서비스 테스트
+### 인터넷을 통한 서비스 테스트 { #internet-test-via-service }
 로드 밸런서에 연결된 플로팅 IP로 HTTP 요청을 보내 Kubernetes 클러스터의 웹 서버 파드가 응답하는지 확인합니다. 서비스 객체의 TCP/8080 포트를 파드의 TCP/80 포트와 연결하도록 설정했기 때문에 TCP/8080 포트로 요청을 보내야 합니다. 외부 로드 밸런서와 서비스 객체, 파드가 잘 연결되었다면 웹 서버는 nginx 기본 페이지를 응답합니다.
 
 ```
@@ -2627,7 +2673,7 @@ Commercial support is available at
 ```
 
 <a id="advanced-lb-configuration"></a>
-### 로드 밸런서 상세 옵션 설정
+### 로드 밸런서 상세 옵션 설정 { #advanced-lb-configuration }
 Kubernetes의 서비스 객체를 정의할 때 로드 밸런서의 여러 가지 옵션을 설정할 수 있습니다. 설정 가능한 항목은 아래와 같습니다.
 
 * 로드 밸런서 이름 설정
@@ -2653,12 +2699,14 @@ Kubernetes의 서비스 객체를 정의할 때 로드 밸런서의 여러 가�
 * 상태 확인 호스트 헤더 설정
 * L7 규칙 및 조건
 
+<a id="advanced-lb-configuration-global-setting-and-per-listener-setting"></a>
 #### 전역 설정과 리스너별 설정
 설정 항목별로 전역 설정과 리스너별 설정이 가능합니다. 전역 설정과 리스너별 설정 모두 없는 경우 설정별 기본값을 사용합니다.
 
 * 리스너별 설정: 대상 리스너에만 적용되는 설정입니다.
 * 전역 설정: 대상 리스너에 리스너별 설정이 없는 경우 이 설정을 적용합니다.
 
+<a id="advanced-lb-configuration-format-of-per-listener-setting"></a>
 #### 리스너별 설정 형식
 리스너별 설정은 전역 설정 키에 리스너를 나타내는 접두어(prefix)를 붙여 설정할 수 있습니다. 리스너를 나타내는 접두어는 서비스 객체의 포트 프로토콜(`spec.ports[].protocol`)과 포트 번호(`spec.ports[].port`)를 대시(`-`)로 연결한 것입니다. 예를 들어 프로토콜이 TCP이고, 포트 번호가 80인 경우 접두어는 `TCP-80`입니다. 이 포트와 연결되는 리스너에 세션 지속성 설정을 하고 싶다면 .metadata.annotations 하위의 TCP-80.loadbalancer.nhncloud/pool-session-persistence에 설정할 수 있습니다.
 
@@ -2726,6 +2774,7 @@ kubectl annotate svc <name> loadbalancer.nhncloud/force-reconcile=true
 > [주의]
 > 이 기능은 플랫폼 버전이 1.202605.0 이상인 클러스터에서 동작합니다.
 
+<a id="advanced-lb-configuration-setting-load-balancer-name"></a>
 #### 로드 밸런서 이름 설정
 
 로드 밸런서의 이름을 설정할 수 있습니다.
@@ -2742,6 +2791,7 @@ kubectl annotate svc <name> loadbalancer.nhncloud/force-reconcile=true
 > * 서비스 객체가 생성된 후 로드 밸런서 이름을 수정
 > * 프로젝트 내에 같은 이름의 로드 밸런서를 생성
 
+<a id="advanced-lb-configuration-set-load-balancer-type"></a>
 #### 로드 밸런서 타입 설정
 로드 밸런서의 타입을 설정할 수 있습니다. 로드 밸런서에 대한 자세한 내용은 [로드 밸런서 콘솔 사용 가이드](/Network/Load%20Balancer/ko/console-guide/)를 참고하세요.
 
@@ -2751,6 +2801,7 @@ kubectl annotate svc <name> loadbalancer.nhncloud/force-reconcile=true
     * shared: '일반' 타입의 로드 밸런서를 생성합니다. 미설정 시 기본값입니다.
     * dedicated: '전용' 타입의 로드 밸런서를 생성합니다.
 
+<a id="advanced-lb-configuration-set-static-routes"></a>
 #### 정적 라우트 설정
 로드 밸런서의 정적 라우트 적용 여부를 설정할 수 있습니다. 
 
@@ -2763,6 +2814,7 @@ kubectl annotate svc <name> loadbalancer.nhncloud/force-reconcile=true
 > [주의]
 > 정적 라우트 설정은 2024년 8월 27일 이후에 생성됐거나 k8s 버전을 업그레이드한 클러스터에서 설정 가능합니다.
 
+<a id="advanced-lb-configuration-set-the-session-affinity"></a>
 #### 세션 지속성 설정
 로드 밸런서의 세션 지속성을 설정할 수 있습니다.
 
@@ -2777,6 +2829,7 @@ kubectl annotate svc <name> loadbalancer.nhncloud/force-reconcile=true
 * v1.19.13 이후 클러스터
     * 로드 밸런서 생성 후에도 변경 가능합니다.
 
+<a id="advanced-lb-configuration-set-whether-to-keep-a-floating-ip-address"></a>
 #### 플로팅 IP 주소 보존 여부 설정
 로드 밸런서에는 플로팅 IP가 연결되어 있습니다. 로드 밸런서 삭제 및 플로팅 IP 변경 시 로드 밸런서에 연결된 플로팅 IP의 삭제 혹은 보존 여부를 설정할 수 있습니다.
 
@@ -2798,6 +2851,7 @@ kubectl annotate svc <name> loadbalancer.nhncloud/force-reconcile=true
 > 2021년 10월 26일 이전에 생성된 v1.18.19 클러스터는 로드 밸런서가 삭제될 때 플로팅 IP가 삭제되지 않는 문제가 있습니다. 고객 센터의 1:1 문의를 통해 문의주시면 이 문제를 해결하기 위한 절차에 대해 상세히 알려드리겠습니다.
 
 
+<a id="advanced-lb-configuration-set-the-load-balancer-ip"></a>
 #### 로드 밸런서 IP 설정
 로드 밸런서를 생성할 때 로드 밸런서의 IP를 설정할 수 있습니다.
 
@@ -2828,6 +2882,7 @@ spec:
   type: LoadBalancer
 ```
 
+<a id="advanced-lb-configuration-set-whether-to-use-the-floating-ip"></a>
 #### 플로팅 IP 사용 여부 설정
 로드 밸런서 생성 시 플로팅 IP의 사용 여부를 설정할 수 있습니다.
 
@@ -2871,6 +2926,7 @@ spec:
 | true | 설정 | 로드 밸런서에 지정된 VIP를 연결합니다. |
 
 
+<a id="advanced-lb-configuration-set-vpc"></a>
 #### VPC 설정
 로드 밸런서 생성 시 로드 밸런서가 연결될 VPC를 설정할 수 있습니다.
 
@@ -2878,6 +2934,7 @@ spec:
 * 리스너별 설정을 적용할 수 없습니다.
 * 설정하지 않으면 클러스터 생성 시 설정한 VPC로 설정합니다.
 
+<a id="advanced-lb-configuration-set-subnet"></a>
 #### 서브넷 설정
 로드 밸런서 생성 시 로드 밸런서가 연결될 서브넷을 설정할 수 있습니다. 설정된 서브넷에 로드 밸런서의 프라이빗 IP가 연결됩니다. 멤버 서브넷 설정이 없는 경우 이 서브넷에 연결된 워커 노드가 로드 밸런서 멤버로 추가됩니다.
 
@@ -2907,6 +2964,7 @@ spec:
   type: LoadBalancer
 ```
 
+<a id="advanced-lb-configuration-set-member-subnet"></a>
 #### 멤버 서브넷 설정
 로드 밸런서 생성 시 로드 밸런서 멤버가 연결될 서브넷을 설정할 수 있습니다. 이 서브넷에 연결된 워커 노드가 로드 밸런서 멤버로 추가됩니다.
 
@@ -2967,6 +3025,7 @@ spec:
 > 멤버 서브넷은 2023년 11월 28일 이후 v1.24.3 이상의 버전으로 업그레이드됐거나 신규 생성된 클러스터에서 설정 가능합니다.
 
 
+<a id="advanced-lb-configuration-set-the-listener-connection-limit"></a>
 #### 리스너 연결 제한 설정
 리스너의 연결 제한을 설정할 수 있습니다.
 
@@ -2980,6 +3039,7 @@ spec:
     * 설정하지 않거나 범위에서 벗어나는 값을 입력한 경우 기본값인 60000으로 설정됩니다.
 
 
+<a id="advanced-lb-configuration-set-the-listener-protocol"></a>
 #### 리스너 프로토콜 설정
 리스너의 프로토콜을 설정할 수 있습니다.
 
@@ -3070,6 +3130,7 @@ metadata:
 > Certificate Manager에 등록된 인증서를 이용하는 방법은 2024년 5월 28일 이후에 생성됐거나 k8s 버전을 업그레이드한 클러스터에서 설정 가능합니다.
 > 리스너와 연동된 Certificate Manager의 인증서를 삭제하면 로드 밸런서의 동작에 영향을 줄 수 있습니다.
 
+<a id="advanced-lb-configuration-set-the-listener-proxy-protocol"></a>
 #### 리스너 프록시 프로토콜(Proxy Protocol) 설정
 리스너 프로토콜이 TCP 혹은 HTTPS인 경우 리스너에 프록시 프로토콜을 설정할 수 있습니다. 프록시 프로토콜에 대한 자세한 내용은 [로드 밸런서 프록시 모드](/Network/Load%20Balancer/ko/overview/#_4)를 참고하세요.
 
@@ -3079,6 +3140,7 @@ metadata:
     * true: 프록시 프로토콜을 활성화합니다.
     * false: 프록시 프로토콜을 비활성화합니다. 미설정 시 기본값입니다.
 
+<a id="advanced-lb-configuration-set-the-load-balancing-method"></a>
 #### 로드 밸런싱 방식 설정
 로드 밸런싱 방식을 설정할 수 있습니다.
 
@@ -3090,6 +3152,7 @@ metadata:
     * SOURCE_IP
 
 
+<a id="advanced-lb-configuration-set-the-health-check-protocol"></a>
 #### 상태 확인 프로토콜 설정
 상태 확인 프로토콜을 설정할 수 있습니다.
 
@@ -3120,6 +3183,7 @@ HTTP 상태 코드는 다음과 같이 설정할 수 있습니다.
 * 단일값(예: 200), 목록(예: 200,202), 범위(예: 200-204) 형태로 입력할 수 있습니다.
 * 설정하지 않거나 규칙에 맞지 않는 값을 입력하면 기본값인 200으로 설정됩니다.
 
+<a id="advanced-lb-configuration-set-the-health-check-interval"></a>
 #### 상태 확인 주기 설정
 상태 확인 주기를 설정할 수 있습니다.
 
@@ -3129,6 +3193,7 @@ HTTP 상태 코드는 다음과 같이 설정할 수 있습니다.
 * 최솟값 1, 최댓값 5000입니다.
 * 설정하지 않거나 범위에서 벗어나는 값을 입력하면 기본값인 60으로 설정됩니다.
 
+<a id="advanced-lb-configuration-set-the-health-check-maximum-response-time"></a>
 #### 상태 확인 최대 응답 시간 설정
 상태 확인 최대 응답 시간을 설정할 수 있습니다.
 
@@ -3140,6 +3205,7 @@ HTTP 상태 코드는 다음과 같이 설정할 수 있습니다.
 * 설정하지 않거나 범위에서 벗어나는 값을 입력하면 기본값인 30으로 설정됩니다.
 * 단, 입력값 혹은 설정값이 상태 확인 주기 설정보다 크면 상태 확인 주기 설정의 1/2로 설정됩니다.
 
+<a id="advanced-lb-configuration-set-the-maximum-number-of-retries-for-a-health-check"></a>
 #### 상태 확인 최대 재시도 횟수 설정
 상태 확인 최대 재시도 횟수를 설정할 수 있습니다.
 
@@ -3148,6 +3214,7 @@ HTTP 상태 코드는 다음과 같이 설정할 수 있습니다.
 * 최솟값 1, 최댓값 10입니다.
 * 설정하지 않거나 범위에서 벗어나는 값을 입력하면 기본값인 3으로 설정됩니다.
 
+<a id="advanced-lb-configuration-health-check-port-settings"></a>
 #### 상태 확인 포트 설정
 헬스 체크의 대상이 되는 멤버 포트를 설정할 수 있습니다.
 
@@ -3157,6 +3224,7 @@ HTTP 상태 코드는 다음과 같이 설정할 수 있습니다.
 * 0을 지정하는 경우 각 멤버별로 지정된 포트 번호를 대상으로 상태 확인을 수행합니다.
 * 설정하지 않거나 범위에서 벗어나는 값을 입력하면 기본값인 0으로 설정됩니다.
 
+<a id="advanced-lb-configuration-health-check-host-header-settings"></a>
 #### 상태 확인 호스트 헤더 설정
 상태 확인에 사용할 호스트 헤더의 필드값을 설정할 수 있습니다.
 
@@ -3164,6 +3232,7 @@ HTTP 상태 코드는 다음과 같이 설정할 수 있습니다.
 * 리스너별 설정을 적용할 수 있습니다.
 * 상태 확인 프로토콜을 TCP로 설정한 경우 이 필드에 설정한 값은 무시됩니다.
 
+<a id="advanced-lb-configuration-setting-keep-alive-timeout"></a>
 #### keep-alive 타임아웃 설정
 keep-alive 타임아웃 값을 설정할 수 있습니다.
 
@@ -3176,6 +3245,7 @@ keep-alive 타임아웃 값을 설정할 수 있습니다.
 > [주의]
 > keep-alive 타임아웃은 2023년 11월 28일 이후 v1.24.3 이상의 버전으로 업그레이드됐거나 신규 생성된 클러스터에서 설정 가능합니다.
 
+<a id="advanced-lb-configuration-l7-rules"></a>
 #### L7 규칙
 리스너별로 L7 규칙을 설정할 수 있습니다. L7 규칙은 다음과 같이 동작합니다.
 
@@ -3206,6 +3276,7 @@ L7 규칙 설정에는 다음의 제약 사항이 있습니다.
 * 한 리스너에 설정되는 L7 규칙들은 서로 다른 인덱스 값으로 설정해야 합니다.
 * 한 리스너에 설정되는 L7 규칙들은 서로 다른 이름으로 설정해야 합니다.
 
+<a id="advanced-lb-configuration-l7-conditions"></a>
 #### L7 조건
 L7 규칙별로 L7 조건을 설정할 수 있습니다. L7 조건은 다음과 같이 동작합니다.
 
@@ -3308,19 +3379,20 @@ spec:
 ```
 
 <a id="ingress-controller"></a>
-## 인그레스 컨트롤러
+## 인그레스 컨트롤러 { #ingress-controller }
 인그레스 컨트롤러(ingress controller)는 인그레스(Ingress) 객체에 정의된 규칙을 참조하여 클러스터 외부에서 내부 서비스로 HTTP와 HTTPS 요청을 라우팅하고 SSL/TSL 종료, 가상 호스팅 등을 제공합니다. 인그레스 컨트롤러와 인그레스에 대한 자세한 내용은 [인그레스 컨트롤러](https://kubernetes.io/ko/docs/concepts/services-networking/ingress-controllers/), [인그레스](https://kubernetes.io/ko/docs/concepts/services-networking/ingress/) 문서를 참고하세요.
 
 <a id="install-nginx-ingress-controller"></a>
-### NGINX Ingress Controller 설치
+### NGINX Ingress Controller 설치 { #install-nginx-ingress-controller }
 NGINX Ingress Controller는 많이 사용되는 인그레스 컨트롤러 중 하나입니다. 자세한 내용은 [NGINX Ingress Controller](https://kubernetes.github.io/ingress-nginx/)와 [NGINX Ingress Controller for Kubernetes](https://www.nginx.com/products/nginx-ingress-controller/) 문서를 참고하세요. NGINX Ingress Controller의 설치는 [Installation Guide](https://kubernetes.github.io/ingress-nginx/deploy/) 문서를 참고하세요.
 
 <a id="uri-based-service-routing"></a>
-### URI 기반 서비스 분기
+### URI 기반 서비스 분기 { #uri-based-service-routing }
 인그레스 컨트롤러는 URI를 기반으로 서비스를 분기할 수 있습니다. 아래 그림은 URI를 기반으로 서비스를 분기하는 간단한 예제의 구조를 나타냅니다.
 
 ![ingress-01.png](http://static.toastoven.net/prod_infrastructure/container/kubernetes/ingress-01.png)
 
+<a id="uri-based-service-routing-create-services-and-pods"></a>
 #### 서비스와 파드 생성
 다음과 같이 서비스와 파드를 생성하기 위한 매니페스트를 작성합니다. `tea-svc` 서비스에는 `tea` 파드를 연결하고, `coffee-svc` 서비스에는 `coffee` 파드를 연결합니다.
 
@@ -3421,6 +3493,7 @@ pod/tea-5c457db9-fdkxl        1/1     Running   0          27m
 pod/tea-5c457db9-z6hl5        1/1     Running   0          27m
 ```
 
+<a id="uri-based-service-routing-create-ingress"></a>
 #### 인그레스(Ingress) 생성
 요청 경로에 따라 서비스를 연결하는 인그레스 매니페스트를 작성합니다. 엔드포인트가 `/tea`인 요청은 `tea-svc` 서비스에 연결하고 `/coffee`인 요청은 `coffee-svc` 서비스에 연결합니다.
 
@@ -3462,6 +3535,7 @@ NAME               CLASS   HOSTS   ADDRESS          PORTS   AGE
 cafe-ingress-uri   nginx   *       123.123.123.44   80      23s
 ```
 
+<a id="uri-based-service-routing-send-http-requests"></a>
 #### HTTP 요청 전송
 외부 호스트에서 ingress의 **ADDRESS** 필드에 설정된 IP 주소로 HTTP 요청을 전송해 인그레스가 올바르게 설정되었는지 확인합니다.
 
@@ -3520,6 +3594,7 @@ $ curl 123.123.123.44/unknown
 </html>
 ```
 
+<a id="uri-based-service-routing-delete-resources"></a>
 #### 리소스 삭제
 테스트에 사용한 자원들은 생성할 때 사용한 매니페스트를 이용해 삭제할 수 있습니다.
 
@@ -3535,14 +3610,16 @@ service "tea-svc" deleted
 ```
 
 <a id="host-based-service-routing"></a>
-### 호스트 기반 서비스 분기
+### 호스트 기반 서비스 분기 { #host-based-service-routing }
 인그레스 컨트롤러는 호스트 이름을 기반으로 서비스를 분기할 수 있습니다. 아래 그림은 호스트 이름을 기반으로 서비스를 분기하는 간단한 예제의 구조를 나타냅니다.
 
 ![ingress-02.png](http://static.toastoven.net/prod_infrastructure/container/kubernetes/ingress-02.png)
 
+<a id="host-based-service-routing-create-services-and-pods"></a>
 #### 서비스와 파드 생성
 [URI 기반 서비스 분기](/Container/NKS/ko/user-guide/#uri)와 동일한 매니페스트를 이용해 서비스와 파드를 생성합니다.
 
+<a id="host-based-service-routing-create-ingress"></a>
 #### 인그레스 생성
 호스트 이름에 따라 서비스를 연결하는 인그레스 매니페스트를 작성합니다. `tea.cafe.example.com` 호스트로 들어온 요청은 `tea-svc` 서비스에 연결하고 `coffee.cafe.example.com` 호스트로 들어온 요청은 `coffee-svc` 서비스에 연결합니다.
 
@@ -3588,6 +3665,7 @@ NAME                CLASS   HOSTS                                          ADDRE
 cafe-ingress-host   nginx   tea.cafe.example.com,coffee.cafe.example.com   123.123.123.44   80      36s
 ```
 
+<a id="host-based-service-routing-send-http-requests"></a>
 #### HTTP Request 전송
 외부 호스트에서 인그레스의 ADDRESS에 설정된 IP로 HTTP 요청을 전송합니다. 다만 호스트 이름을 이용해 서비스를 분기하도록 인그레스를 구성했기 때문에 호스트 이름을 이용해 요청을 전송해야 합니다.
 
@@ -3631,9 +3709,10 @@ $ curl 123.123.123.44/unknown
 ```
 
 <a id="ingress-nginx-internal-communication"></a>
-### ingress-nginx 컨트롤러 내부 통신 구조 및 주의 사항
+### ingress-nginx 컨트롤러 내부 통신 구조 및 주의 사항 { #ingress-nginx-internal-communication }
 ingress-nginx 컨트롤러를 통해 서비스를 외부에 노출할 경우, 요청을 보내는 클라이언트의 위치(클러스터 내부 또는 외부)에 따라 요청이 워크로드로 전달되는 경로가 달라집니다.
 
+<a id="ingress-nginx-internal-communication-cluster-external-client"></a>
 #### 클러스터 외부 클라이언트
 클러스터 외부 클라이언트가 보내는 요청은 로드 밸런서를 통해 Ingress Controller로 전달됩니다. 로드 밸런서는 Ingress Controller Service의 외부 엔드포인트 역할을 하며, Ingress Controller는 Ingress 규칙에 따라 요청을 목적지 Backend Pod로 라우팅합니다.
 
@@ -3641,6 +3720,7 @@ ingress-nginx 컨트롤러를 통해 서비스를 외부에 노출할 경우, �
 클러스터 외부 클라이언트 → 로드 밸런서 → ingress-nginx Service → ingress-nginx Controller Pod → Backend Pod
 ```
 
+<a id="ingress-nginx-internal-communication-cluster-internal-client"></a>
 #### 클러스터 내부 클라이언트
 클러스터 내부 Pod가 Ingress 주소로 요청할 경우, 트래픽은 로드 밸런서를 거치지 않습니다. 요청은 Ingress Controller Service의 ClusterIP를 통해 내부 경로로 직접 전달되며 이 과정에서 CNI에 따라 다음 방식으로 라우팅됩니다.
 
@@ -3652,6 +3732,7 @@ ingress-nginx 컨트롤러를 통해 서비스를 외부에 노출할 경우, �
 내부 Pod → ingress-nginx Service (ClusterIP) → ingress-nginx Controller Pod → Backend Pod
 ```
 
+<a id="ingress-nginx-internal-communication-cautions"></a>
 #### 주의 사항
 
 - 내부 요청은 로드 밸런서 정책을 적용 받지 않습니다. 로드 밸런서의 TLS 설정, 보안 정책, 방화벽 규칙 등은 내부 트래픽에 영향을 주지 않습니다.
@@ -3660,7 +3741,7 @@ ingress-nginx 컨트롤러를 통해 서비스를 외부에 노출할 경우, �
 
 
 <a id="k8s-dashboard"></a>
-## Kubernetes 대시보드
+## Kubernetes 대시보드 { #k8s-dashboard }
 NHN Kubernetes Service(NKS)는 기본 웹 UI 대시보드(dashboard)를 제공합니다. Kubernetes 대시보드에 대한 자세한 내용은 [웹 UI (대시보드)](https://kubernetes.io/ko/docs/tasks/access-application-cluster/web-ui-dashboard/) 문서를 참고하세요.
 
 > [주의]
@@ -3669,7 +3750,7 @@ NHN Kubernetes Service(NKS)는 기본 웹 UI 대시보드(dashboard)를 제공�
 > * NHN Cloud 콘솔에서 Kubernetes 리소스를 조회할 수 있습니다.
 
 <a id="expose-dashboard"></a>
-### 대시보드 서비스 공개
+### 대시보드 서비스 공개 { #expose-dashboard }
 사용자 Kubernetes에는 대시보드를 공개하기 위한 `kubernetes-dashboard` 서비스 객체가 미리 생성되어 있습니다.
 
 ```
@@ -3697,6 +3778,7 @@ Events:            <none>
 
 그러나 `kubernetes-dashboard` 서비스 객체는 ClusterIP 유형이기 때문에 아직 클러스터 외부에 공개되어 있지 않습니다. 대시보드를 외부 공개하려면 서비스 객체를 LoadBalancer 유형으로 변경하거나 인그레스 컨트롤러와 인그레스 객체를 생성해야 합니다.
 
+<a id="expose-dashboard-change-into-loadbalancer"></a>
 #### LoadBalancer 서비스 객체로 변경
 
 `LoadBalancer` 유형으로 서비스 객체를 변경하면 클러스터 외부에 NHN Cloud Load Balancer가 생성되고, 로드 밸런서와 서비스 객체가 연결됩니다. 로드 밸런서와 연결된 서비스 객체를 조회하면 **EXTERNAL-IP** 필드에 로드 밸런서의 IP가 표시됩니다. `LoadBalancer` 유형의 서비스 객체에 대한 설명은 [LoadBalancer 서비스](/Container/NKS/ko/user-guide/#loadbalancer)를 참고하세요. 아래 그림은 `LoadBalancer` 유형의 서비스를 이용해 대시보드를 외부에 공개하는 구조를 나타냅니다.
@@ -3728,6 +3810,7 @@ kubernetes-dashboard   LoadBalancer   10.254.95.176   123.123.123.81   443:30963
 > [참고]
 > Kubernetes 대시보드는 자동 생성되는 사설 인증서를 사용하기 때문에 웹 브라우저의 종류와 보안 설정에 따라 안전하지 않은 페이지로 표시될 수 있습니다.
 
+<a id="expose-dashboard-open-services-with-ingress"></a>
 #### 인그레스(Ingress)를 이용한 서비스 공개
 
 인그레스는 클러스터 내부의 여러 서비스들로 접근하기 위한 라우팅을 제공하는 네트워크 객체입니다. 인그레스 객체의 설정은 인그레스 컨트롤러로 구동됩니다. `kubernetes-dashboard` 서비스 객체를 인그레스를 통해 공개할 수 있습니다. 인그레스와 인그레스 컨트롤러에 대한 설명은 [인그레스 컨트롤러](/Container/NKS/ko/user-guide/#ingress-controller)를 참고하세요. 아래 그림은 인그레스를 통해 대시보드를 외부에 공개하는 구조를 나타냅니다.
@@ -3780,7 +3863,7 @@ k8s-dashboard-ingress   nginx   *       123.123.123.44   80, 443   34s
 웹 브라우저에서 `https://{ADDRESS}`로 접속하면 Kubernetes 대시보드 페이지가 로딩됩니다. 로그인을 위해 필요한 토큰은 [대시보드 액세스 토큰](/Container/NKS/ko/user-guide/#dashboard-access-token)을 참고하세요.
 
 <a id="dashboard-access-token"></a>
-### 대시보드 액세스 토큰
+### 대시보드 액세스 토큰 { #dashboard-access-token }
 Kubernetes 대시보드에 로그인하려면 토큰이 필요합니다. 토큰은 다음 명령으로 얻을 수 있습니다.
 
 ```
@@ -3793,7 +3876,7 @@ eyJhbGc...-QmXA
 출력된 토큰을 브라우저의 토큰 입력 창에 입력하면 클러스터 관리자 권한을 부여 받은 사용자로 로그인할 수 있습니다.
 
 <a id="persistent-volume"></a>
-## 퍼시스턴트 볼륨
+## 퍼시스턴트 볼륨 { #persistent-volume }
 퍼시스턴트 볼륨(Persistent Volume, PV)는 물리 저장 장치(volume)를 표현하는 Kubernetes의 자원입니다. 하나의 PV는 하나의 NHN Cloud Block Storage와 연결됩니다. 자세한 내용은 [퍼시스턴트 볼륨](https://kubernetes.io/ko/docs/concepts/storage/persistent-volumes/) 문서를 참고하세요.
 
 PV를 파드에 연결해 사용하려면 퍼시스턴트 볼륨 클레임(Persistent Volume Claims, PVC) 객체가 필요합니다. PVC는 용량, 읽기/쓰기 모드 등 필요한 볼륨의 요구 사항을 정의합니다.
@@ -3801,7 +3884,7 @@ PV를 파드에 연결해 사용하려면 퍼시스턴트 볼륨 클레임(Persi
 PV와 PVC로 사용자는 사용하고 싶은 볼륨의 속성을 정의하고, 시스템은 사용자의 요구 사항에 맞는 볼륨 리소스를 할당하는 방식으로 자원의 사용과 관리를 분리합니다.
 
 <a id="pv-lifecycle"></a>
-### PV/PVC의 생명 주기
+### PV/PVC의 생명 주기 { #pv-lifecycle }
 PV와 PVC는 4단계의 생명 주기(life cycle)를 따릅니다.
 
 * 프로비저닝(provisioning)
@@ -3823,15 +3906,17 @@ PV를 파드에 마운트해 사용합니다.
 | 재사용(Recycle) | PV를 삭제할 때 연결된 볼륨을 삭제하지 않고 재사용할 수 있는 상태로 만듭니다. 이 방법은 사용 중단(deprecated)되었습니다. |
 
 <a id="storageclass"></a>
-### 스토리지 클래스(StorageClass)
+### 스토리지 클래스(StorageClass) { #storageclass }
 프로비저닝을 하기 위해서는 먼저 스토리지 클래스가 정의되어 있어야 합니다. 스토리지 클래스는 어떤 특성으로 스토리지들을 분류할 수 있는 방법을 제공합니다. 스토리지 제공자(provisioner)에 대한 정보를 포함해 미디어의 종류나 가용성 영역 등을 설정할 수 있습니다. 
 
+<a id="storageclass-storage-provider-provisioner"></a>
 #### 스토리지 제공자(provisioner)
 스토리지의 제공자 정보를 설정합니다. Kubernetes 버전에 따라 지원되는 스토리지 제공자 정보는 다음과 같습니다.
 
 * v1.19.13 이전 버전: provisioner 필드를 반드시 `kubernetes.io/cinder`로 설정해야 합니다.
 * v1.20.12 이후 버전: provisioner 필드를 `cinder.csi.openstack.org`로 설정해 사용할 수 있습니다.
 
+<a id="storageclass-parameters-parameter"></a>
 #### 파라미터(parameter)
 스토리지 클래스를 통해 다음의 파라미터를 설정할 수 있습니다.
 
@@ -3843,18 +3928,21 @@ PV를 파드에 마운트해 사용합니다.
     * 평촌 리전: **kr2-pub-a** 혹은 **kr2-pub-b**
     * 광주 리전: **kr3-pub-a** 혹은 **kr3-pub-b**
 
+<a id="storageclass-volume-binding-mode-volumebindingmode"></a>
 #### 볼륨 바인딩 모드(VolumeBindingMode)
 볼륨 바인딩 모드는 볼륨 바인딩과 동적 프로비저닝의 시작 시점을 제어합니다. 이 설정은 스토리지 제공자가 cinder.csi.openstack.org인 경우에만 설정 가능합니다. 
 
 * **Immediate**: 퍼시스턴트 볼륨 클레임이 생성되는 즉시 볼륨 바인딩과 동적 프로비저닝이 시작됩니다. 퍼시스턴트 볼륨 클레임이 생성되는 시점에는 볼륨을 연결할 파드에 대한 사전 지식이 없는 상태입니다. 그래서 볼륨의 가용성 영역과 파드가 스케줄링될 노드의 가용성 영역이 서로 다르면 경우 파드가 정상 동작하지 않습니다. 
 * **WaitForFirstConsumer**: 퍼시스턴트 볼륨 클레임이 생성될 때는 볼륨 바인딩과 동적 프로비저닝을 하지 않습니다. 이 퍼시스턴트 볼륨 클레임이 처음으로 파드에 연결되면, 파드가 스케줄링된 노드의 가용성 영역 정보를 기반으로 볼륨 바인딩과 동적 프로비저닝을 수행합니다. 따라서 Immediate 모드와 같은 볼륨의 가용성 영역과 인스턴스의 가용성 영역이 서로 달라 파드가 정상 동작하지 않는 경우가 발생하지 않습니다.
 
+<a id="storageclass-allow-volume-expansion-allowvolumeexpansion"></a>
 #### 볼륨 확장 허용(allowVolumeExpansion)
 생성된 볼륨의 확장 허용 여부를 설정합니다(미입력 시 false가 설정됩니다).
 
 * **True**: 볼륨 확장을 허용합니다.
 * **False**: 볼륨 확장을 허용하지 않습니다.
 
+<a id="storageclass-example-1"></a>
 #### 예시1
 아래 스토리지 클래스 매니페스트는 v1.19.13 이전 버전을 사용하는 Kubernetes 클러스터에서 사용할 수 있습니다. 파라미터를 통해 가용성 영역과 볼륨 타입을 지정할 수 있습니다.
 
@@ -3881,6 +3969,7 @@ NAME     PROVISIONER            RECLAIMPOLICY   VOLUMEBINDINGMODE   ALLOWVOLUMEE
 sc-ssd   kubernetes.io/cinder   Delete          Immediate           false                  3s
 ```
 
+<a id="storageclass-example-2"></a>
 #### 예시2
 아래 스토리지 클래스 매니페시트는 v1.20.12 이후 버전을 사용하는 Kubernetes 클러스터에서 사용할 수 있습니다. 볼륨 바인딩 모드를 WaitForFirstConsumer로 설정해 퍼시스턴트 볼륨 클레임이 파드에 연결될 때 볼륨 바인딩과 동적 프로비저닝을 시작합니다.
 
@@ -3906,7 +3995,7 @@ csi-storageclass   cinder.csi.openstack.org   Delete          WaitForFirstConsum
 ```
 
 <a id="static-provisioning"></a>
-### 정적 프로비저닝
+### 정적 프로비저닝 { #static-provisioning }
 
 정적 프로비저닝(static provisioning)은 사용자가 직접 블록 스토리지를 준비해야 합니다. NHN Cloud 웹 콘솔의 **Storage > Block Storage** 서비스 페이지에서 **블록 스토리지 생성** 버튼을 클릭해 PV와 연결할 블록 스토리지를 생성합니다. 블록 스토리지 가이드의 [블록 스토리지 생성](/Storage/Block%20Storage/ko/console-guide/#_1)을 참고하세요.
 
@@ -3991,7 +4080,7 @@ pv-static-001   10Gi       RWO            Delete           Bound    default/pvc-
 ```
 
 <a id="dynamic-provisioning"></a>
-### 동적 프로비저닝
+### 동적 프로비저닝 { #dynamic-provisioning }
 
 동적 프로비저닝(dynamic provisioning)은 스토리지 클래스에 정의된 속성을 참조하여 자동으로 블록 스토리지를 생성합니다. 동적 프로비저닝을 사용하기 위해서는 스토리지 클래스의 볼륨 바인딩 모드를 설정하지 않거나 **Immediate**로 설정해야 합니다.
 
@@ -4044,7 +4133,7 @@ persistentvolumeclaim/pvc-dynamic   Bound    pvc-1056949c-bc67-45cc-abaa-1d1bd9e
 > 동적 프로비저닝으로 생성된 블록 스토리지는 웹 콘솔에서 삭제할 수 없습니다. 또한 클러스터를 삭제할 때 자동으로 삭제되지 않습니다. 따라서 클러스터를 삭제하기 전에 PVC를 모두 삭제해야 합니다. PVC를 삭제하지 않고 클러스터를 삭제하면 과금될 수 있습니다. 동적 프로비저닝을 생성된 PV의 reclaimPolicy는 기본적으로 `Delete`로 설정되기 때문에 PVC만 삭제해도 PV와 블록 스토리지가 삭제됩니다.
 
 <a id="pod-pvc-mount"></a>
-### 파드에 PVC 마운트
+### 파드에 PVC 마운트 { #pod-pvc-mount }
 
 파드에 PVC를 마운트하려면 파드 매니페스트에 마운트 정보를 정의해야 합니다. `spec.volumes.persistenVolumeClaim.claimName`에 사용할 PVC 이름을 입력합니다. 그리고 `spec.containers.volumeMounts.mountPath`에 마운트할 경로를 입력합니다.
 
@@ -4094,10 +4183,11 @@ Filesystem      Size  Used Avail Use% Mounted on
 NHN Cloud 웹 콘솔 **Storage > Block Storage** 서비스 페이지에서도 블록 스토리지의 연결 정보를 확인할 수 있습니다.
 
 <a id="volume-expansion"></a>
-### 볼륨 확장
+### 볼륨 확장 { #volume-expansion }
 PersistentVolumeClaim (PVC) 개체를 편집하여 기존 볼륨의 크기를 조정할 수 있습니다. PVC 개체의 **spec.resources.requests.storage**항목의 수정을 통해 볼륨 사이즈를 변경할 수 있습니다. 볼륨 축소는 지원되지 않습니다. 볼륨 확장 기능을 사용하기 위해서는 StorageClass의 **allowVolumeExpansion** 속성이 **True**여야 합니다.
 
 
+<a id="volume-expansion-from-v11913-and-older"></a>
 #### v1.19.13 이전 버전의 볼륨 확장
 v1.19.13 이전 버전의 스토리지 제공자 **kubernetes.io/cinder**는 사용 중인 볼륨의 확장 기능을 제공하지 않습니다. 사용 중인 볼륨의 확장 기능을 사용하기 위해서는 v1.20.12 이후 버전의 **cinder.csi.openstack.org** 스토리지 제공자를 사용해야 합니다. 클러스터 업그레이드 기능을 통해 v1.20.12 이후 버전으로 업그레이드하여 **cinder.csi.openstack.org** 스토리지 제공자를 사용할 수 있습니다.
 
@@ -4144,14 +4234,15 @@ status:
   phase: Bound
 ```
 
+<a id="volume-expansion-from-v12012-and-older"></a>
 #### v1.20.12 이후 버전의 볼륨 확장
 v1.20.12 이후 버전의 스토리지 제공자 **cinder.csi.openstack.org**는 기본적으로 사용 중인 볼륨의 확장 기능을 지원합니다. PVC 개체의 **spec.resources.requests.storage**항목을 원하는 값으로 수정하여 볼륨 사이즈를 변경할 수 있습니다.
 
 <a id="service-integration"></a>
-## NHN Cloud 서비스 연동
+## NHN Cloud 서비스 연동 { #service-integration }
 
 <a id="ncr-integration"></a>
-### NHN Cloud Container Registry(NCR) 서비스 연동
+### NHN Cloud Container Registry(NCR) 서비스 연동 { #ncr-integration }
 NHN Cloud Container Registry에 저장한 이미지를 사용할 수 있습니다. 레지스트리에 저장된 이미지를 사용하기 위해서는 사용자 레지스트리에 로그인하기 위한 시크릿(secret)을 만들어야 합니다.
 
 NHN Cloud (Old) Container Registry를 사용하려면 다음과 같이 시크릿을 생성해야 합니다.
@@ -4201,12 +4292,13 @@ spec:
 > NHN Cloud Container Registry 사용 방법은 [NHN Cloud Container Registry(NCR) 사용자 가이드](/Container/NCR/ko/user-guide) 문서를 참고하세요.
 
 <a id="nas-integration"></a>
-### NHN Cloud NAS 서비스 연동
+### NHN Cloud NAS 서비스 연동 { #nas-integration }
 NHN Cloud에서 제공하는 NAS 볼륨을 PV로 활용할 수 있습니다. NAS 서비스를 사용하기 위해서는 v1.20 이후 버전의 클러스터를 사용해야 합니다. NHN Cloud NAS 사용에 대한 자세한 내용은 [NAS 콘솔 사용 가이드](/Storage/NAS%20(online)/ko/console-guide)를 참고하세요.
 
 > [참고]
 > NHN Cloud NAS 서비스는 현재(2024. 08.) 기준 일부 리전에서만 제공되고 있습니다. NHN Cloud NAS 서비스의 지원 리전에 대한 자세한 정보는 [NAS 서비스 개요](/Storage/NAS%20(online)/ko/overview)를 참고하세요.
 
+<a id="nas-integration-run-the-rpcbind-service-on-all-worker-nodes"></a>
 #### 모든 워커 노드에서 rpcbind 서비스 실행
 NAS 볼륨을 사용하려면 모든 워커 노드에서 rpcbind 서비스를 실행해야 합니다. 모든 워커 노드에 접속한 뒤 아래 명령어를 통해 rpcbind 서비스를 실행합니다.
 
@@ -4224,6 +4316,7 @@ $ systemctl start rpcbind
 | egress | TCP | 111 | IPv4 | NAS IP 주소 | rpc의 portmapper 포트, 방향: csi-nfs-node(워커 노드) → NAS |
 | egress | TCP | 635 | IPv4 | NAS IP 주소 |  rpc의 mountd 포트, 방향: csi-nfs-node(워커 노드) → NAS |
 
+<a id="nas-integration-install-csi-driver-nfs"></a>
 #### csi-driver-nfs 설치
 NHN Cloud NAS 서비스를 사용하기 위해 클러스터에 NHN Kubernetes Service(NKS)의 Addon 기능으로 [nfs-csi-plugin](/Container/NKS/ko/user-guide/#addon-mgmt-addon-nfs-csi-plugin)을 배포해야 합니다.
 
@@ -4234,6 +4327,7 @@ csi-driver-nfs를 사용하여 여러 개의 PV를 구성하는 경우 csi-drive
 <br>
 ![nfs-csi-driver-02.png](http://static.toastoven.net/prod_infrastructure/container/kubernetes/nfs-csi-driver-02.png)
 
+<a id="nas-integration-how-to-use-existing-nhn-cloud-nas-volume-when-provisioning"></a>
 #### 프로비저닝 시 기존 NHN Cloud NAS 볼륨을 이용하는 방법
 PV 매니페스트 작성 시 NAS 정보를 입력하거나 StorageClass 매니페스트에 NAS 정보를 입력해 기존 NAS 볼륨을 PV로 사용할 수 있습니다.
 
@@ -4436,6 +4530,7 @@ Filesystem                                                                 Size 
 ...
 ```
 
+<a id="nas-integration-how-to-create-new-nhn-cloud-nas-volume-when-provisioning"></a>
 #### 프로비저닝 시 새로운 NHN Cloud NAS 볼륨을 생성하는 방법
 StorageClass 및 PVC 매니페스트 작성 시 NAS 정보를 입력해 자동으로 생성된 NAS 볼륨을 PV로 사용할 수 있습니다.
 
@@ -4607,7 +4702,7 @@ tmpfs                                                                          1
 > 파드에 PV를 마운트하는 과정에서 subdirectory만 마운트되는 것이 아니라 NFS 스토리지 전체가 마운트되기 때문에 애플리케이션이 프로비저닝된 크기만큼 볼륨을 사용하도록 강제할 수 없습니다.
 
 <a id="encrypted-block-storage-integration"></a>
-### NHN Cloud 암호화 블록 스토리지 연동
+### NHN Cloud 암호화 블록 스토리지 연동 { #encrypted-block-storage-integration }
 NHN Cloud에서 제공하는 암호화된 블록 스토리지를 PV로 활용할 수 있습니다. NHN Cloud 암호화 블록 스토리지에 대한 자세한 내용은 [암호화 블록 스토리지](/Storage/Block%20Storage/ko/console-guide/#_2)를 참고하세요.
 
 > [참고]
@@ -4618,6 +4713,7 @@ NHN Cloud에서 제공하는 암호화된 블록 스토리지를 PV로 활용할
 > [주의]
 > v1.24.3 이전 버전의 클러스터를 업그레이드하지 않고 cinder-csi-plugin 컨테이너 이미지만 교체하여 사용하는 경우 오동작을 초래할 수 있습니다.
 
+<a id="encrypted-block-storage-integration-updating-cinder-csi-plugin-image-for-encrypted-block-storage-integration"></a>
 #### 암호화 블록 스토리지 연동을 위한 cinder-csi-plugin 이미지 업데이트
 아래 커맨드를 실행하여 현재 클러스터에 배포된 cinder-csi-plugin 이미지의 태그를 확인할 수 있습니다.
 
@@ -4655,6 +4751,7 @@ $ kubectl -n kube-system patch daemonset csi-cinder-nodeplugin -p "{\"spec\": {\
 > cinder-csi-plugin 컨테이너 이미지는 NHN Cloud NCR에서 관리되고 있습니다. 폐쇄망 환경에 구성된 클러스터는 인터넷에 연결되어 있지 않기 때문에 이미지를 정상적으로 받아오기 위해서는 Private URI를 사용하기 위한 환경 구성이 필요합니다. Private URI 사용법에 대한 자세한 내용은 [NHN Cloud Container Registry(NCR) 사용자 가이드](/Container/NCR/ko/user-guide/#private-uri)를 참고하세요.
 
 
+<a id="encrypted-block-storage-integration-static-provisioning"></a>
 #### 정적 프로비저닝
 PV를 생성하려면 암호화 블록 스토리지의 ID가 필요합니다. Storage > Block Storage 서비스 페이지의 블록 스토리지 목록에서 사용할 블록 스토리지를 선택합니다. 하단 정보 탭의 블록 스토리지 이름 항목에서 ID를 확인할 수 있습니다.
 
@@ -4688,6 +4785,7 @@ spec:
 
 PVC 매니페스트 작성 및 파드에 마운트하는 과정은 일반 블록 스토리지의 정적 프로비저닝과 동일합니다. 자세한 내용은 [정적 프로비저닝](/Container/NKS/ko/user-guide/#static-provisioning)을 참고하세요.
 
+<a id="encrypted-block-storage-integration-dynamic-provisioning"></a>
 #### 동적 프로비저닝
 스토리지 클래스 매니페스트 작성 시 암호화 블록 스토리지 생성에 필요한 정보를 입력해 자동으로 생성된 암호화 블록 스토리지를 PV로 사용할 수 있습니다.
 
@@ -4719,16 +4817,18 @@ PVC 매니페스트 작성 및 파드에 마운트하는 과정은 일반 블록
 
 
 <a id="etcd-encryption-with-skm"></a>
-### 기밀 데이터 암/복호화 시 Secure Key Manager 서비스 연동
+### 기밀 데이터 암/복호화 시 Secure Key Manager 서비스 연동 { #etcd-encryption-with-skm }
 
 NKS 클러스터는 secret 리소스를 데이터 저장소(etcd)에 저장할 때 데이터를 암호화해 저장합니다. NKS는 이 데이터를 암호화하기 위해 두 가지 방식을 제공합니다.
 
+<a id="etcd-encryption-with-skm-standard"></a>
 #### 기본 방식
 
 * 클러스터 생성 시 대칭 키를 자동 생성하여 컨트롤 플레인에 저장
 * 해당 키로 etcd 데이터를 암호화
 * 키 관리가 클러스터 내부에서 이루어짐
 
+<a id="etcd-encryption-with-skm-skm-integration"></a>
 #### SKM 연동 방식
 
 * 저장소 암호화 제공자를 Secure Key Manager(SKM)으로 설정

--- a/ko/version-guide.md
+++ b/ko/version-guide.md
@@ -1,21 +1,27 @@
-## Container > NHN Kubernetes Service(NKS) > 버전 가이드
+<!-- pre-align:aligned sig=c2b4f6b0a381 -->
+
+<a id="container-nhn-kubernetes-servicenks-version-guide"></a>
+## Container > NHN Kubernetes Service(NKS) > 버전 가이드 { #container-nhn-kubernetes-servicenks-version-guide }
 
 <a id="cluster-version-management"></a>
-## 클러스터 버전 관리
+## 클러스터 버전 관리 { #cluster-version-management }
 
 NKS 클러스터는 클러스터 컨트롤 플레인과 워커 노드 그룹별로 Kubernetes 버전과 플랫폼 버전을 관리합니다. 두 버전의 차이는 다음과 같습니다.
 
-### Kubernetes 버전
+<a id="kubernetes-version"></a>
+### Kubernetes 버전 { #kubernetes-version }
 - 업스트림 Kubernetes에서 정의하는 버전입니다.
 - NKS 클러스터를 구성하는 Kubernetes 주요 구성 요소의 버전을 결정합니다.
 - 주요 구성 요소: `kube-apiserver`, `kube-controller-manager`, `kube-scheduler`, `kubelet`, `kube-proxy`
 
-### 플랫폼 버전
+<a id="cluster-version-management-platform-version"></a>
+### 플랫폼 버전 { #cluster-version-management-platform-version }
 - NKS 서비스 수준에서 정의하는 버전입니다.
 - 클러스터를 구성하는 여러 구성 요소를 하나의 버전으로 정의해 관리합니다.
 - 주요 구성 요소: `containerd`, `etcd` 등 컨트롤 플레인 및 워커 노드 주요 구성 요소, 각종 시스템 구성 요소 및 시스템 관리 도구 등
 
-### 버전 상태에 따른 업그레이드 대상
+<a id="upgrade-targets-by-version-status"></a>
+### 버전 상태에 따른 업그레이드 대상 { #upgrade-targets-by-version-status }
 
 | Kubernetes 버전의 최신 여부 | 플랫폼 버전의 최신 여부 | 업그레이드 대상 |
 |----------------------------|----------------------|----------------|
@@ -27,14 +33,16 @@ NKS 클러스터는 클러스터 컨트롤 플레인과 워커 노드 그룹별�
 > 컨트롤 플레인의 버전 정보는 **클러스터 조회** 화면에서, 워커 노드 그룹의 버전 정보는 각 **워커 노드 그룹 조회** 화면에서 확인할 수 있습니다.
 
 <a id="support-policy"></a>
-## Kubernetes 버전 지원 정책
+## Kubernetes 버전 지원 정책 { #support-policy }
 
-### 클러스터 생성 가능 버전
+<a id="available-cluster-versions"></a>
+### 클러스터 생성 가능 버전 { #available-cluster-versions }
 - NKS에서 릴리스한 Kubernetes 버전 중 최신 3개 버전으로 신규 클러스터를 생성할 수 있습니다.
 - 신규 버전이 릴리스되면, 기존 생성 가능 버전 목록 중 가장 낮은 버전은 자동으로 제거됩니다.
 - Kubernetes 버전의 패치 버전은 내부 정책에 따라 업데이트될 수 있습니다.
 
-### 서비스 지원 정책
+<a id="service-support-policy"></a>
+### 서비스 지원 정책 { #service-support-policy }
 안정적인 서비스 운영을 위해 Kubernetes 버전별 서비스 지원 정책을 적용합니다.
 
 - NKS는 **Kubernetes 버전**을 기준으로 서비스 지원 여부가 결정됩니다.
@@ -46,6 +54,7 @@ NKS 클러스터는 클러스터 컨트롤 플레인과 워커 노드 그룹별�
 | **서비스 지원** | Kubernetes 버전 릴리스 후 약 14개월 미만 | 보장 | 가능 |
 | **서비스 미지원** | Kubernetes 버전 릴리스 후 약 14개월 이상 | 보장 안 됨 | 단, 서비스 지원 종료 후 10개월간 업그레이드 지원 |
 
+<a id="service-support-policy-example-lifecycle-of-version-v133-released-in-november-2025"></a>
 #### 예시: 2025년 11월 릴리스된 v1.33 버전의 수명주기
 
 | 구분 | 기간 | 주요 특징 |
@@ -61,21 +70,23 @@ NKS 클러스터는 클러스터 컨트롤 플레인과 워커 노드 그룹별�
 
 
 <a id="k8s-version-support-time-table"></a>
-## Kubernetes 버전별 지원 일정
+## Kubernetes 버전별 지원 일정 { #k8s-version-support-time-table }
 
 > [안내] 2025년 11월부터 Kubernetes 버전 지원 정책이 변경됩니다.
 > - v1.32까지는 기존 일정과 정책이 적용됩니다.
 > - v1.33부터는 신규 정책이 적용됩니다.
 > - 표의 날짜는 UTC+00:00 기준입니다.
 
-### 신규 정책 적용 버전 (v1.33 이상)
+<a id="new-policy-applied-version-v133-or-later"></a>
+### 신규 정책 적용 버전 (v1.33 이상) { #new-policy-applied-version-v133-or-later }
 
 | 버전 | 릴리스 | 서비스 지원 종료(업그레이드 지원) | 서비스 지원 종료(EOS) |
 |------|--------|---------------------------------|---------------------|
 | v1.33 | 2025.11 | 2027.01.31 | 2027.11.30 |
 | v1.34 | 2026.05 | 2027.07.31 | 2028.05.31 |
 
-### 기존 정책 적용 버전 (v1.32 이하)
+<a id="old-policy-applied-version-v132-or-earlier"></a>
+### 기존 정책 적용 버전 (v1.32 이하) { #old-policy-applied-version-v132-or-earlier }
 
 | 버전 | 릴리스 | 서비스 지원 종료(업그레이드 지원) | 서비스 지원 종료(EOS) |
 |------|--------|---------------------------------|---------------------|
@@ -86,10 +97,10 @@ NKS 클러스터는 클러스터 컨트롤 플레인과 워커 노드 그룹별�
 | v1.32.3 | 2025.05 | 2027.02.28 (예정) | 2027.02.28 (예정) |
 
 <a id="platform-version"></a>
-## 플랫폼 버전
+## 플랫폼 버전 { #platform-version }
 
 <a id="platform-version-info"></a>
-### 플랫폼 버전별 정보
+### 플랫폼 버전별 정보 { #platform-version-info }
 
 | 버전 | 릴리스 시점 | Kubernetes 호환 버전 | 설명 |
 |------|------------|--------------------|-----|
@@ -101,7 +112,7 @@ NKS 클러스터는 클러스터 컨트롤 플레인과 워커 노드 그룹별�
 | 1.202605.0 | 2026.05 | v1.30–v1.34 | 기능 개선<br>- 워커 노드 CGroup v1 → v2 마이그레이션 지원<br>- Kubernetes v1.34 클러스터의 `ImageVolume` feature gate 활성화<br>- kube-apiserver와 pod 간의 통신을 위한 konnectivity 지원<br>- etcd 업그레이드 지원 |
 
 <a id="platform-component-versions"></a>
-### 플랫폼 버전별 주요 컴포넌트 버전
+### 플랫폼 버전별 주요 컴포넌트 버전 { #platform-component-versions }
 
 | 플랫폼 버전 | etcd | containerd |
 | :--- | :--- | :--- |
@@ -112,7 +123,7 @@ NKS 클러스터는 클러스터 컨트롤 플레인과 워커 노드 그룹별�
 | **1.202605.0** | v3.5.29 | k8s v1.33 이하 : 1.7.27 </br> k8s v1.34 이상 : 2.2.1 |
 
 <a id="platform-version-cgroup-v2-support"></a>
-### CGroup v2 OS 이미지 사용을 위한 플랫폼 버전
+### CGroup v2 OS 이미지 사용을 위한 플랫폼 버전 { #platform-version-cgroup-v2-support }
 * 플랫폼 버전 1.202602.0 미만인 클러스터는 CGroup 버전이 v2로 설정된 OS 이미지를 사용할 수 없습니다.
 * OS 이미지의 릴리스 날짜에 따라 설정된 CGroup 버전이 다릅니다.
   * 2026/03/10 이전 릴리스 이미지: CGroup v1


### PR DESCRIPTION
LLM-matched alignment of `en`/`ja` heading structure to `ko` — heading levels, missing-section stubs, and anchor ids.

**Body text is never modified.** The model only sees heading outlines; edits apply to heading lines (and `<!-- TODO: translate body -->` stubs for missing sections) only.

## Analysis

| | |
| --- | --- |
| Engine | `api (Anthropic SDK)` |
| Model | `claude-sonnet-4-6` |
| Source → targets | `ko` → `en, ja` |
| Base ref | `beta` |
| Scope | 9 doc(s) scanned · 27 file(s) changed |
| Self-verify | ⚠️ 13 mismatch(es) remain |
| Jenkins build | http://cd.cloud.toastoven.net:8080/job/content_deploy/job/align-heading/job/main/132/ |
| Generated | 2026-07-13T13:04:12 |

## Heading compare (docs viewer)

ko ↔ en/ja heading 구조 비교 — base 브랜치(적용 전)와 이 PR(적용 후)를 각각 확인:

- **Base 브랜치** (`beta`): [Compare ↗](http://content-agent.cloud.toastoven.net:7700/compare-headings?url=https%3A%2F%2Fgithub.com%2FTOAST-DOCS%2FContainer-Kubernetes%2Ftree%2Fbeta&source=ko&langs=en%2Cja)
- **이 PR**: [Compare ↗](http://content-agent.cloud.toastoven.net:7700/compare-headings?url=https%3A%2F%2Fgithub.com%2FTOAST-DOCS%2FContainer-Kubernetes%2Fpull%2F470&source=ko&langs=en%2Cja)

## Link check

이 PR 의 링크 상태: [Link Check ↗](http://content-agent.cloud.toastoven.net:7700/link-check?url=https%3A%2F%2Fgithub.com%2FTOAST-DOCS%2FContainer-Kubernetes%2Fpull%2F470&ref=beta&langs=en%2Cja)

<!-- LINK_CHECK_SUMMARY -->

## Changes

| File | level fixed | inserted | body xl | id fixed | extra flagged | extra demoted | extra removed | marker | verify |
| --- | --: | --: | --: | --: | --: | --: | --: | :--: | :--: |
| `ko/backup-guide.md` | 0 | 0 | 0 | 0 | 0 | 0 | 0 | ✅ | ✅ |
| `en/backup-guide.md` | 0 | 0 | 0 | 0 | 0 | 0 | 0 | ✅ | ✅ |
| `ja/backup-guide.md` | 0 | 0 | 0 | 0 | 0 | 0 | 0 | ✅ | ✅ |
| `ko/gateway-api-guide.md` | 0 | 0 | 0 | 0 | 0 | 0 | 0 | ✅ | ✅ |
| `en/gateway-api-guide.md` | 0 | 0 | 0 | 0 | 0 | 0 | 0 | ✅ | ✅ |
| `ja/gateway-api-guide.md` | 0 | 0 | 0 | 0 | 0 | 0 | 0 | ✅ | ✅ |
| `ko/istio-guide.md` | 0 | 0 | 0 | 0 | 0 | 0 | 0 | ✅ | ✅ |
| `en/istio-guide.md` | 0 | 0 | 0 | 0 | 0 | 0 | 0 | ✅ | ✅ |
| `ja/istio-guide.md` | 0 | 0 | 0 | 0 | 0 | 0 | 0 | ✅ | ✅ |
| `ko/overview.md` | 0 | 0 | 0 | 0 | 0 | 0 | 0 | ✅ | ✅ |
| `en/overview.md` | 0 | 0 | 0 | 0 | 0 | 0 | 0 | ✅ | ✅ |
| `ja/overview.md` | 0 | 0 | 0 | 0 | 0 | 0 | 0 | ✅ | ✅ |
| `ko/public-api.md` | 0 | 0 | 0 | 0 | 0 | 0 | 0 | — | ✅ |
| `en/public-api.md` | 0 | 0 | 0 | 0 | 0 | 0 | 3 | — | ⚠️ 3 |
| `ja/public-api.md` | 0 | 2 | 0 | 0 | 0 | 0 | 0 | — | ✅ |
| `ko/release-notes.md` | 0 | 0 | 0 | 0 | 0 | 0 | 0 | ✅ | ✅ |
| `en/release-notes.md` | 0 | 0 | 0 | 0 | 0 | 0 | 0 | ✅ | ✅ |
| `ja/release-notes.md` | 0 | 3 | 0 | 0 | 0 | 0 | 0 | ✅ | ✅ |
| `ko/troubleshooting-guide.md` | 0 | 0 | 0 | 0 | 0 | 0 | 0 | ✅ | ✅ |
| `en/troubleshooting-guide.md` | 0 | 0 | 0 | 0 | 0 | 0 | 0 | ✅ | ✅ |
| `ja/troubleshooting-guide.md` | 1 | 0 | 0 | 0 | 0 | 0 | 0 | ✅ | ✅ |
| `ko/user-guide.md` | 0 | 0 | 0 | 0 | 0 | 0 | 0 | — | ✅ |
| `en/user-guide.md` | 4 | 0 | 0 | 0 | 0 | 0 | 0 | — | ✅ |
| `ja/user-guide.md` | 2 | 1 | 0 | 0 | 0 | 0 | 9 | — | ⚠️ 10 |
| `ko/version-guide.md` | 0 | 0 | 0 | 0 | 0 | 0 | 0 | ✅ | ✅ |
| `en/version-guide.md` | 0 | 0 | 0 | 0 | 0 | 0 | 0 | ✅ | ✅ |
| `ja/version-guide.md` | 0 | 0 | 0 | 0 | 0 | 0 | 0 | ✅ | ✅ |

<details><summary>남은 불일치 (검토 필요)</summary>

- `en/public-api.md`:
  - missing_in_target (ko#45/en#None)
  - missing_in_target (ko#50/en#None)
  - missing_in_target (ko#51/en#None)
- `ja/user-guide.md`:
  - extra_in_target (ko#None/ja#129)
  - extra_in_target (ko#None/ja#130)
  - extra_in_target (ko#None/ja#131)
  - extra_in_target (ko#None/ja#132)
  - extra_in_target (ko#None/ja#133)
  - missing_in_target (ko#130/ja#None)
  - missing_in_target (ko#131/ja#None)
  - missing_in_target (ko#132/ja#None)
  - missing_in_target (ko#133/ja#None)
  - missing_in_target (ko#134/ja#None)

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code) · `pre-align/fix_headings.py` on `TOAST-DOCS/Container-Kubernetes`