### PR TITLE
chore(pre-align): align heading structure (9 docs) with ko

### DIFF
--- a/en/user-guide.md
+++ b/en/user-guide.md
@@ -1,9 +1,9 @@
-<a id="container-nhn-kubernetes-service-nks-user-guide"></a>
+<!-- pre-align:aligned sig=98b43adf5be7 -->
 
+<a id="container-nhn-kubernetes-service-nks-user-guide"></a>
 ## Container > NHN Kubernetes Service(NKS) > User Guide { #container-nhn-kubernetes-service-nks-user-guide }
 
 <a id="cluster-headings"></a>
-
 ## Cluster { #cluster-headings }
 A cluster is a group of instances that make up the user's Kubernetes.
 
@@ -159,12 +159,10 @@ A cluster with a key pair configured operates under the permissions of the servi
 > * The cluster owner change feature is no longer provided. To allow a cluster to operate under the service user's permissions, use the key pair change feature.
 
 <a id="nodegroup-headings"></a>
-
 ## Node Group { #nodegroup-headings }
 A node group is a group of worker node instances that make up Kubernetes.
 
 <a id="nodegroup-show"></a>
-
 ### Query Node Groups { #nodegroup-show }
 Click the cluster name in the cluster list to view the list of node groups. The node group list shows brief information about each node group.
 
@@ -217,7 +215,6 @@ You can view the following information on the **Basic Information** tab:
 On the **Node List** tab, you can view the list of instances that make up the node group.
 
 <a id="nodegroup-create"></a>
-
 ### Create Node Groups { #nodegroup-create }
 Along with a new cluster, a default node group is created, but more node groups can be created depending on the needs. If higher specifications are required to run a container, or more worker node instances are required to scale out, node groups may be additionally created. Click **Create Node Groups** from the page of node group list, and the page of creating a node group shows up. The following items are required to create a node group:
 
@@ -238,7 +235,6 @@ Enter information as required and click **Create Node Groups**, and a node group
 > Only the user who created the cluster can create node groups.
 
 <a id="nodegroup-delete"></a>
-
 ### Delete Node Groups { #nodegroup-delete }
 Select the node group to delete from the node group list and click **Delete Node Group** to proceed with deletion. It takes about 5 minutes to delete a node group; more time may be required depending on the node group status.
 
@@ -249,7 +245,6 @@ All nodes included in the node group are deleted in the following order:
 * The node is deleted at the instance level.
 
 <a id="nodegroup-scale-out"></a>
-
 ### Add Nodes to a Node Group { #nodegroup-scale-out }
 You can add nodes to an operating node group. The current list of nodes will appear upon clicking the node list tab on the node group information query page. Click the Add Node button and enter the number of nodes to add them.
 
@@ -257,7 +252,6 @@ You can add nodes to an operating node group. The current list of nodes will app
 > Nodes cannot be added manually to a node group with the autoscaler enabled.
 
 <a id="nodegroup-scale-in"></a>
-
 ### Delete Nodes from a Node Group { #nodegroup-scale-in }
 Nodes can be deleted from operating node groups. The current list of nodes will appear upon clicking the node list tab on the node group information query page. A confirmation dialog box will appear when a user selects nodes for deletion and clicks the Delete Node button. When the user confirms the node name and selects the OK button, the node will be deleted.
 
@@ -271,7 +265,6 @@ All nodes included in the node group are deleted in the following order:
 > Nodes cannot be deleted manually from a node group with the autoscaler enabled.
 
 <a id="node-start-stop"></a>
-
 ### Stop and Start Nodes { #node-start-stop }
 Nodes can be stopped from node groups and started again. The current list of nodes will appear upon clicking the node list tab on the node group information query page. Nodes can be stopped when a user selects nodes and clicks the stop button. The stopped nodes can be restarted when the user selects them and clicks the start button.
 
@@ -313,7 +306,6 @@ The status icon on the node list tab is displayed based on the node's status. Th
 * Red: Node in an abnormal state
 
 <a id="use-gpu-nodegroup"></a>
-
 ### Use GPU Node Groups { #use-gpu-nodegroup }
 When you need to run GPU-based workloads through Kubernetes, you can create a node group composed of GPU instances.
 Select the `g2` type when selecting a flavor while creating the clusters or node groups to create a GPU node group.
@@ -436,7 +428,6 @@ totalMemory: 14.73GiB freeMemory: 14.62GiB
 > If you want to prevent workloads that do not require a GPU from being assigned to GPU nodes, refer to [Taints and Tolerations Overview](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/).
 
 <a id="autoscaler"></a>
-
 ### Autoscaler { #autoscaler }
 An autoscaler is a feature that automatically adjusts the number of nodes when a node group runs out of available resources or when node utilization stays below a certain threshold. It can be configured for each node group and operates independently. NKS supports two types of autoscalers.
 
@@ -462,7 +453,6 @@ The terms used in the autoscaler feature and their meanings are as follows:
 | Scale-in | Decreasing the number of nodes |
 
 <a id="metric-base-autoscaler"></a>
-
 #### Metric-Based Autoscaler
 The metric-based autoscaler operates based on NHN Cloud's [Cloud Monitoring](/Monitoring/Cloud%20Monitoring/en/overview/) service. A metric collection agent installed on worker nodes sends system metrics to Cloud Monitoring every minute. If the collected metrics exceed or fall below the configured threshold, nodes are automatically added or removed. The scale-out and scale-in features can each be enabled independently.
 
@@ -585,7 +575,6 @@ Nodes are scaled in when all of the following conditions are met:
 | 24 - | 28% | 6 | – | Below scale-out threshold → scale-down unneeded time measurement of 2 minutes begins<br>If the 10-minute wait time after scale-in (24 → 34) is satisfied thereafter, nodes will be removed one by one. |
 
 <a id="cluster-autoscaler"></a>
-
 #### Cluster Autoscaler
 Cluster Autoscaler works based on the cluster-autoscaler feature, which is an officially supported feature of the Kubernetes project. For more information, see [Cluster Autoscaler](https://github.com/kubernetes/autoscaler/tree/master/cluster-autoscaler).
 
@@ -1038,7 +1027,6 @@ autoscaler-test-default-w-ohw5ab5wpzug-node-0   Ready    <none>   22d   v1.28.3
 ```
 
 <a id="user-script-old"></a>
-
 ### User script (old) { #user-script-old }
 You can register a user script when creating clusters and additional node groups. A user script has the following features.
 
@@ -1059,7 +1047,6 @@ You can register a user script when creating clusters and additional node groups
         * Script standard output and standard error stream: `/var/log/userscript.output`
 
 <a id="user-script"></a>
-
 ### User script { #user-script }
 The features of a new version of user script are included in the node groups created after July 26, 2022. The following features are found in the new version.
 
@@ -1080,7 +1067,6 @@ The features of a new version of user script are included in the node groups cre
         2. New version user script
 
 <a id="instance-flavor-update"></a>
-
 ### Change instance flavor { #instance-flavor-update }
 Changes the instance flavor of a worker node group. The instance flavor of all worker nodes belonging to the worker node group is changed.
 
@@ -1112,7 +1098,6 @@ The flavors that can be changed to depend on the current instance flavor.
 * u2 flavor instances cannot have their flavor changed after creation. Changing to another u2 flavor is also not supported.
 
 <a id="custom-image"></a>
-
 ### Use Custom Images as Worker Images { #custom-image }
 
 You can create a worker node group using your custom images. This requires additional work (conversion to NKS worker node) in NHN Cloud Image Builder so that the custom image can be used as a worker node image. In Image Builder, you can create custom worker node images by creating image templates with the worker node application of NHN Kubernetes Service (NKS). For more information on Image Builder, see [Image Builder User Guide](/Compute/Image%20Builder/en/console-guide/#_1).
@@ -1170,7 +1155,6 @@ To use a custom image as a worker node image, perform the following steps in the
 ![nkscustom_image_3.png](http://static.toastoven.net/prod_infrastructure/container/kubernetes/nkscustom_image_3.png)
 
 <a id="extra-volumes"></a>
-
 ### Additional Block Storage { #extra-volumes }
 You can use additional block storage for a node group. You can specify additional block storage when creating a cluster or node group, or add additional block storage to an existing node group. Additional block storage has the following characteristics:
 
@@ -1189,7 +1173,6 @@ You can use additional block storage for a node group. You can specify additiona
 > Changing the settings of additional block storage involves unmounting existing volumes, which may affect services that are currently in use.
 
 <a id="extra-security-groups"></a>
-
 ### Additional Security Groups { #extra-security-groups }
 You can configure additional security groups for a node group. You can specify additional security groups when creating a cluster or node group, or configure additional security groups for an existing node group. Additional security groups have the following characteristics:
 
@@ -1206,7 +1189,6 @@ You can configure additional security groups for a node group. You can specify a
 > Changing additional security groups modifies the network settings, which may temporarily affect communication while the settings are being applied.
 
 <a id="fip-auto-bind"></a>
-
 ### Floating IP Auto-Assignment { #fip-auto-bind }
 You can use the floating IP auto-assignment feature for a node group. When this feature is enabled, a floating IP is automatically assigned to each node when it is created. You can choose whether to enable this feature when creating a cluster or an additional node group. Once set, the option cannot be changed later. The following items are required to enable the floating IP auto-assignment feature:
 
@@ -1225,12 +1207,10 @@ The floating IP auto-assignment feature has the following characteristics:
   * Even if the feature is disabled for a node group that had it enabled, the floating IPs assigned to existing nodes are not released.
 
 <a id="cluster-management"></a>
-
 ## Cluster Management { #cluster-management }
 To manage and operate a cluster from a remote host, you need `kubectl`, the command-line tool (CLI) provided by Kubernetes.
 
 <a id="kubectl-install"></a>
-
 ### Install kubectl { #kubectl-install }
 kubectl can be used immediately by downloading the executable file without any special installation process. The download commands for each operating system are as follows:
 
@@ -1269,7 +1249,6 @@ $ export PATH=$PATH:$(pwd)
 ```
 
 <a id="kubectl-set-kubeconfig"></a>
-
 ### Configuration { #kubectl-set-kubeconfig }
 To access Kubernetes cluster with kubectl, cluster configuration file (kubeconfig) is required. On the NHN Cloud web console, open the **Container > NHN Kubernetes Service(NKS)** page and select a cluster to access. From **Basic Information**, click **Download** of **Configuration Files** to download a configuration file. Move the downloaded configuration file to a location of your choice to serve it as a reference for kubectl execution.
 
@@ -1285,7 +1264,6 @@ $ export KUBECONFIG={cluster configuration file path}
 You may copy cluster configuration file path to `$HOME/.kube/config`, which is the default configuration file of kubectl, if you don't want to save it to an environment variable. However, when there are many clusters, it is easier to change environment variables.
 
 <a id="kubectl-check-connection"></a>
-
 ### Check Connection { #kubectl-check-connection }
 Use the `kubectl version` command to verify that the configuration is correct. If there are no issues, `Server Version` is displayed.
 
@@ -1299,7 +1277,6 @@ Server Version: version.Info{Major:"1", Minor:"15", GitVersion:"v1.15.7", GitCom
 * Server Version: Version information of Kubernetes that makes up the cluster
 
 <a id="certificatesigningrequest"></a>
-
 ### CSR(CertificateSigningRequest) { #certificatesigningrequest }
 Using the Certificate API of Kubernetes, you can request and issue the X.509 certificate for a Kubernetes API client. CSR resource lets you request a certificate and decide to accept/reject the request. For more information, see the [Certificate Signing Requests](https://kubernetes.io/docs/reference/access-authn-authz/certificate-signing-requests/) document.
 
@@ -1404,7 +1381,6 @@ status:
 > * Pyeongchon region: Clusters created on December 24, 2020, or later
 
 <a id="admission-controller"></a>
-
 ### Admission Controller Plugin { #admission-controller }
 The admission controller can intercept a Kubernetes API server request and change objects or deny the request. See [Admission Controller](https://kubernetes.io/docs/reference/access-authn-authz/admission-controllers/) for more information about the admission controller. For usage examples of the admission controller, see [Admission Controller Guide](https://kubernetes.io/blog/2019/03/21/a-guide-to-kubernetes-admission-controllers/).
 
@@ -1445,7 +1421,6 @@ All default active admission controllers per Kubernetes version are enabled. The
 * PodSecurityPolicy
 
 <a id="cluster-upgrade"></a>
-
 ### Cluster Upgrade { #cluster-upgrade }
 NHN Kubernetes Service (NKS) supports upgrading Kubernetes components in operating Kubernetes clusters.
 
@@ -1626,7 +1601,6 @@ Verify that the resources that existing users have been operating are compatible
 When all resources in the Blue environment are decommissioned, the versions of the control plane and all worker node groups will all match.
 
 <a id="api-endpoint-ipacl"></a>
-
 ### Apply IP Access Control to Cluster API Endpoints { #api-endpoint-ipacl }
 You can enforce or disable IP access control to cluster API endpoints.
 For more information about the IP access control feature, see [IP Access Control](/Network/Load%20Balancer/en/overview/#ip).
@@ -1642,7 +1616,6 @@ The following rules apply when adding IP access control targets for a cluster AP
 * At least one IP access control target must exist.
 
 <a id="rotate-certificate"></a>
-
 ### Renew Cluster Certificates { #rotate-certificate }
 Kubernetes requires PKI certificates for TLS authentication between components. For more information about PKI certificates, see [PKI Certificates and Requirements](https://kubernetes.io/docs/setup/best-practices/certificates/). When you create an NKS cluster, the required certificates are generated automatically, and the default validity period for these certificates is set to 5 years.
 
@@ -1677,7 +1650,6 @@ To use the certificate renewal feature, follow the steps below:
 > To minimize the impact of these operations, you should avoid performing tasks such as creating new Pods while certificate renewal is in progress.
 
 <a id="k8s-component"></a>
-
 ### Kubernetes Component Configuration { #k8s-component }
 
 You can configure various options for Kubernetes components. These options can be set when creating a cluster and can also be changed after the cluster is created.
@@ -1690,7 +1662,6 @@ The components and options supported for configuration by operation area are as 
 > * The configuration of components running on worker nodes can be set per worker node group. (Only available for platform version 1.202602.0 and later)
 
 <a id="control-plain-options"></a>
-
 ### Control Plane Options { #control-plain-options }
 
 | Component | Option | Description |
@@ -1701,7 +1672,6 @@ The components and options supported for configuration by operation area are as 
 | kube-controller-manager | unhealthy-zone-threshold | Defines the threshold for the ratio of NotReady nodes at which a zone is considered unhealthy.<br>(Unit: percentage, Default: 55, Min: 0, Max: 100) |
 
 <a id="worker-node-options"></a>
-
 ### Worker Node Options { #worker-node-options }
 
 | Component | Option | Description |
@@ -1710,7 +1680,6 @@ The components and options supported for configuration by operation area are as 
 | kubelet | max-pods | Defines the maximum number of pods that can run on a node.<br>(Default: 110, Min: 1, Max: the maximum number of pod IPs that can be created, calculated based on the pod network and subnet size settings)<br>Supported in platform version 1.202602.0 and later. |
 
 <a id="k8s-label"></a>
-
 ### Kubernetes Label Configuration { #k8s-label }
 You can use the Kubernetes label setting for each node group. When this feature is enabled, the user-defined labels are automatically applied to the nodes when they are created. Labels are key-value pairs attached to Kubernetes objects such as pods and nodes, and are used to identify characteristics of those objects. For a detailed description of labels, see [Labels and Selectors](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/).
 
@@ -1740,7 +1709,6 @@ A label key can have a prefix and a name separated by a slash (/), and the prefi
 > * When you change the Kubernetes label configuration, the updated settings are applied starting from newly created nodes.
 
 <a id="oidc-auth"></a>
-
 ### OIDC Authentication Configuration { #oidc-auth }
 
 OIDC (OpenID Connect) is an interoperable authentication protocol based on the OAuth 2.0 framework. With OIDC, you can authenticate users through an external authentication service. For detailed information on how OIDC works, see [What is OpenID Connect](https://openid.net/developers/how-connect-works/).
@@ -1760,7 +1728,6 @@ NKS clusters can be configured to handle authentication using OIDC. The configur
 | Signing Algs | X | List of allowed JOSE asymmetric signing algorithms. Default: 'RS256' |
 
 <a id="control-plane-k8s-log"></a>
-
 ### Store Control Plane Kubernetes Component Logs { #control-plane-k8s-log }
 NHN Kubernetes Service (NKS) provides logs for key Kubernetes components running on the control plane. These logs help you better understand various events and operations occurring within the cluster, and can be useful for diagnosing service status and troubleshooting issues.
 
@@ -1879,7 +1846,6 @@ The path where logs are created in the OBS container is as follows:
   nks-test-master-0/kube-apiserver/2025/04/20250428-101500-index0.gz
 
 <a id="k8s-taint"></a>
-
 ### Kubernetes Taint Configuration { #k8s-taint }
 You can use the Kubernetes taint configuration feature for each node group. Node groups created with this feature are initialized with the taints that you configured. For more information about taints, see [Taints and Tolerations](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/).
 
@@ -1923,7 +1889,6 @@ You must specify one of the following three values:
 * If you change the Kubernetes taint configuration, the updated configuration is applied to newly created nodes going forward.
 
 <a id="konnectivity-description"></a>
-
 ### konnectivity { #konnectivity-description }
 
 Konnectivity is a component in Kubernetes that securely proxies network communication between the control plane (API server) and worker nodes. Previously, the API server had to access the kubelet or pods on a node directly, which made network configuration complex.
@@ -1947,11 +1912,9 @@ The Konnectivity Server and Konnectivity Agent first establish a connection to c
 > Konnectivity is available on platform version 1.202605.0 or later.
 
 <a id="worker-node-management"></a>
-
 ## Manage Worker Nodes { #worker-node-management }
 
 <a id="container-management"></a>
-
 ### Manage Containers { #container-management }
 
 <a id="container-management-clusters-of-kubernetes-v1243-or-older"></a>
@@ -1964,7 +1927,6 @@ Clusters of Kubernetes v1.24.3 or older use Docker to comprise the container run
 Clusters of Kubernetes v1.24.3 or later use containerd to comprise the container runtime. In the worker node, you can use nerdctl instead of the docker CLI to view the container status and the container image. For more details and usage on nerdctl, see [nerdctl: Docker-compatible CLI for containerd](https://github.com/containerd/nerdctl#nerdctl-docker-compatible-cli-for-containerd).
 
 <a id="network-management"></a>
-
 ### Network Management { #network-management }
 
 <a id="network-management-default-network-interface"></a>
@@ -2049,7 +2011,6 @@ route add -net 0.0.0.0/0 gw 192.168.0.1 dev eth1 metric 0
 ```
 
 <a id="kubelet-argument"></a>
-
 ### Kubelet Custom Arguments Setting Feature { #kubelet-argument }
 A kubelet is a node agent that runs on all worker nodes. The kubelet receives input for many settings using command-line arguments. The kubelet custom arguments setting feature provided by NKS allows you to add arguments that are input at kubelet startup. You can set up kubelet custom arguments and apply them to your system as follows.
 
@@ -2065,7 +2026,6 @@ A kubelet is a node agent that runs on all worker nodes. The kubelet receives in
 > * The configured custom arguments are applied even after a system restart.
 
 <a id="containerd-registry-config"></a>
-
 ### Custom containerd Registry Settings Feature (deprecated) { #containerd-registry-config }
 
 > [Caution]
@@ -2173,7 +2133,6 @@ echo '[ { "registry": "user-defined.registry.io", "endpoint_list": [ "http://use
 >     * If you do not want to use the `docker.io` registry, you can simply not include any settings for the `docker.io` registry. However, at least one registry setting must exist.
 
 <a id="constraints-on-cgroup"></a>
-
 ### Constraints Based on Kubernetes Version and CGroup Version { #constraints-on-cgroup }
 CGroup (Control Group) is a Linux kernel feature that allows you to limit, isolate, and monitor the usage of system resources such as CPU, memory, disk I/O, and network for groups of processes. It is one of the core foundations of container technologies, including Kubernetes. CGroup started with version 1 (v1) and evolved to version 2 (v2) with enhanced memory and I/O control capabilities. Because it is a Linux kernel feature, CGroup v2 has a dependency on the Linux kernel. Therefore, CGroup v2 is only supported on relatively recent distributions and versions.
 
@@ -2203,14 +2162,12 @@ The OS image distributions and versions that support changing the CGroup version
 Node groups created using an OS image whose default CGroup version is v1 and that cannot be changed to v2 cannot be upgraded to Kubernetes v1.34 using the rolling upgrade method. In this case, you can upgrade the node group using the Blue-Green method.
 
 <a id="worker-management-caution"></a>
-
 ### Worker Node Management Precautions { #worker-management-caution }
 * You must not arbitrarily delete container images that have been pulled to worker nodes. Pods required by the NKS cluster may fail to run.
 * If you forcibly stop the system using commands such as `shutdown`, `halt`, or `poweroff`, you will not be able to restart it from the console. Use the worker node start/stop feature instead.
 * You must not modify various configuration files within the worker node or manipulate system services. Critical issues may occur in the NKS cluster.
 
 <a id="cni"></a>
-
 ## CNI (Container Network Interface) { #cni }
 NHN Kubernetes Service (NKS) provides different types of Container Network Interface (CNI) through the Addon feature. When creating a cluster, you can select one of the following CNIs: Calico-VXLAN, Calico-eBPF, or Cilium. The default setting is Calico-VXLAN. Calico-eBPF utilizes the BGP routing protocol for container workloads and leverages eBPF technology for direct communication, while certain segments—such as NodePort—rely on VXLAN. For more information about Calico's eBPF, see [about eBPF](https://docs.tigera.io/calico/latest/about/kubernetes-training/about-ebpf). Cilium is based on a VXLAN overlay network and uses eBPF technology to provide high network performance. For more information about Cilium's eBPF, see [eBPF Datapath](https://docs.cilium.io/ko/stable/network/ebpf/).
 
@@ -2247,7 +2204,6 @@ Notes
 > To use those images, you must update Calico to v3.28.2 or later through the addon management feature.
 
 <a id="security-group"></a>
-
 ## Security Group { #security-group }
 When you set Enhanced Security Rules to True during cluster creation, only required security rules are created when creating a worker node security group.
 
@@ -2341,7 +2297,6 @@ If you don't use enhanced security rules, additional security rules are created 
 
 
 <a id="addon-mgmt"></a>
-
 ## Add-on Management Feature { #addon-mgmt }
 An add-on is a component that is not a required component of a Kubernetes cluster, but is provided to extend the functionality of an NKS cluster or to provide specialized functionality. Add-ons can include components that perform functions such as networking, service discovery, monitoring, storage provisioning, and more. Users can install/update/remove add-ons provided by NHN Cloud to the cluster through the add-on management feature.
 
@@ -2582,12 +2537,10 @@ NFS CSI Plugin is a CSI driver that can provision and manage NFS in NHN Cloud.
         * Fixed an issue where the optional snapshot configuration was being required as mandatory.
 
 <a id="loadbalancer-service"></a>
-
 ## LoadBalancer Service { #loadbalancer-service }
 A pod is the basic execution unit of a Kubernetes application and is connected to the cluster network via a CNI (container network interface). By default, pods are not accessible from outside the cluster. To expose a pod's services to the outside of the cluster, you need to create a path to expose to the outside using the Kubernetes `LoadBalancer` Service object. Creating a LoadBalancer service object creates an NHN Cloud Load Balancer outside the cluster and associates it with the service object.
 
 <a id="create-webserver-pod"></a>
-
 ### Create a web server pod { #create-webserver-pod }
 Write a manifest file for a Deployment object that runs two nginx pods as shown below, and create the object.
 
@@ -2629,7 +2582,6 @@ nginx-deployment-7fd6966748-wv7rd   1/1     Running   0          4m13s
 ```
 
 <a id="create-lb-service"></a>
-
 ### Create a LoadBalancer service { #create-lb-service }
 To define a service object in Kubernetes, you need a manifest composed of the following items.
 
@@ -2688,7 +2640,6 @@ nginx-svc    LoadBalancer   10.254.134.18   123.123.123.30   8080:30013/TCP   3m
 > Load balancer IP is a floating IP allowing external access. You can check it on the **Network > Floating IP** page.
 
 <a id="internet-test-via-service"></a>
-
 ### Test the service via the internet { #internet-test-via-service }
 Send an HTTP request to a floating IP associated with a load balancer to see whether the web server pod in a Kubernetes cluster responds. Since the TCP/8080 port of a service object is attached to the TCP/80 port of a pod, the request must be sent to the TCP/8080 port. If the external load balancer, service object, and pod are well associated, the web server shall respond to the nginx default page.
 
@@ -2722,7 +2673,6 @@ Commercial support is available at
 ```
 
 <a id="advanced-lb-configuration"></a>
-
 ### Configure advanced load balancer options { #advanced-lb-configuration }
 When defining service objects in Kubernetes, you can set several options for the load balancer. You can set the following.
 
@@ -2750,7 +2700,6 @@ When defining service objects in Kubernetes, you can set several options for the
 * L7 rules and conditions
 
 <a id="advanced-lb-configuration-global-setting-and-per-listener-setting"></a>
-
 #### Global settings and per-listener settings
 Each setting item can be configured as either a global setting or a per-listener setting. If neither a global setting nor a per-listener setting is configured, the default value for that setting is used.
 
@@ -2758,7 +2707,6 @@ Each setting item can be configured as either a global setting or a per-listener
 * Global setting: Applied to the target listener when no per-listener setting exists for that listener.
 
 <a id="advanced-lb-configuration-format-of-per-listener-setting"></a>
-
 #### Per-listener setting format
 Per-listener settings can be set by appending a prefix representing the listener to the global settings key. The prefix representing the listener is the service object's port protocol (`spec.ports[].protocol`) and port number (`spec.ports[].port`) concatenated with a dash (`-`). For example, if the protocol is TCP and the port number is 80, the prefix is `TCP-80`. If you want to set session affinity for the listener associated with this port, you can set it in TCP-80.loadbalancer.nhncloud/pool-session-persistence under .metadata.annotations.
 
@@ -2813,7 +2761,6 @@ When this manifest is applied, the per-listener settings are configured as shown
 >
 
 <a id="loadbalancer-update-without-modification"></a>
-
 #### Update a load balancer without changing its settings
 
 If you need to update a load balancer without changing its settings — for example, to update a certificate — you can use the following command.
@@ -2828,7 +2775,6 @@ Once the load balancer update starts, the annotation set by the above command is
 > This feature works on clusters with a platform version of 1.202605.0 or later.
 
 <a id="advanced-lb-configuration-setting-load-balancer-name"></a>
-
 #### Set load balancer name
 
 You can set the name of the load balancer.
@@ -2846,7 +2792,6 @@ You can set the name of the load balancer.
 > * Creating a load balancer with the same name within the same project
 
 <a id="advanced-lb-configuration-set-load-balancer-type"></a>
-
 #### Set load balancer type
 You can set the type of the load balancer. For more information about load balancers, see the [Load Balancer Console User Guide](/Network/Load%20Balancer/en/console-guide/).
 
@@ -2857,7 +2802,6 @@ You can set the type of the load balancer. For more information about load balan
     * dedicated: Creates a 'dedicated' type load balancer.
 
 <a id="advanced-lb-configuration-set-static-routes"></a>
-
 #### Configure static routes
 You can configure whether to apply static routes to the load balancer.
 
@@ -2871,7 +2815,6 @@ You can configure whether to apply static routes to the load balancer.
 > The static route setting is available for clusters created after August 27, 2024 or clusters that have had their k8s version upgraded.
 
 <a id="advanced-lb-configuration-set-the-session-affinity"></a>
-
 #### Configure session affinity
 You can configure session affinity for the load balancer.
 
@@ -2887,7 +2830,6 @@ You can configure session affinity for the load balancer.
     * Can be changed after the load balancer is created.
 
 <a id="advanced-lb-configuration-set-whether-to-keep-a-floating-ip-address"></a>
-
 #### Set whether to keep the floating IP address
 A floating IP is associated with the load balancer. When deleting a load balancer or changing the floating IP, you can configure whether to delete or retain the floating IP associated with the load balancer.
 
@@ -2910,7 +2852,6 @@ A floating IP is associated with the load balancer. When deleting a load balance
 
 
 <a id="advanced-lb-configuration-set-the-load-balancer-ip"></a>
-
 #### Set load balancer IP
 You can set the IP of the load balancer when creating it.
 
@@ -2942,7 +2883,6 @@ spec:
 ```
 
 <a id="advanced-lb-configuration-set-whether-to-use-the-floating-ip"></a>
-
 #### Set Whether to Use Floating IPs
 You can set whether to use floating IPs when creating the load balancer.
 
@@ -2987,7 +2927,6 @@ Depending on the combination of floating IP usage and load balancer IP setting, 
 
 
 <a id="advanced-lb-configuration-set-vpc"></a>
-
 #### Set VPC
 You can set a VPC to which the load balancer is connected when creating a load balancer.
 
@@ -2996,7 +2935,6 @@ You can set a VPC to which the load balancer is connected when creating a load b
 * If not set, the VPC configured when the cluster was created is used.
 
 <a id="advanced-lb-configuration-set-subnet"></a>
-
 #### Set Subnet
 You can set a subnet to which the load balancer is connected when creating a load balancer. The load balancer's private IP is connected to the set subnet. If no member subnet is set, worker nodes connected to this subnet are added as load balancer members.
 
@@ -3027,7 +2965,6 @@ spec:
 ```
 
 <a id="advanced-lb-configuration-set-member-subnet"></a>
-
 #### Set Member Subnets
 When creating a load balancer, you can set a subnet to which load balancer members will be connected. Worker nodes connected to this subnet are added as load balancer members.
 
@@ -3089,7 +3026,6 @@ spec:
 
 
 <a id="advanced-lb-configuration-set-the-listener-connection-limit"></a>
-
 #### Set Listener Connection Limit
 You can set the connection limit for a listener.
 
@@ -3104,7 +3040,6 @@ You can set the connection limit for a listener.
 
 
 <a id="advanced-lb-configuration-set-the-listener-protocol"></a>
-
 #### Set the listener protocol
 You can set the protocol for a listener.
 
@@ -3196,7 +3131,6 @@ metadata:
 > Deleting a certificate from Certificate Manager that is associated with a listener might affect the behavior of the load balancer.
 
 <a id="advanced-lb-configuration-set-the-listener-proxy-protocol"></a>
-
 #### Set the listener proxy protocol (Proxy Protocol)
 When the listener protocol is TCP or HTTPS, you can set the proxy protocol to the listener. For more information on proxy protocol, see [Load Balancer Proxy Mode](/Network/Load%20Balancer/en/overview/#_4).
 
@@ -3207,7 +3141,6 @@ When the listener protocol is TCP or HTTPS, you can set the proxy protocol to th
     * false: Disables the proxy protocol. This is the default value if not set.
 
 <a id="advanced-lb-configuration-set-the-load-balancing-method"></a>
-
 #### Set the load balancing method
 You can set the load balancing method.
 
@@ -3220,7 +3153,6 @@ You can set the load balancing method.
 
 
 <a id="advanced-lb-configuration-set-the-health-check-protocol"></a>
-
 #### Set the health check protocol
 You can set the health check protocol.
 
@@ -3252,7 +3184,6 @@ The HTTP status code can be configured as follows:
 * If you do not set a value or enter a value that does not conform to the rule, it is set to the default value of 200.
 
 <a id="advanced-lb-configuration-set-the-health-check-interval"></a>
-
 #### Set the health check interval
 You can set the health check interval.
 
@@ -3263,7 +3194,6 @@ You can set the health check interval.
 * If you do not set a value or enter a value outside the range, it is set to the default value of 60.
 
 <a id="advanced-lb-configuration-set-the-health-check-maximum-response-time"></a>
-
 #### Set the health check maximum response time
 You can set the health check maximum response time.
 
@@ -3276,7 +3206,6 @@ You can set the health check maximum response time.
 * However, if the entered value or configured value is greater than the health check interval, it is set to 1/2 of the health check interval setting.
 
 <a id="advanced-lb-configuration-set-the-maximum-number-of-retries-for-a-health-check"></a>
-
 #### Set the maximum number of retries for a health check
 You can set the maximum number of retries for a health check.
 
@@ -3286,7 +3215,6 @@ You can set the maximum number of retries for a health check.
 * If you do not set a value or enter a value outside the range, it is set to the default value of 3.
 
 <a id="advanced-lb-configuration-health-check-port-settings"></a>
-
 #### Set the health check port
 You can set the member port to be targeted for health checks.
 
@@ -3297,7 +3225,6 @@ You can set the member port to be targeted for health checks.
 * If you do not set a value or enter a value outside the range, it is set to the default value of 0.
 
 <a id="advanced-lb-configuration-health-check-host-header-settings"></a>
-
 #### Set the health check host header
 You can set the field value of the host header to use for health checks.
 
@@ -3306,7 +3233,6 @@ You can set the field value of the host header to use for health checks.
 * If the health check protocol is set to TCP, the value configured in this field is ignored.
 
 <a id="advanced-lb-configuration-setting-keep-alive-timeout"></a>
-
 #### Set keep-alive timeout
 You can set the keep-alive timeout value.
 
@@ -3320,7 +3246,6 @@ You can set the keep-alive timeout value.
 > keep-alive timeout can be set up on clusters that have been upgraded to v1.24.3 or later after November 28, 2023, or are newly created.
 
 <a id="advanced-lb-configuration-l7-rules"></a>
-
 #### L7 rules
 You can set L7 rules per listener. L7 rules work as follows:
 
@@ -3352,7 +3277,6 @@ The following constraints apply to L7 rule settings:
 * L7 rules configured for the same listener must use different names.
 
 <a id="advanced-lb-configuration-l7-conditions"></a>
-
 #### L7 Conditions
 You can set L7 conditions for each L7 rule. L7 conditions work as follows:
 
@@ -3455,17 +3379,14 @@ spec:
 ```
 
 <a id="ingress-controller"></a>
-
 ## Ingress Controller { #ingress-controller }
 Ingress Controller routes HTTP and HTTPS requests from cluster externals to internal services, in reference of the rules that are defined at ingress object so as to provide SSL/TSL closure and virtual hosting. For more details on Ingress Controller and Ingress, see [Ingress Controller](https://kubernetes.io/ko/docs/concepts/services-networking/ingress-controllers/), [Ingress](https://kubernetes.io/ko/docs/concepts/services-networking/ingress/).
 
 <a id="install-nginx-ingress-controller"></a>
-
 ### Install NGINX Ingress Controller { #install-nginx-ingress-controller }
 NGINX Ingress Controller is one of the most frequently used ingress controllers. For more details, see [NGINX Ingress Controller](https://kubernetes.github.io/ingress-nginx/) and [NGINX Ingress Controller for Kubernetes](https://www.nginx.com/products/nginx-ingress-controller/). For installation of NGINX Ingress Controller, see [Installation Guide](https://kubernetes.github.io/ingress-nginx/deploy/).
 
 <a id="uri-based-service-routing"></a>
-
 ### URI-Based Service Routing { #uri-based-service-routing }
 Ingress controller can diverge services based on URI. The following figure shows the structure of a simple example of service divergence based on URI.
 
@@ -3689,7 +3610,6 @@ service "tea-svc" deleted
 ```
 
 <a id="host-based-service-routing"></a>
-
 ### Host-Based Service Routing { #host-based-service-routing }
 Ingress controller can diverge services based on the host name. The following figure shows the structure of a simple example of service divergence based on the host name.
 
@@ -3789,7 +3709,6 @@ $ curl 123.123.123.44/unknown
 ```
 
 <a id="ingress-nginx-internal-communication"></a>
-
 ### ingress-nginx Controller Internal Communication Structure and Cautions { #ingress-nginx-internal-communication }
 When exposing a service externally through the ingress-nginx controller, the path through which requests are forwarded to the workload differs depending on the location of the client sending the request (inside or outside the cluster).
 
@@ -3821,7 +3740,6 @@ Internal Pod → ingress-nginx Service (ClusterIP) → ingress-nginx Controller 
 - We recommend that you use the Service DNS instead of the Ingress domain for internal communication. For communication between internal Pods, use the Service directly, and use Ingress only for externally exposed endpoints.
 
 <a id="k8s-dashboard"></a>
-
 ## Kubernetes Dashboard { #k8s-dashboard }
 NHN Kubernetes Service (NKS) provides a default web UI dashboard. For more information about the Kubernetes dashboard, see [Web UI (Dashboard)](https://kubernetes.io/ko/docs/tasks/access-application-cluster/web-ui-dashboard/).
 
@@ -3957,7 +3875,6 @@ eyJhbGc...-QmXA
 Enter the output token in the token input field of the browser to log in as a user with cluster administrator privileges.
 
 <a id="persistent-volume"></a>
-
 ## Persistent Volume { #persistent-volume }
 Persistent Volume or PV is a Kubernetes resource representing physical storage volume. One PV is attached to one NHN Cloud Block Storage. For more details, see [Persistent Volumes](https://kubernetes.io/ko/docs/concepts/storage/persistent-volumes/).
 
@@ -3966,7 +3883,6 @@ Persistent Volume Claims, or PVC is required to attach PV to pods. PVC defines n
 With PV and PVC, users can define the attributes of a volume of choice, while the system separates the use of resources from management by assigning volume resources for each user requirement.
 
 <a id="pv-lifecycle"></a>
-
 ### PV/PVC Lifecycle { #pv-lifecycle }
 PV and PVC follow a four-stage lifecycle.
 
@@ -3989,7 +3905,6 @@ Reclaims the volume after use. Reclaim methods include Delete, Retain, and Recyc
 | Recycle | Does not delete the connected volume when the PV is deleted, but puts it in a state ready for reuse. This method is deprecated. |
 
 <a id="storageclass"></a>
-
 ### Storage Class (StorageClass) { #storageclass }
 A storage class must be defined before provisioning. Storage classes provide a way to classify storage by certain characteristics. You can set the information, such as media type and availability zone, by including information about the storage provider (provisioner).
 
@@ -4079,7 +3994,6 @@ csi-storageclass   cinder.csi.openstack.org   Delete          WaitForFirstConsum
 ```
 
 <a id="static-provisioning"></a>
-
 ### Static Provisioning { #static-provisioning }
 
 Static provisioning requires the user to prepare a block storage manually. On the **Storage > Block Storage** service page of the NHN Cloud web console, click the **Create Block Storage** button to create a block storage to attach to the PV. See [Create Block Storage](/Storage/Block%20Storage/en/console-guide/#_1) in the Block Storage guide.
@@ -4165,7 +4079,6 @@ pv-static-001   10Gi       RWO            Delete           Bound    default/pvc-
 ```
 
 <a id="dynamic-provisioning"></a>
-
 ### Dynamic Provisioning { #dynamic-provisioning }
 
 With Dynamic Provisioning, block storage is automatically created in reference of attributes defined at storage class. To use Dynamic Provisioning, do not set Volume Binding Mode of storage class or set it to **Immediate**.
@@ -4219,7 +4132,6 @@ persistentvolumeclaim/pvc-dynamic   Bound    pvc-1056949c-bc67-45cc-abaa-1d1bd9e
 > A block storage created by dynamic provisioning cannot be deleted from the web console. It is not automatically deleted along with a cluster being deleted. Therefore, before a cluster is deleted, all PVCs must be deleted first; otherwise, you may be charged for PVC usage. The reclaimPolicy of PV created by dynamic provisioning is set to `Delete` by default, so deleting only the PVC will also delete the PV and block storage.
 
 <a id="pod-pvc-mount"></a>
-
 ### Mount PVC to a Pod { #pod-pvc-mount }
 
 To mount PVC to a pod, mount information must be defined at the pod manifest. Enter the PVC name to use in `spec.volumes.persistenVolumeClaim.claimName` and enter paths to mount in `spec.containers.volumeMounts.mountPath`.
@@ -4270,7 +4182,6 @@ Filesystem      Size  Used Avail Use% Mounted on
 You can also check block storage attachment information in the **Storage > Block Storage** service page of the NHN Cloud web console.
 
 <a id="volume-expansion"></a>
-
 ### Volume Expansion { #volume-expansion }
 You can adjust an existing volume by editing the PersistentVolumeClaim (PVC) object. You can change the volume size by editing the **spec.resources.requests.storage** item of the PVC object. Volume shrinking is not supported. To use the volume expansion feature, the **allowVolumeExpansion** property of StorageClass must be **True**.
 
@@ -4327,11 +4238,9 @@ status:
 The storage provider **cinder.csi.openstack.org** from v1.20.12 and later supports the expansion of the volume in use by default. You can change the volume size by modifying the **spec.resources.requests.storage** item of the PVC object to a desired value.
 
 <a id="service-integration"></a>
-
 ## NHN Cloud Service Integration { #service-integration }
 
 <a id="ncr-integration"></a>
-
 ### NHN Cloud Container Registry (NCR) Service Integration { #ncr-integration }
 You can use images saved at NHN Cloud Container Registry. To use images registered in the registry, first create a secret to login to user registry.
 
@@ -4381,7 +4290,6 @@ spec:
 > For information on how to use NHN Cloud Container Registry, see the [NHN Cloud Container Registry (NCR) User Guide](/Container/NCR/en/user-guide) document.
 
 <a id="nas-integration"></a>
-
 ### NHN Cloud NAS Service Integration { #nas-integration }
 You can utilize NAS volumes provided by NHN Cloud as PV. In order to use NAS services, you must use a cluster of version v1.20 or later. For more information on using NHN Cloud NAS, please refer to the [NAS Console User Guide](/Storage/NAS%20(online)/en/console-guide).
 
@@ -4389,7 +4297,6 @@ You can utilize NAS volumes provided by NHN Cloud as PV. In order to use NAS ser
 > As of the current date (August 2024), the NHN Cloud NAS service is only available in select regions. For more information on the supported regions for the NHN Cloud NAS service, see the [NAS Service Overview](/Storage/NAS%20(online)/en/overview).
 
 <a id="nas-integration-run-the-rpcbind-service-on-all-worker-nodes"></a>
-
 #### Run the rpcbind Service on All Worker Nodes
 To use NAS volumes, you must run the rpcbind service on all worker nodes. Connect to all worker nodes and run the rpcbind service by using the following command.
 
@@ -4408,7 +4315,6 @@ For clusters using enhanced security rules, additional security rules must be ad
 | egress | TCP | 635 | IPv4 | NAS IP address | mountd port for rpc, direction: csi-nfs-node (worker node) → NAS |
 
 <a id="nas-integration-install-csi-driver-nfs"></a>
-
 #### Install csi-driver-nfs
 To use the NHN Cloud NAS service, you must deploy [nfs-csi-plugin](/Container/NKS/en/user-guide/#addon-mgmt-addon-nfs-csi-plugin) to the cluster using the Addon feature of NHN Kubernetes Service (NKS).
 
@@ -4420,7 +4326,6 @@ If you configure multiple PVs using the csi-driver-nfs, the csi-driver-nfs regis
 ![nfs-csi-driver-02.png](http://static.toastoven.net/prod_infrastructure/container/kubernetes/nfs-csi-driver-02.png)
 
 <a id="nas-integration-how-to-use-existing-nhn-cloud-nas-volume-when-provisioning"></a>
-
 #### How to use an existing NHN Cloud NAS volume when provisioning
 You can use existing NAS storage as a PV by entering the NAS information when creating the PV manifest or by entering the NAS information in the StorageClass manifest.
 
@@ -4624,7 +4529,6 @@ Filesystem                                                                 Size 
 ```
 
 <a id="nas-integration-how-to-create-new-nhn-cloud-nas-volume-when-provisioning"></a>
-
 #### How to create a new NHN Cloud NAS volume during provisioning
 You can use an automatically created NAS volume as a PV by entering NAS information when creating a StorageClass and PVC manifest.
 
@@ -4796,7 +4700,6 @@ tmpfs                                                                          1
 > In the process of mounting the PV to the pod, not only the subdirectory is mounted, but the entire NFS storage is mounted, so it is not possible to force the application to use the volume by the provisioned size.
 
 <a id="encrypted-block-storage-integration"></a>
-
 ### NHN Cloud Encrypted Block Storage Integration { #encrypted-block-storage-integration }
 You can utilize encrypted block storage provided by NHN Cloud as PV. For more information about NHN Cloud encrypted block storage, see [Encrypted Block Storage](/Storage/Block%20Storage/en/console-guide/#_2).
 
@@ -4912,7 +4815,6 @@ The process of creating a PVC manifest and mounting it to a Pod is the same as d
 
 
 <a id="etcd-encryption-with-skm"></a>
-
 ### Integrate Secure Key Manager for Encrypting and Decrypting Sensitive Data { #etcd-encryption-with-skm }
 
 NKS clusters encrypt data when storing secret resources in the data store (etcd). NKS provides two methods for encrypting this data.

--- a/ja/user-guide.md
+++ b/ja/user-guide.md
@@ -1,9 +1,9 @@
-<a id="container-nhn-kubernetes-service-nks-user-guide"></a>
+<!-- pre-align:aligned sig=98b43adf5be7 -->
 
+<a id="container-nhn-kubernetes-service-nks-user-guide"></a>
 ## Container > NHN Kubernetes Service(NKS) > 使用ガイド { #container-nhn-kubernetes-service-nks-user-guide }
 
 <a id="cluster-headings"></a>
-
 ## クラスター { #cluster-headings }
 クラスターは、ユーザーの Kubernetes を構成するインスタンスのグループです。
 
@@ -159,12 +159,10 @@ k8s Node状態のアイコンの意味は次のとおりです。
 > * クラスターオーナー変更機能は提供されなくなりました。クラスターがサービスユーザーの権限で動作できるようにするには、キーペア変更機能を使用してください。
 
 <a id="nodegroup-headings"></a>
-
 ## ノードグループ { #nodegroup-headings }
 ノードグループは、Kubernetes を構成するワーカーノードインスタンスのグループです。
 
 <a id="nodegroup-show"></a>
-
 ### ノードグループ照会 { #nodegroup-show }
 クラスター一覧でクラスター名をクリックすると、ノードグループ一覧を確認できます。ノードグループ一覧には、各ノードグループの概要情報が表示されます。
 
@@ -217,7 +215,6 @@ k8s Node状態のアイコンの意味は次のとおりです。
 **[ノード一覧]** タブでは、ノードグループを構成するインスタンスの一覧を確認できます。
 
 <a id="nodegroup-create"></a>
-
 ### ノードグループ作成 { #nodegroup-create }
 クラスターを作成するとデフォルトのノードグループが作成されますが、必要に応じて追加のノードグループを作成できます。デフォルトのノードグループのインスタンスより高い仕様のコンテナ実行環境が必要な場合や、スケールアウト（拡張）のためにより多くのワーカーノードインスタンスが必要な場合は、追加のノードグループを作成して使用できます。ノードグループ一覧ページで **[ノードグループ作成]** ボタンをクリックすると、ノードグループ作成ページが表示されます。ノードグループ作成に必要な項目は次のとおりです。
 
@@ -238,7 +235,6 @@ k8s Node状態のアイコンの意味は次のとおりです。
 > 該当するクラスターを作成したユーザーのみがノードグループを作成できます。
 
 <a id="nodegroup-delete"></a>
-
 ### ノードグループ削除 { #nodegroup-delete }
 ノードグループ一覧で削除するノードグループを選択し、**[ノードグループ削除]** ボタンをクリックすると削除が開始されます。ノードグループの削除には約 5 分程度かかります。ノードグループの状態によってはさらに時間がかかる場合があります。
 
@@ -249,7 +245,6 @@ k8s Node状態のアイコンの意味は次のとおりです。
 * 該当ノードがインスタンスレベルで削除されます。
 
 <a id="nodegroup-scale-out"></a>
-
 ### ノードグループへのノード追加 { #nodegroup-scale-out }
 動作中のノードグループにノードを追加できます。ノードグループ情報照会ページのノード一覧タブをクリックすると、現在のノード一覧が表示されます。ノード追加ボタンをクリックしてノード数を入力すると、ノードが追加されます。
 
@@ -257,7 +252,6 @@ k8s Node状態のアイコンの意味は次のとおりです。
 > オートスケーラーが有効になっているノードグループは、手動でノードを追加することはできません。
 
 <a id="nodegroup-scale-in"></a>
-
 ### ノードグループからのノード削除 { #nodegroup-scale-in }
 動作中のノードグループからノードを削除できます。ノードグループ情報照会ページのノード一覧タブをクリックすると、現在のノード一覧が表示されます。ノード一覧から削除するノードを選択し、ノード削除ボタンをクリックすると確認ダイアログが表示されます。削除するノード名を再度確認し、確認ボタンをクリックするとノードが削除されます。
 
@@ -271,7 +265,6 @@ k8s Node状態のアイコンの意味は次のとおりです。
 > オートスケーラーが有効になっているノードグループは、手動でノードを削除することはできません。
 
 <a id="node-start-stop"></a>
-
 ### ノードの停止と起動 { #node-start-stop }
 ノードグループに属するノードの一部を停止し、停止されたノードを再起動できます。ノードグループ情報照会ページのノードリストタブをクリックすると、現在のノードリストが表示されます。停止するノードを選択してノード停止ボタンをクリックすると、ノードが停止されます。停止されたノードを選択してノード起動ボタンをクリックすると、ノードが再起動されます。
 
@@ -313,7 +306,6 @@ k8s Node状態のアイコンの意味は次のとおりです。
 * 赤色: 異常状態のノード
 
 <a id="use-gpu-nodegroup"></a>
-
 ### GPU ノードグループの使用 { #use-gpu-nodegroup }
 Kubernetes を通じた GPU ベースのワークロード実行が必要な場合、GPU インスタンスで構成されたノードグループを作成できます。
 クラスターまたはノードグループの作成時にインスタンスタイプを選択する際、`g2` タイプを選択すると GPU ノードグループを作成できます。
@@ -436,7 +428,6 @@ totalMemory: 14.73GiB freeMemory: 14.62GiB
 > GPU が不要なワークロードが GPU ノードに割り当てられるのを防ぎたい場合は、[Taint および Toleration の概要](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/)を参照してください。
 
 <a id="autoscaler"></a>
-
 ### オートスケーラー { #autoscaler }
 オートスケーラーは、ノードグループの利用可能なリソースが不足している場合、またはノードの使用率が一定レベル以下に維持される場合に、ノード数を自動的に調整する機能です。この機能はノードグループごとに設定でき、それぞれ独立して動作します。NKS では 2 種類のオートスケーラーをサポートしています。
 
@@ -462,7 +453,6 @@ totalMemory: 14.73GiB freeMemory: 14.62GiB
 | スケールイン | ノード数を減少させることをいいます |
 
 <a id="metric-base-autoscaler"></a>
-
 #### 指標ベースのオートスケーラー
 指標ベースのオートスケーラーは、NHN Cloud の [Cloud Monitoring](/Monitoring/Cloud%20Monitoring/ja/overview/) サービスをベースに動作します。ワーカーノードにインストールされた指標収集エージェントが 1 分周期でシステム指標を Cloud Monitoring に送信し、収集された指標が設定したしきい値を超過または下回った場合に、自動的にノードを追加または削除します。スケールアウト (Scale Out) とスケールイン (Scale In) の機能はそれぞれ独立して有効化できます。
 
@@ -585,7 +575,6 @@ totalMemory: 14.73GiB freeMemory: 14.62GiB
 | 24〜 | 28% | 6 | – | スケールアウト条件のしきい値以下 → しきい値維持時間 2 分の計測開始<br>その後、スケールイン後の待機 10 分 (24→34) の条件を満たすと 1 台ずつスケールインされる |
 
 <a id="cluster-autoscaler"></a>
-
 #### クラスターオートスケーラー
 クラスターオートスケーラーは、Kubernetes プロジェクトの公式サポート機能である cluster-autoscaler 機能をベースに動作します。詳細については、[Cluster Autoscaler](https://github.com/kubernetes/autoscaler/tree/master/cluster-autoscaler) を参照してください。
 
@@ -1038,7 +1027,6 @@ autoscaler-test-default-w-ohw5ab5wpzug-node-0   Ready    <none>   22d   v1.28.3
 ```
 
 <a id="user-script-old"></a>
-
 ### ユーザースクリプト (old) { #user-script-old }
 クラスターを作成するときおよび追加ノードグループを作成するときに、ユーザースクリプトを登録できます。ユーザースクリプト機能には次のような特徴があります。
 
@@ -1059,7 +1047,6 @@ autoscaler-test-default-w-ohw5ab5wpzug-node-0   Ready    <none>   22d   v1.28.3
         * スクリプトの標準出力および標準エラーストリーム: `/var/log/userscript.output`
 
 <a id="user-script"></a>
-
 ### ユーザースクリプト { #user-script }
 2022年7月26日以降に作成されるノードグループには、新しいバージョンのユーザースクリプト機能が搭載されます。以前のバージョンの機能と比較して、次のような特徴があります。
 
@@ -1080,7 +1067,6 @@ autoscaler-test-default-w-ohw5ab5wpzug-node-0   Ready    <none>   22d   v1.28.3
         2. 新バージョンのユーザースクリプト
 
 <a id="instance-flavor-update"></a>
-
 ### インスタンスタイプの変更 { #instance-flavor-update }
 ワーカーノードグループのインスタンスタイプを変更します。ワーカーノードグループに属するすべてのワーカーノードのインスタンスタイプが変更されます。
 
@@ -1112,7 +1098,6 @@ autoscaler-test-default-w-ohw5ab5wpzug-node-0   Ready    <none>   22d   v1.28.3
 * u2タイプのインスタンスは、作成後にタイプを変更することはできません。同じu2タイプへの変更も不可です。
 
 <a id="custom-image"></a>
-
 ### カスタムイメージをワーカーイメージとして活用 { #custom-image }
 
 ユーザーのカスタムイメージを基にしたワーカーノードグループを作成できます。カスタムイメージをワーカーノードイメージとして活用できるようにするために、NHN Cloud Image Builder サービスで追加作業 (NKS ワーカーノード化) が必要です。Image Builder サービスで NHN Kubernetes Service (NKS) ワーカーノードアプリケーションを使用してイメージテンプレートを作成し、カスタムワーカーノードイメージを生成できます。Image Builder サービスの詳細については、[Image Builder ユーザーガイド](/Compute/Image%20Builder/ja/console-guide/#_1)を参照してください。
@@ -1169,7 +1154,6 @@ autoscaler-test-default-w-ohw5ab5wpzug-node-0   Ready    <none>   22d   v1.28.3
 ![nkscustom_image_3.png](http://static.toastoven.net/prod_infrastructure/container/kubernetes/nkscustom_image_3.png)
 
 <a id="extra-volumes"></a>
-
 ### 追加ブロックストレージ { #extra-volumes }
 ノードグループに追加ブロックストレージを使用できます。クラスターおよびノードグループの作成時に追加ブロックストレージを指定して作成するか、既存のノードグループに追加ブロックストレージを作成して使用できます。追加ブロックストレージの特徴は次のとおりです。
 
@@ -1188,7 +1172,6 @@ autoscaler-test-default-w-ohw5ab5wpzug-node-0   Ready    <none>   22d   v1.28.3
 > 追加ブロックストレージの設定変更は既存ボリュームのアンマウントを含むため、使用中のサービスに影響を与える可能性があります。
 
 <a id="extra-security-groups"></a>
-
 ### 追加セキュリティグループ { #extra-security-groups }
 ノードグループに追加セキュリティグループを設定できます。クラスターおよびノードグループの作成時に追加セキュリティグループを指定して作成するか、既存のノードグループに追加セキュリティグループを設定できます。追加セキュリティグループの特徴は次のとおりです。
 
@@ -1205,7 +1188,6 @@ autoscaler-test-default-w-ohw5ab5wpzug-node-0   Ready    <none>   22d   v1.28.3
 > 追加セキュリティグループの変更時はネットワーク設定が変更されるため、設定が適用される間、一時的に通信に影響が生じる場合があります。
 
 <a id="fip-auto-bind"></a>
-
 ### フローティング IP 自動割り当て { #fip-auto-bind }
 ノードグループにフローティング IP 自動割り当て機能を使用できます。機能が有効化されたノードグループは、ノード作成時にフローティング IP を自動的に割り当てます。クラスターおよび追加ノードグループの作成時に機能の有効化/無効化を選択でき、設定したオプションは後から変更できます。フローティング IP 自動割り当て機能を有効化するために必要な項目は次のとおりです。
 
@@ -1224,12 +1206,10 @@ autoscaler-test-default-w-ohw5ab5wpzug-node-0   Ready    <none>   22d   v1.28.3
   * 機能が有効化されたノードグループで機能を無効化しても、既存のノードに割り当て済みのフローティング IP は解除されません。
 
 <a id="cluster-management"></a>
-
 ## クラスター管理 { #cluster-management }
 リモートホストからクラスターを操作・管理するには、Kubernetes が提供するコマンドラインツール (CLI) である `kubectl` が必要です。
 
 <a id="kubectl-install"></a>
-
 ### kubectl のインストール { #kubectl-install }
 kubectl は特別なインストール手順なしに、実行ファイルをダウンロードしてすぐに使用できます。OS 別のダウンロードコマンドは次のとおりです。
 
@@ -1268,7 +1248,6 @@ $ export PATH=$PATH:$(pwd)
 ```
 
 <a id="kubectl-set-kubeconfig"></a>
-
 ### 設定 { #kubectl-set-kubeconfig }
 kubectl で Kubernetes クラスターにアクセスするには、クラスター設定ファイル (kubeconfig) が必要です。NHN Cloud Web コンソールで **Container > NHN Kubernetes Service(NKS)** ページを開き、アクセスするクラスターを選択します。下部の **[基本情報]** タブで **[設定ファイル]** 項目の **[ダウンロード]** ボタンをクリックして設定ファイルをダウンロードします。ダウンロードした設定ファイルは任意の場所に移動し、kubectl 実行時に参照できるよう準備します。
 
@@ -1284,7 +1263,6 @@ $ export KUBECONFIG={クラスター設定ファイルパス}
 クラスター設定ファイルのパスを環境変数に保存したくない場合は、kubectl のデフォルト設定ファイルである `$HOME/.kube/config` にコピーして使用することもできます。ただし、複数のクラスターを運用する場合は、環境変数の値を変更する方法が便利です。
 
 <a id="kubectl-check-connection"></a>
-
 ### 接続確認 { #kubectl-check-connection }
 `kubectl version` コマンドで正常に設定されているか確認します。問題がなければ `Server Version` が出力されます。
 
@@ -1298,7 +1276,6 @@ Server Version: version.Info{Major:"1", Minor:"15", GitVersion:"v1.15.7", GitCom
 * Server Version: クラスターを構成している Kubernetes のバージョン情報
 
 <a id="certificatesigningrequest"></a>
-
 ### CSR(CertificateSigningRequest) { #certificatesigningrequest }
 KubernetesのCertificate APIを通じて、Kubernetes APIクライアント向けのX.509証明書を要求および発行できます。CSRリソースは、証明書の要求と、要求に対する承認・拒否を決定できるようにします。詳細については、[Certificate Signing Requests](https://kubernetes.io/docs/reference/access-authn-authz/certificate-signing-requests/) を参照してください。
 
@@ -1403,7 +1380,6 @@ status:
 > * 平村リージョン: 2020年12月24日以降に作成したクラスター
 
 <a id="admission-controller"></a>
-
 ### Admission Controller プラグイン { #admission-controller }
 Admission Controllerは、Kubernetes APIサーバーへのリクエストをインターセプトし、オブジェクトを変更したりリクエストを拒否したりできます。Admission Controllerの詳細については、[承認コントローラー](https://kubernetes.io/docs/reference/access-authn-authz/admission-controllers/) を参照してください。また、Admission Controllerの使用例については、[承認コントローラーガイド](https://kubernetes.io/blog/2019/03/21/a-guide-to-kubernetes-admission-controllers/) を参照してください。
 
@@ -1444,7 +1420,6 @@ Kubernetesバージョンごとのデフォルトで有効なAdmission Controlle
 * PodSecurityPolicy
 
 <a id="cluster-upgrade"></a>
-
 ### クラスターアップグレード { #cluster-upgrade }
 NHN Kubernetes Service(NKS)は、動作中の Kubernetes クラスターの Kubernetes コンポーネントのアップグレードをサポートします。
 
@@ -1625,7 +1600,6 @@ NKS クラスターのコントロールプレーンは高可用性を保証し�
 Blue 環境のリソースをすべて廃棄すると、コントロールプレーンとすべてのワーカーノードグループのバージョンがすべて一致した状態になります。
 
 <a id="api-endpoint-ipacl"></a>
-
 ### クラスター API エンドポイント IP アクセス制御の適用 { #api-endpoint-ipacl }
 クラスター API エンドポイントに IP アクセス制御を適用または解除できます。
 IP アクセス制御機能の詳細については、[IP アクセス制御](/Network/Load%20Balancer/ja/overview/#ip) のドキュメントを参照してください。
@@ -1641,7 +1615,6 @@ IP アクセス制御機能の詳細については、[IP アクセス制御](/N
 * IP アクセス制御対象は 1 件以上存在する必要があります。
 
 <a id="rotate-certificate"></a>
-
 ### クラスター証明書の更新 { #rotate-certificate }
 Kubernetes は、コンポーネント間の TLS 認証に PKI 証明書が必要です。PKI 証明書の詳細については、[PKI 証明書と要件](https://kubernetes.io/ko/docs/setup/best-practices/certificates/) を参照してください。NKS クラスターを作成すると、クラスターに必要な証明書が自動的に生成され、この証明書のデフォルトの有効期間は 5 年に設定されています。
 
@@ -1676,7 +1649,6 @@ Kubernetes は、コンポーネント間の TLS 認証に PKI 証明書が必�
 > このような作業の影響を最小化するために、証明書更新作業が進行中は新規 Pod の作成などの作業を実施しないでください。
 
 <a id="k8s-component"></a>
-
 ### Kubernetes コンポーネント設定機能 { #k8s-component }
 
 Kubernetes コンポーネントのさまざまなオプションを設定できます。クラスター作成時に設定でき、設定したオプションはクラスター作成完了後に変更することもできます。
@@ -1689,7 +1661,6 @@ Kubernetes コンポーネントのさまざまなオプションを設定でき
 > * ワーカーノードで動作するコンポーネントの設定は、ワーカーノードグループごとに設定できます。（プラットフォームバージョン 1.202602.0 以降に限ります）
 
 <a id="control-plain-options"></a>
-
 ### コントロールプレーンオプション { #control-plain-options }
 
 | コンポーネント | オプション | 説明 |
@@ -1700,7 +1671,6 @@ Kubernetes コンポーネントのさまざまなオプションを設定でき
 | kube-controller-manager | unhealthy-zone-threshold | Availability Zone を異常と見なす NotReady ノード比率のしきい値を定義します。<br>（単位: パーセント、デフォルト値: 55、最小値: 0、最大値: 100） |
 
 <a id="worker-node-options"></a>
-
 ### ワーカーノードオプション { #worker-node-options }
 
 | コンポーネント | オプション | 説明 |
@@ -1709,7 +1679,6 @@ Kubernetes コンポーネントのさまざまなオプションを設定でき
 | kubelet | max-pods | ノードで実行可能な最大 Pod 数を定義します。<br>（デフォルト値: 110、最小値: 1、最大値: Podネットワークおよびサブネットサイズ設定に基づいて計算された最大作成可能 Pod IP 数）<br>プラットフォームバージョン 1.202602.0 以降でサポートされます。 |
 
 <a id="k8s-label"></a>
-
 ### Kubernetes ラベル設定機能 { #k8s-label }
 ノードグループごとに Kubernetes ラベル設定機能を使用できます。この機能を通じてラベルが設定されたノードグループは、ノード作成時にユーザーが設定したラベルを自動的に追加します。ラベルは Pod やノードなどのオブジェクトに付与されたキーと値のペアで、オブジェクトの特性を識別するために使用されます。ラベルの詳細については、[Labels and Selectors](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/) を参照してください。
 
@@ -1739,7 +1708,6 @@ Kubernetes ラベルはキーと値のペアで構成されており、有効な
 > * Kubernetes ラベルの設定を変更すると、以降に新規作成されるノードから変更後の設定が適用されます。
 
 <a id="oidc-auth"></a>
-
 ### OIDC 認証設定機能 { #oidc-auth }
 
 OIDC（OpenID Connect）は、OAuth 2.0 フレームワークをベースにした相互運用可能な認証プロトコルです。OIDC を使用することで、外部認証サービスを通じてユーザーを認証できます。OIDC の詳細な動作については、[What is OpenID Connect](https://openid.net/developers/how-connect-works/) を参照してください。
@@ -1759,7 +1727,6 @@ NKS クラスターは OIDC を使用した認証を処理するように設定�
 | Signing Algs | X | 許可された JOSE 非対称署名アルゴリズムのリスト。デフォルト値: `RS256` |
 
 <a id="control-plane-k8s-log"></a>
-
 ### コントロールプレーン Kubernetes コンポーネントログの保存 { #control-plane-k8s-log }
 NHN Kubernetes Service(NKS) は、コントロールプレーンで実行中の主要な Kubernetes コンポーネントのログを提供します。これにより、クラスター内で発生するさまざまなイベントや動作をより明確に把握でき、サービス状態の診断および問題解決に役立てることができます。
 
@@ -1878,7 +1845,6 @@ OBS コンテナにログが生成されるパスは次のとおりです。
   nks-test-master-0/kube-apiserver/2025/04/20250428-101500-index0.gz
 
 <a id="k8s-taint"></a>
-
 ### Kubernetes テイント設定機能 { #k8s-taint }
 ノードグループごとに Kubernetes テイント (taint) 設定機能を使用できます。この機能を使用して作成されたノードグループは、ユーザーが設定したテイントが適用された状態で初期化されます。Taint の詳細については、[Taints and Tolerations](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/) を参照してください。
 
@@ -1922,7 +1888,6 @@ Kubernetes テイントはキー、値、効果 (effect) で構成され、各�
 * Kubernetes テイント設定を変更すると、以降に新規作成されるノードから変更後の設定が適用されます。
 
 <a id="konnectivity-description"></a>
-
 ### konnectivity { #konnectivity-description }
 
 Konnectivity は、Kubernetes においてコントロールプレーン (API サーバー) とワーカーノード間のネットワーク通信を安全にプロキシするコンポーネントです。従来は API サーバーがノードの kubelet や Pod に直接アクセスする必要があり、ネットワーク構成が複雑になる問題がありました。
@@ -1946,11 +1911,9 @@ Konnectivity Server と Konnectivity Agent が先に接続を確立してトン�
 > Konnectivity はプラットフォームバージョン 1.202605.0 以上で提供されます。
 
 <a id="worker-node-management"></a>
-
 ## ワーカーノード管理 { #worker-node-management }
 
 <a id="container-management"></a>
-
 ### コンテナ管理 { #container-management }
 
 <a id="container-management-clusters-of-kubernetes-v1243-or-older"></a>
@@ -1963,7 +1926,6 @@ Kubernetes v1.24.3 以前のバージョンのクラスターは、Docker を使
 Kubernetes v1.24.3 以降のバージョンのクラスターは、containerd を使用してコンテナランタイムを構成します。ワーカーノードで docker CLI の代わりに nerdctl を使用してコンテナの状態照会、コンテナイメージの照会などの作業を行うことができます。nerdctl の詳細な説明と使用方法については、[nerdctl: Docker-compatible CLI for containerd](https://github.com/containerd/nerdctl#nerdctl-docker-compatible-cli-for-containerd) を参照してください。
 
 <a id="network-management"></a>
-
 ### ネットワーク管理 { #network-management }
 
 <a id="network-management-default-network-interface"></a>
@@ -2048,7 +2010,6 @@ route add -net 0.0.0.0/0 gw 192.168.0.1 dev eth1 metric 0
 ```
 
 <a id="kubelet-argument"></a>
-
 ### kubelet ユーザー定義引数設定機能 { #kubelet-argument }
 kubelet はすべてのワーカーノードで動作するノードエージェントです。kubelet はコマンドライン引数を使用してさまざまな設定を受け取ります。NKS が提供する kubelet ユーザー定義引数設定機能を使用すると、kubelet 起動時に入力される引数を追加できます。kubelet ユーザー定義引数は、次のように設定してシステムに適用できます。
 
@@ -2064,7 +2025,6 @@ kubelet はすべてのワーカーノードで動作するノードエージェ
 > * 設定されたユーザー定義引数は、システム再起動後も引き続き適用されます。
 
 <a id="containerd-registry-config"></a>
-
 ### カスタム containerd レジストリ設定機能 (deprecated) { #containerd-registry-config }
 
 > [注意]
@@ -2172,7 +2132,6 @@ echo '[ { "registry": "user-defined.registry.io", "endpoint_list": [ "http://use
 >     * `docker.io` レジストリを使用しない場合は、`docker.io` レジストリに関する設定を含めなければ問題ありません。ただし、1 つ以上のレジストリ設定が存在する必要があります。
 
 <a id="constraints-on-cgroup"></a>
-
 ### Kubernetes バージョンと CGroup バージョンに関する制約事項 { #constraints-on-cgroup }
 CGroup (Control Group) は Linux カーネルの機能で、プロセスグループの CPU、メモリ、ディスク I/O、ネットワークなどのシステムリソース使用量を制限・隔離・モニタリングできます。Kubernetes をはじめとするコンテナ技術の中核となる基盤の 1 つです。CGroup は最初のバージョン 1 (v1) から始まり、メモリ・I/O 制御機能を強化してバージョン 2 (v2) へと発展しました。Linux カーネルの機能であるため、CGroup v2 は Linux カーネルへの依存性を持ちます。そのため、比較的新しいディストリビューション/バージョンでのみ CGroup v2 がサポートされます。
 
@@ -2202,14 +2161,12 @@ CGroup バージョンを v1 から v2 に変更できる OS イメージのデ�
 デフォルト CGroup バージョンが v1 で、CGroup バージョンを v2 に変更できない OS イメージで作成したワーカーノードグループは、ローリングアップグレード方式で Kubernetes v1.34 にアップグレードすることはできません。この場合、Blue-Green 方式でワーカーノードグループをアップグレードできます。
 
 <a id="worker-management-caution"></a>
-
 ### ワーカーノード管理の注意事項 { #worker-management-caution }
 * ワーカーノードに pull されているコンテナイメージを任意に削除しないでください。NKS クラスターに必要な Pod が動作しなくなる場合があります。
 * `shutdown`、`halt`、`poweroff` などのコマンドでシステムを任意に停止すると、コンソールから再起動できなくなります。ワーカーノードの起動/停止機能を使用してください。
 * ワーカーノード内のさまざまな設定ファイルを任意に変更したり、システムサービスを任意に操作しないでください。NKS クラスターに深刻な問題が発生する可能性があります。
 
 <a id="cni"></a>
-
 ## CNI (Container Network Interface) { #cni }
 NHN Kubernetes Service (NKS) は、Addon 機能を通じてさまざまな種類の Container Network Interface (CNI) を提供します。クラスター作成時に Calico-VXLAN、Calico-eBPF、Cilium のいずれか 1 つの CNI を選択でき、デフォルト設定は Calico-VXLAN です。Calico-eBPF はコンテナワークロードを BGP ルーティングプロトコルで構成し、eBPF 技術を基盤として直接通信します。一部の区間 (NodePort など) は VXLAN を使用して通信します。Calico の eBPF に関する詳細は [about eBPF](https://docs.tigera.io/calico/latest/about/kubernetes-training/about-ebpf) を参照してください。Cilium は VXLAN オーバーレイネットワークを基盤とし、eBPF 技術を活用して高いネットワーク性能を提供します。Cilium の eBPF に関する詳細は [eBPF Datapath](https://docs.cilium.io/en/stable/network/ebpf/) を参照してください。
 
@@ -2246,7 +2203,6 @@ NHN Kubernetes Service (NKS) が提供する Calico-VXLAN と Calico-eBPF には
 > 該当イメージを使用するには、アドオン管理機能を通じて Calico を v3.28.2 以降にアップデートする必要があります。
 
 <a id="security-group"></a>
-
 ## セキュリティグループ { #security-group }
 クラスター作成時に強化されたセキュリティルールを True に設定すると、ワーカーノードのセキュリティグループ作成時に必須のセキュリティルールのみが作成されます。
 
@@ -2340,7 +2296,6 @@ Cilium CNI を使用するクラスターで Hubble、Envoy、Prometheus など�
 
 
 <a id="addon-mgmt"></a>
-
 ## アドオン管理機能 { #addon-mgmt }
 アドオンとは、Kubernetes クラスターの必須構成要素ではないものの、NKS クラスターの機能を拡張したり、特化した機能を提供するために用意された構成要素のことです。アドオンには、ネットワーキング、サービスディスカバリー、モニタリング、ストレージプロビジョニングなどの機能を担う構成要素が含まれる場合があります。ユーザーはアドオン管理機能を通じて、NHN Cloud が提供するアドオンをクラスターにインストール/変更/削除できます。
 
@@ -2582,12 +2537,10 @@ NFS CSI Plugin は NHN Cloud の NFS をプロビジョニングおよび管理�
         * 任意項目である snapshot 設定が必須として要求されていた問題を修正しました。
 
 <a id="loadbalancer-service"></a>
-
 ## LoadBalancer サービス { #loadbalancer-service }
 Kubernetes アプリケーションの基本実行単位である Pod は、CNI (container network interface) によってクラスターネットワークに接続されます。デフォルトでは、クラスター外部から Pod へアクセスすることはできません。Pod のサービスをクラスター外部に公開するには、Kubernetes の `LoadBalancer` サービス (Service) オブジェクト (object) を使用して、外部に公開するパスを作成する必要があります。LoadBalancer サービスオブジェクトを作成すると、クラスター外部に NHN Cloud Load Balancer が作成され、サービスオブジェクトと関連付けられます。
 
 <a id="create-webserver-pod"></a>
-
 ### Webサーバー Pod の作成 { #create-webserver-pod }
 次のように、2つの nginx Pod を実行するデプロイメント (deployment) オブジェクトのマニフェストファイルを作成し、オブジェクトを作成します。
 
@@ -2629,7 +2582,6 @@ nginx-deployment-7fd6966748-wv7rd   1/1     Running   0          4m13s
 ```
 
 <a id="create-lb-service"></a>
-
 ### LoadBalancer サービスの作成 { #create-lb-service }
 Kubernetes のサービスオブジェクトを定義するには、次の項目で構成されたマニフェストが必要です。
 
@@ -2688,7 +2640,6 @@ nginx-svc    LoadBalancer   10.254.134.18   123.123.123.30   8080:30013/TCP   3m
 > ロードバランサーの IP は外部からアクセスできるフローティング IP です。**Network > Floating IP** ページで確認できます。
 
 <a id="internet-test-via-service"></a>
-
 ### インターネットを介したサービステスト { #internet-test-via-service }
 ロードバランサーに接続されたフローティング IP に HTTP リクエストを送信し、Kubernetes クラスターの Web サーバー Pod が応答するかどうかを確認します。サービスオブジェクトの TCP/8080 ポートを Pod の TCP/80 ポートに接続するよう設定しているため、TCP/8080 ポートにリクエストを送信する必要があります。外部ロードバランサーとサービスオブジェクト、Pod が正しく接続されていれば、Web サーバーは nginx のデフォルトページを返します。
 
@@ -2722,7 +2673,6 @@ Commercial support is available at
 ```
 
 <a id="advanced-lb-configuration"></a>
-
 ### ロードバランサーの詳細オプション設定 { #advanced-lb-configuration }
 Kubernetes のサービスオブジェクトを定義する際に、ロードバランサーのさまざまなオプションを設定できます。設定可能な項目は次のとおりです。
 
@@ -2750,7 +2700,6 @@ Kubernetes のサービスオブジェクトを定義する際に、ロードバ
 * L7 ルールおよび条件
 
 <a id="advanced-lb-configuration-global-setting-and-per-listener-setting"></a>
-
 #### 全体設定とリスナーごとの設定
 設定項目ごとに全体設定とリスナーごとの設定が可能です。全体設定とリスナーごとの設定がどちらもない場合は、設定ごとのデフォルト値を使用します。
 
@@ -2758,7 +2707,6 @@ Kubernetes のサービスオブジェクトを定義する際に、ロードバ
 * 全体設定: 対象リスナーにリスナーごとの設定がない場合に、この設定を適用します。
 
 <a id="advanced-lb-configuration-format-of-per-listener-setting"></a>
-
 #### リスナーごとの設定形式
 リスナーごとの設定は、全体設定のキーにリスナーを示すプレフィックス (prefix) を付けて設定できます。リスナーを示すプレフィックスは、サービスオブジェクトのポートプロトコル (`spec.ports[].protocol`) とポート番号 (`spec.ports[].port`) をダッシュ (`-`) で連結したものです。例えば、プロトコルが TCP でポート番号が 80 の場合、プレフィックスは `TCP-80` です。このポートに関連付けられるリスナーにセッション持続性を設定したい場合は、.metadata.annotations 配下の TCP-80.loadbalancer.nhncloud/pool-session-persistence に設定できます。
 
@@ -2813,7 +2761,6 @@ spec:
 >
 
 <a id="loadbalancer-update-without-modification"></a>
-
 #### 設定を変更せずにロードバランサーを更新する方法
 
 証明書の更新など、ロードバランサーの設定変更なしにロードバランサーの更新が必要な場合は、次のコマンドを使用できます。
@@ -2828,7 +2775,6 @@ kubectl annotate svc <name> loadbalancer.nhncloud/force-reconcile=true
 > この機能は、プラットフォームバージョンが 1.202605.0 以上のクラスターで動作します。
 
 <a id="advanced-lb-configuration-setting-load-balancer-name"></a>
-
 #### ロードバランサー名の設定
 
 ロードバランサーの名前を設定できます。
@@ -2846,7 +2792,6 @@ kubectl annotate svc <name> loadbalancer.nhncloud/force-reconcile=true
 > * プロジェクト内に同じ名前のロードバランサーを作成する
 
 <a id="advanced-lb-configuration-set-load-balancer-type"></a>
-
 #### ロードバランサータイプの設定
 ロードバランサーのタイプを設定できます。ロードバランサーの詳細については、[ロードバランサーコンソール使用ガイド](/Network/Load%20Balancer/ja/console-guide/)を参照してください。
 
@@ -2857,7 +2802,6 @@ kubectl annotate svc <name> loadbalancer.nhncloud/force-reconcile=true
     * dedicated: 「専用」タイプのロードバランサーを作成します。
 
 <a id="advanced-lb-configuration-set-static-routes"></a>
-
 #### 静的ルートの設定
 ロードバランサーの静的ルート適用の有無を設定できます。
 
@@ -2871,7 +2815,6 @@ kubectl annotate svc <name> loadbalancer.nhncloud/force-reconcile=true
 > 静的ルートの設定は、2024年8月27日以降に作成されたか、k8s バージョンをアップグレードしたクラスターで設定可能です。
 
 <a id="advanced-lb-configuration-set-the-session-affinity"></a>
-
 #### セッション持続性の設定
 ロードバランサーのセッション持続性を設定できます。
 
@@ -2887,7 +2830,6 @@ kubectl annotate svc <name> loadbalancer.nhncloud/force-reconcile=true
     * ロードバランサー作成後も変更できます。
 
 <a id="advanced-lb-configuration-set-whether-to-keep-a-floating-ip-address"></a>
-
 #### フローティング IP アドレスの保持設定
 ロードバランサーにはフローティング IP が接続されています。ロードバランサーの削除およびフローティング IP の変更時に、ロードバランサーに接続されたフローティング IP を削除するか保持するかを設定できます。
 
@@ -2910,7 +2852,6 @@ kubectl annotate svc <name> loadbalancer.nhncloud/force-reconcile=true
 
 
 <a id="advanced-lb-configuration-set-the-load-balancer-ip"></a>
-
 #### ロードバランサー IP の設定
 ロードバランサーを作成する際に、ロードバランサーの IP を設定できます。
 
@@ -2942,7 +2883,6 @@ spec:
 ```
 
 <a id="advanced-lb-configuration-set-whether-to-use-the-floating-ip"></a>
-
 #### フローティング IP 使用有無の設定
 ロードバランサー作成時に、フローティング IP を使用するかどうかを設定できます。
 
@@ -2987,7 +2927,6 @@ spec:
 
 
 <a id="advanced-lb-configuration-set-vpc"></a>
-
 #### VPC 設定
 ロードバランサー作成時に、ロードバランサーが接続される VPC を設定できます。
 
@@ -2996,7 +2935,6 @@ spec:
 * 設定しない場合は、クラスター作成時に設定した VPC が使用されます。
 
 <a id="advanced-lb-configuration-set-subnet"></a>
-
 #### サブネット設定
 ロードバランサー作成時に、ロードバランサーが接続されるサブネットを設定できます。設定されたサブネットにロードバランサーのプライベート IP が接続されます。メンバーサブネットの設定がない場合、このサブネットに接続されたワーカーノードがロードバランサーのメンバーとして追加されます。
 
@@ -3027,7 +2965,6 @@ spec:
 ```
 
 <a id="advanced-lb-configuration-set-member-subnet"></a>
-
 #### メンバーサブネットの設定
 ロードバランサー作成時に、ロードバランサーメンバーが接続されるサブネットを設定できます。このサブネットに接続されたワーカーノードがロードバランサーメンバーとして追加されます。
 
@@ -3089,7 +3026,6 @@ spec:
 
 
 <a id="advanced-lb-configuration-set-the-listener-connection-limit"></a>
-
 #### リスナー接続制限の設定
 リスナーの接続制限を設定できます。
 
@@ -3104,7 +3040,6 @@ spec:
 
 
 <a id="advanced-lb-configuration-set-the-listener-protocol"></a>
-
 #### リスナープロトコル設定
 リスナーのプロトコルを設定できます。
 
@@ -3196,7 +3131,6 @@ metadata:
 > リスナーと連携している Certificate Manager の証明書を削除すると、ロードバランサーの動作に影響を与える可能性があります。
 
 <a id="advanced-lb-configuration-set-the-listener-proxy-protocol"></a>
-
 #### リスナープロキシプロトコル (Proxy Protocol) 設定
 リスナープロトコルが TCP または HTTPS の場合、リスナーにプロキシプロトコルを設定できます。プロキシプロトコルの詳細については、[ロードバランサープロキシモード](/Network/Load%20Balancer/ja/overview/#_4)を参照してください。
 
@@ -3207,7 +3141,6 @@ metadata:
     * false: プロキシプロトコルを無効にします。未設定時のデフォルト値です。
 
 <a id="advanced-lb-configuration-set-the-load-balancing-method"></a>
-
 #### ロードバランシング方式設定
 ロードバランシング方式を設定できます。
 
@@ -3220,7 +3153,6 @@ metadata:
 
 
 <a id="advanced-lb-configuration-set-the-health-check-protocol"></a>
-
 #### ヘルスチェックプロトコル設定
 ヘルスチェックプロトコルを設定できます。
 
@@ -3252,7 +3184,6 @@ HTTP ステータスコードは次のように設定できます。
 * 設定しない場合や規則に合わない値を入力した場合は、デフォルト値の 200 に設定されます。
 
 <a id="advanced-lb-configuration-set-the-health-check-interval"></a>
-
 #### ヘルスチェック間隔設定
 ヘルスチェックの間隔を設定できます。
 
@@ -3263,7 +3194,6 @@ HTTP ステータスコードは次のように設定できます。
 * 設定しない場合や範囲外の値を入力した場合は、デフォルト値の 60 に設定されます。
 
 <a id="advanced-lb-configuration-set-the-health-check-maximum-response-time"></a>
-
 #### ヘルスチェック最大応答時間設定
 ヘルスチェックの最大応答時間を設定できます。
 
@@ -3276,7 +3206,6 @@ HTTP ステータスコードは次のように設定できます。
 * ただし、入力値または設定値がヘルスチェック間隔設定より大きい場合は、ヘルスチェック間隔設定の 1/2 に設定されます。
 
 <a id="advanced-lb-configuration-set-the-maximum-number-of-retries-for-a-health-check"></a>
-
 #### ヘルスチェック最大リトライ回数設定
 ヘルスチェックの最大リトライ回数を設定できます。
 
@@ -3286,7 +3215,6 @@ HTTP ステータスコードは次のように設定できます。
 * 設定しない場合や範囲外の値を入力した場合は、デフォルト値の 3 に設定されます。
 
 <a id="advanced-lb-configuration-health-check-port-settings"></a>
-
 #### ヘルスチェックポート設定
 ヘルスチェックの対象となるメンバーポートを設定できます。
 
@@ -3297,7 +3225,6 @@ HTTP ステータスコードは次のように設定できます。
 * 設定しない場合や範囲外の値を入力した場合は、デフォルト値の 0 に設定されます。
 
 <a id="advanced-lb-configuration-health-check-host-header-settings"></a>
-
 #### ヘルスチェックホストヘッダー設定
 ヘルスチェックに使用するホストヘッダーのフィールド値を設定できます。
 
@@ -3306,7 +3233,6 @@ HTTP ステータスコードは次のように設定できます。
 * ヘルスチェックプロトコルを TCP に設定した場合、このフィールドに設定した値は無視されます。
 
 <a id="advanced-lb-configuration-setting-keep-alive-timeout"></a>
-
 #### keep-alive タイムアウト設定
 keep-alive タイムアウト値を設定できます。
 
@@ -3320,7 +3246,6 @@ keep-alive タイムアウト値を設定できます。
 > keep-alive タイムアウトは、2023 年 11 月 28 日以降に v1.24.3 以上のバージョンにアップグレードされたか、新規作成されたクラスターで設定可能です。
 
 <a id="advanced-lb-configuration-l7-rules"></a>
-
 #### L7 ルール
 リスナーごとに L7 ルールを設定できます。L7 ルールは次のように動作します。
 
@@ -3352,7 +3277,6 @@ L7 ルール設定には次の制約事項があります。
 * 1 つのリスナーに設定される L7 ルールは、互いに異なる名前で設定する必要があります。
 
 <a id="advanced-lb-configuration-l7-conditions"></a>
-
 #### L7条件
 L7ルールごとにL7条件を設定できます。L7条件は次のように動作します。
 
@@ -3455,17 +3379,14 @@ spec:
 ```
 
 <a id="ingress-controller"></a>
-
 ## Ingress Controller { #ingress-controller }
 インgressコントローラー（ingress controller）は、Ingress オブジェクトに定義されたルールを参照し、クラスター外部から内部サービスへの HTTP および HTTPS リクエストをルーティングし、SSL/TLS 終端、仮想ホスティングなどを提供します。インgressコントローラーおよびIngressの詳細については、[インgressコントローラー](https://kubernetes.io/ko/docs/concepts/services-networking/ingress-controllers/)、[Ingress](https://kubernetes.io/ko/docs/concepts/services-networking/ingress/) のドキュメントを参照してください。
 
 <a id="install-nginx-ingress-controller"></a>
-
 ### NGINX Ingress Controller のインストール { #install-nginx-ingress-controller }
 NGINX Ingress Controller は、広く使用されているIngressコントローラーの1つです。詳細については、[NGINX Ingress Controller](https://kubernetes.github.io/ingress-nginx/) および [NGINX Ingress Controller for Kubernetes](https://www.nginx.com/products/nginx-ingress-controller/) のドキュメントを参照してください。NGINX Ingress Controller のインストールについては、[Installation Guide](https://kubernetes.github.io/ingress-nginx/deploy/) のドキュメントを参照してください。
 
 <a id="uri-based-service-routing"></a>
-
 ### URI 기반 서비스 분기 { #uri-based-service-routing }
 Ingressコントローラーは、URIを基にサービスを分岐できます。以下の図は、URIを基にサービスを分岐する簡単な例の構造を示しています。
 
@@ -3689,7 +3610,6 @@ service "tea-svc" deleted
 ```
 
 <a id="host-based-service-routing"></a>
-
 ### ホストベースのサービス分岐 { #host-based-service-routing }
 Ingressコントローラーは、ホスト名を基にサービスを分岐できます。以下の図は、ホスト名を基にサービスを分岐する簡単な例の構造を示しています。
 
@@ -3789,7 +3709,6 @@ $ curl 123.123.123.44/unknown
 ```
 
 <a id="ingress-nginx-internal-communication"></a>
-
 ### ingress-nginxコントローラーの内部通信構造と注意事項 { #ingress-nginx-internal-communication }
 ingress-nginxコントローラーを通じてサービスを外部に公開する場合、リクエストを送信するクライアントの位置（クラスター内部または外部）によって、リクエストがワークロードに転送される経路が異なります。
 
@@ -3822,7 +3741,6 @@ ingress-nginxコントローラーを通じてサービスを外部に公開す�
 
 
 <a id="k8s-dashboard"></a>
-
 ## Kubernetes 대시보드 { #k8s-dashboard }
 NHN Kubernetes Service(NKS) は、デフォルトの Web UI ダッシュボード (dashboard) を提供します。Kubernetes ダッシュボードの詳細については、[Web UI (ダッシュボード)](https://kubernetes.io/ko/docs/tasks/access-application-cluster/web-ui-dashboard/) のドキュメントを参照してください。
 
@@ -3958,7 +3876,6 @@ eyJhbGc...-QmXA
 出力されたトークンをブラウザーのトークン入力欄に入力すると、クラスター管理者権限を付与されたユーザーとしてログインできます。
 
 <a id="persistent-volume"></a>
-
 ## パシステントボリューム { #persistent-volume }
 パシステントボリューム (Persistent Volume、PV) は、物理ストレージデバイス (volume) を表す Kubernetes のリソースです。1 つの PV は 1 つの NHN Cloud Block Storage と接続されます。詳細については、[パシステントボリューム](https://kubernetes.io/ko/docs/concepts/storage/persistent-volumes/) のドキュメントを参照してください。
 
@@ -3967,7 +3884,6 @@ PV を Pod に接続して使用するには、パシステントボリューム
 PV と PVC を使用することで、ユーザーは使用したいボリュームの属性を定義し、システムはユーザーの要件に合ったボリュームリソースを割り当てる方式でリソースの使用と管理を分離します。
 
 <a id="pv-lifecycle"></a>
-
 ### PV/PVC のライフサイクル { #pv-lifecycle }
 PV と PVC は 4 段階のライフサイクル (life cycle) に従います。
 
@@ -3990,7 +3906,6 @@ PV を Pod にマウントして使用します。
 | 再利用 (Recycle) | PV を削除するとき、接続されたボリュームを削除せず、再利用可能な状態にします。この方法は非推奨 (deprecated) です。 |
 
 <a id="storageclass"></a>
-
 ### StorageClass { #storageclass }
 プロビジョニングを行うには、まずストレージクラスが定義されている必要があります。ストレージクラスは、特定の特性に基づいてストレージを分類する方法を提供します。ストレージ提供者（provisioner）に関する情報をはじめ、メディアの種類や Availability Zone などを設定できます。
 
@@ -4080,7 +3995,6 @@ csi-storageclass   cinder.csi.openstack.org   Delete          WaitForFirstConsum
 ```
 
 <a id="static-provisioning"></a>
-
 ### 静的プロビジョニング { #static-provisioning }
 
 静的プロビジョニング (static provisioning) では、ユーザーが自分でブロックストレージを準備する必要があります。NHN Cloud ウェブコンソールの **Storage > Block Storage** サービスページで **[ブロックストレージ作成]** ボタンをクリックし、PV と接続するブロックストレージを作成します。ブロックストレージガイドの[ブロックストレージ作成](/Storage/Block%20Storage/ja/console-guide/#_1)を参照してください。
@@ -4166,7 +4080,6 @@ pv-static-001   10Gi       RWO            Delete           Bound    default/pvc-
 ```
 
 <a id="dynamic-provisioning"></a>
-
 ### Dynamic Provisioning { #dynamic-provisioning }
 
 動的プロビジョニング (dynamic provisioning) は、ストレージクラスに定義された属性を参照して、自動的にブロックストレージを作成します。動的プロビジョニングを使用するには、ストレージクラスのボリュームバインディングモードを設定しないか、**Immediate** に設定する必要があります。
@@ -4220,7 +4133,6 @@ persistentvolumeclaim/pvc-dynamic   Bound    pvc-1056949c-bc67-45cc-abaa-1d1bd9e
 > 動的プロビジョニングで作成されたブロックストレージは、ウェブコンソールから削除することはできません。また、クラスターを削除する際に自動的に削除されません。そのため、クラスターを削除する前に、すべての PVC を削除する必要があります。PVC を削除せずにクラスターを削除した場合、課金される可能性があります。動的プロビジョニングで作成された PV の reclaimPolicy はデフォルトで `Delete` に設定されているため、PVC を削除するだけで PV とブロックストレージも削除されます。
 
 <a id="pod-pvc-mount"></a>
-
 ### Pod への PVC マウント { #pod-pvc-mount }
 
 Pod に PVC をマウントするには、Pod マニフェストにマウント情報を定義する必要があります。`spec.volumes.persistenVolumeClaim.claimName` に使用する PVC 名を入力します。また、`spec.containers.volumeMounts.mountPath` にマウントするパスを入力します。
@@ -4271,7 +4183,6 @@ Filesystem      Size  Used Avail Use% Mounted on
 NHN Cloud ウェブコンソールの **Storage > Block Storage** サービスページでも、ブロックストレージの接続情報を確認できます。
 
 <a id="volume-expansion"></a>
-
 ### Volume Expansion { #volume-expansion }
 PersistentVolumeClaim (PVC) オブジェクトを編集して、既存のボリュームのサイズを変更できます。PVC オブジェクトの **spec.resources.requests.storage** 項目を変更することで、ボリュームサイズを変更できます。ボリュームの縮小はサポートされていません。ボリューム拡張機能を使用するには、StorageClass の **allowVolumeExpansion** 属性が **True** である必要があります。
 
@@ -4328,11 +4239,9 @@ status:
 v1.20.12 以降のバージョンのストレージプロバイダー **cinder.csi.openstack.org** は、デフォルトで使用中のボリュームの拡張機能をサポートしています。PVC オブジェクトの **spec.resources.requests.storage** 項目を任意の値に変更することで、ボリュームサイズを変更できます。
 
 <a id="service-integration"></a>
-
 ## NHN Cloud サービス連携 { #service-integration }
 
 <a id="ncr-integration"></a>
-
 ### NHN Cloud Container Registry(NCR) サービス連携 { #ncr-integration }
 NHN Cloud Container Registry に保存したイメージを使用できます。レジストリに保存されたイメージを使用するには、ユーザーレジストリにログインするためのシークレット (secret) を作成する必要があります。
 
@@ -4382,7 +4291,6 @@ spec:
 > NHN Cloud Container Registry の使用方法については、[NHN Cloud Container Registry(NCR) ユーザーガイド](/Container/NCR/ja/user-guide) を参照してください。
 
 <a id="nas-integration"></a>
-
 ### NHN Cloud NAS サービス連携 { #nas-integration }
 NHN Cloud が提供する NAS ボリュームを PV として活用できます。NAS サービスを使用するには、v1.20 以降のバージョンのクラスターを使用する必要があります。NHN Cloud NAS の使用に関する詳細については、[NAS コンソール使用ガイド](/Storage/NAS%20(online)/ja/console-guide) を参照してください。
 
@@ -4390,7 +4298,6 @@ NHN Cloud が提供する NAS ボリュームを PV として活用できます�
 > NHN Cloud NAS サービスは、現時点 (2024年8月) において一部のリージョンでのみ提供されています。NHN Cloud NAS サービスのサポートリージョンに関する詳細については、[NAS サービス概要](/Storage/NAS%20(online)/ja/overview) を参照してください。
 
 <a id="nas-integration-run-the-rpcbind-service-on-all-worker-nodes"></a>
-
 #### すべてのワーカーノードで rpcbind サービスを実行
 NAS ボリュームを使用するには、すべてのワーカーノードで rpcbind サービスを実行する必要があります。すべてのワーカーノードに接続した後、次のコマンドで rpcbind サービスを実行します。
 
@@ -4409,7 +4316,6 @@ $ systemctl start rpcbind
 | egress | TCP | 635 | IPv4 | NAS IP アドレス | rpc の mountd ポート、方向: csi-nfs-node (ワーカーノード) → NAS |
 
 <a id="nas-integration-install-csi-driver-nfs"></a>
-
 #### csi-driver-nfs のインストール
 NHN Cloud NAS サービスを使用するために、クラスターに NHN Kubernetes Service (NKS) の Addon 機能として [nfs-csi-plugin](/Container/NKS/ja/user-guide/#addon-mgmt-addon-nfs-csi-plugin) をデプロイする必要があります。
 
@@ -4421,7 +4327,6 @@ csi-driver-nfs を使用して複数の PV を構成する場合、csi-driver-nf
 ![nfs-csi-driver-02.png](http://static.toastoven.net/prod_infrastructure/container/kubernetes/nfs-csi-driver-02.png)
 
 <a id="nas-integration-how-to-use-existing-nhn-cloud-nas-volume-when-provisioning"></a>
-
 #### プロビジョニング時に既存の NHN Cloud NAS ボリュームを使用する方法
 PV マニフェスト作成時に NAS 情報を入力するか、StorageClass マニフェストに NAS 情報を入力することで、既存の NAS ボリュームを PV として使用できます。
 
@@ -4625,7 +4530,6 @@ Filesystem                                                                 Size 
 ```
 
 <a id="nas-integration-how-to-create-new-nhn-cloud-nas-volume-when-provisioning"></a>
-
 #### プロビジョニング時に新しい NHN Cloud NAS ボリュームを作成する方法
 StorageClass および PVC マニフェストの作成時に NAS 情報を入力することで、自動的に作成された NAS ボリュームを PV として使用できます。
 
@@ -4797,7 +4701,6 @@ tmpfs                                                                          1
 > Pod に PV をマウントする際、subdirectory のみがマウントされるのではなく、NFS ストレージ全体がマウントされるため、アプリケーションがプロビジョニングされたサイズ分だけボリュームを使用するよう強制することはできません。
 
 <a id="encrypted-block-storage-integration"></a>
-
 ### NHN Cloud 暗号化ブロックストレージ連動 { #encrypted-block-storage-integration }
 NHN Cloud が提供する暗号化されたブロックストレージを PV として活用できます。NHN Cloud 暗号化ブロックストレージの詳細については、[暗号化ブロックストレージ](/Storage/Block%20Storage/ja/console-guide/#_2)を参照してください。
 
@@ -4913,7 +4816,6 @@ PVC マニフェストの作成および Pod へのマウント手順は、通�
 
 
 <a id="etcd-encryption-with-skm"></a>
-
 ### 機密データの暗号化・復号化時の Secure Key Manager サービス連動 { #etcd-encryption-with-skm }
 
 NKS クラスターは secret リソースをデータストア(etcd)に保存する際、データを暗号化して保存します。NKS はこのデータを暗号化するために 2 つの方式を提供します。

--- a/ko/user-guide.md
+++ b/ko/user-guide.md
@@ -1,3 +1,5 @@
+<!-- pre-align:aligned sig=98b43adf5be7 -->
+
 <a id="container-nhn-kubernetes-service-nks-user-guide"></a>
 ## Container > NHN Kubernetes Service(NKS) > 사용 가이드 { #container-nhn-kubernetes-service-nks-user-guide }
 


### PR DESCRIPTION
LLM-matched alignment of `en`/`ja` heading structure to `ko` — heading levels, missing-section stubs, and anchor ids.

**Body text is never modified.** The model only sees heading outlines; edits apply to heading lines (and `<!-- TODO: translate body -->` stubs for missing sections) only.

## Analysis

| | |
| --- | --- |
| Engine | `claude-code (CLI)` |
| Model | `claude-sonnet-4-6` |
| Source → targets | `ko` → `en, ja` |
| Base ref | `pre-align/fix-headings-20260713-124420` |
| Scope | 9 doc(s) scanned · 3 file(s) changed · 8 unchanged |
| Self-verify | ✅ all aligned |
| Jenkins build | http://cd.cloud.toastoven.net:8080/job/content_deploy/job/align-heading/job/main/137/ |
| Generated | 2026-07-14T08:39:48 |

## Heading compare (docs viewer)

ko ↔ en/ja heading 구조 비교 — base 브랜치(적용 전)와 이 PR(적용 후)를 각각 확인:

- **Base 브랜치** (`pre-align/fix-headings-20260713-124420`): [Compare ↗](http://content-agent.cloud.toastoven.net:7700/compare-headings?url=https%3A%2F%2Fgithub.com%2FTOAST-DOCS%2FContainer-Kubernetes%2Ftree%2Fpre-align%2Ffix-headings-20260713-124420&source=ko&langs=en%2Cja)
- **이 PR**: [Compare ↗](http://content-agent.cloud.toastoven.net:7700/compare-headings?url=https%3A%2F%2Fgithub.com%2FTOAST-DOCS%2FContainer-Kubernetes%2Fpull%2F473&source=ko&langs=en%2Cja)

## Link check

이 PR 의 링크 상태: [Link Check ↗](http://content-agent.cloud.toastoven.net:7700/link-check?url=https%3A%2F%2Fgithub.com%2FTOAST-DOCS%2FContainer-Kubernetes%2Fpull%2F473&ref=pre-align%2Ffix-headings-20260713-124420&langs=en%2Cja)

<!-- LINK_CHECK_SUMMARY -->

## Changes

| File | level fixed | inserted | body xl | id fixed | extra flagged | extra demoted | extra removed | marker | verify |
| --- | --: | --: | --: | --: | --: | --: | --: | :--: | :--: |
| `ko/user-guide.md` | 0 | 0 | 0 | 0 | 0 | 0 | 0 | ✅ | ✅ |
| `en/user-guide.md` | 0 | 0 | 0 | 0 | 0 | 0 | 0 | ✅ | ✅ |
| `ja/user-guide.md` | 0 | 0 | 0 | 0 | 0 | 0 | 0 | ✅ | ✅ |

<details><summary>변경 없이 건너뛴 문서 (8) — 이미 `ko`와 정렬됨 / 대상 파일 없음 (PR에서 제외)</summary>

- `backup-guide.md`
- `gateway-api-guide.md`
- `istio-guide.md`
- `overview.md`
- `public-api.md`
- `release-notes.md`
- `troubleshooting-guide.md`
- `version-guide.md`

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code) · `pre-align/fix_headings.py` on `TOAST-DOCS/Container-Kubernetes`